### PR TITLE
fix(wast): SIMD/memory64 validation, element/data segment fixes, GC types

### DIFF
--- a/wrt-build-core/src/wast_execution.rs
+++ b/wrt-build-core/src/wast_execution.rs
@@ -142,10 +142,21 @@ impl WastEngine {
         // Link function imports from registered modules
         self.link_function_imports(&module, instance_idx)?;
 
+        // Validate all imports are satisfied with compatible types
+        self.validate_imports(&module)?;
+
         // Store the module and instance ID for later reference
         let module_name = name.unwrap_or("current").to_string();
         self.modules.insert(module_name.clone(), Arc::clone(&module));
         self.instance_ids.insert(module_name.clone(), instance_idx);
+
+        // Always update "current" to point to the last loaded module,
+        // even if it has a name. This ensures (register "name") without
+        // a module ID can find the most recently loaded module.
+        if name.is_some() {
+            self.modules.insert("current".to_string(), Arc::clone(&module));
+            self.instance_ids.insert("current".to_string(), instance_idx);
+        }
 
         // Register instance name for cross-module exception handling
         self.engine.register_instance_name(instance_idx, &module_name);
@@ -325,8 +336,9 @@ impl WastEngine {
                     // The import type specifies minimum requirements, but the actual
                     // spectest memory always has at least 1 page
                     let core_mem_type = CoreMemoryType {
-                        limits: Limits { min: 1, max: Some(2) },
-                        shared: false,
+                        limits:   Limits { min: 1, max: Some(2) },
+                        shared:   false,
+                        memory64: false,
                     };
 
                     let memory = Memory::new(core_mem_type).map_err(|e| {
@@ -599,6 +611,406 @@ impl WastEngine {
         Ok(())
     }
 
+    /// Validate that all imports in a module can be satisfied by available exports.
+    ///
+    /// For each import, checks:
+    /// 1. The source module exists (spectest or a registered module)
+    /// 2. The source module exports a field with the matching name
+    /// 3. The export kind matches the import kind (function, table, memory, global)
+    /// 4. The types are compatible (signatures match, limits are compatible, etc.)
+    ///
+    /// Returns an error with "unknown import" if the module or field is not found,
+    /// or "incompatible import type" if the types don't match.
+    fn validate_imports(&self, module: &Module) -> Result<()> {
+        use wrt_runtime::module::{ExportKind, RuntimeImportDesc};
+
+        let import_order = &module.import_order;
+        let import_types = &module.import_types;
+
+        if import_types.len() != import_order.len() {
+            return Ok(()); // Can't validate if lengths don't match
+        }
+
+        for (i, (mod_name, field_name)) in import_order.iter().enumerate() {
+            let import_desc = match import_types.get(i) {
+                Some(desc) => desc,
+                None => continue,
+            };
+
+            if mod_name == "spectest" {
+                self.validate_spectest_import(field_name, import_desc, module)?;
+            } else {
+                self.validate_registered_import(mod_name, field_name, import_desc, module)?;
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Validate an import from the spectest module.
+    fn validate_spectest_import(
+        &self,
+        field_name: &str,
+        import_desc: &wrt_foundation::types::ImportDesc<wrt_runtime::bounded_runtime_infra::RuntimeProvider>,
+        module: &Module,
+    ) -> Result<()> {
+        use wrt_foundation::types::ValueType;
+        use wrt_runtime::module::RuntimeImportDesc;
+
+        let spectest_export = get_spectest_export_kind(field_name);
+
+        match spectest_export {
+            None => {
+                return Err(anyhow::anyhow!("unknown import: spectest::{}", field_name));
+            },
+            Some(SpectestExport::Function(ref params, ref results)) => {
+                match import_desc {
+                    RuntimeImportDesc::Function(type_idx) => {
+                        if let Some(func_type) = module.get_function_type(*type_idx) {
+                            let import_params: Vec<ValueType> =
+                                func_type.params.iter().copied().collect();
+                            let import_results: Vec<ValueType> =
+                                func_type.results.iter().copied().collect();
+                            if import_params != *params || import_results != *results {
+                                return Err(anyhow::anyhow!(
+                                    "incompatible import type: spectest::{}",
+                                    field_name
+                                ));
+                            }
+                        }
+                    },
+                    _ => {
+                        return Err(anyhow::anyhow!(
+                            "incompatible import type: spectest::{}",
+                            field_name
+                        ));
+                    },
+                }
+            },
+            Some(SpectestExport::Global(vt, mutable)) => {
+                match import_desc {
+                    RuntimeImportDesc::Global(gt) => {
+                        if gt.value_type != vt || gt.mutable != mutable {
+                            return Err(anyhow::anyhow!(
+                                "incompatible import type: spectest::{}",
+                                field_name
+                            ));
+                        }
+                    },
+                    _ => {
+                        return Err(anyhow::anyhow!(
+                            "incompatible import type: spectest::{}",
+                            field_name
+                        ));
+                    },
+                }
+            },
+            Some(SpectestExport::Table(actual_min, actual_max)) => {
+                match import_desc {
+                    RuntimeImportDesc::Table(table_type) => {
+                        if table_type.element_type != wrt_foundation::types::RefType::Funcref {
+                            return Err(anyhow::anyhow!(
+                                "incompatible import type: spectest::table"
+                            ));
+                        }
+                        if !limits_match(
+                            actual_min,
+                            actual_max,
+                            table_type.limits.min,
+                            table_type.limits.max,
+                        ) {
+                            return Err(anyhow::anyhow!(
+                                "incompatible import type: spectest::table"
+                            ));
+                        }
+                    },
+                    _ => {
+                        return Err(anyhow::anyhow!(
+                            "incompatible import type: spectest::{}",
+                            field_name
+                        ));
+                    },
+                }
+            },
+            Some(SpectestExport::Memory(actual_min, actual_max)) => {
+                match import_desc {
+                    RuntimeImportDesc::Memory(mem_type) => {
+                        if !limits_match(
+                            actual_min,
+                            actual_max,
+                            mem_type.limits.min,
+                            mem_type.limits.max,
+                        ) {
+                            return Err(anyhow::anyhow!(
+                                "incompatible import type: spectest::memory"
+                            ));
+                        }
+                    },
+                    _ => {
+                        return Err(anyhow::anyhow!(
+                            "incompatible import type: spectest::{}",
+                            field_name
+                        ));
+                    },
+                }
+            },
+            Some(SpectestExport::Tag(ref expected_params)) => {
+                match import_desc {
+                    RuntimeImportDesc::Tag(tag_type) => {
+                        if let Some(func_type) = module.get_function_type(tag_type.type_idx) {
+                            let import_params: Vec<ValueType> =
+                                func_type.params.iter().copied().collect();
+                            if import_params != *expected_params {
+                                return Err(anyhow::anyhow!(
+                                    "incompatible import type: spectest::{}",
+                                    field_name
+                                ));
+                            }
+                        }
+                    },
+                    _ => {
+                        return Err(anyhow::anyhow!(
+                            "incompatible import type: spectest::{}",
+                            field_name
+                        ));
+                    },
+                }
+            },
+        }
+
+        Ok(())
+    }
+
+    /// Validate an import from a registered module.
+    fn validate_registered_import(
+        &self,
+        mod_name: &str,
+        field_name: &str,
+        import_desc: &wrt_foundation::types::ImportDesc<wrt_runtime::bounded_runtime_infra::RuntimeProvider>,
+        module: &Module,
+    ) -> Result<()> {
+        use wrt_runtime::module::{ExportKind, RuntimeImportDesc};
+
+        // Check if the source module is registered
+        let source_module = match self.modules.get(mod_name) {
+            Some(m) => m,
+            None => {
+                return Err(anyhow::anyhow!(
+                    "unknown import: {}::{}",
+                    mod_name,
+                    field_name
+                ));
+            },
+        };
+
+        // Look up the export in the source module
+        let bounded_field =
+            wrt_foundation::bounded::BoundedString::<256>::from_str_truncate(field_name)
+                .map_err(|e| anyhow::anyhow!("Field name too long: {:?}", e))?;
+
+        let export = match source_module.exports.get(&bounded_field) {
+            Some(exp) => exp,
+            None => {
+                return Err(anyhow::anyhow!(
+                    "unknown import: {}::{}",
+                    mod_name,
+                    field_name
+                ));
+            },
+        };
+
+        // Check that the export kind matches the import kind and types are compatible
+        match import_desc {
+            RuntimeImportDesc::Function(type_idx) => {
+                if export.kind != ExportKind::Function {
+                    return Err(anyhow::anyhow!(
+                        "incompatible import type: {}::{}",
+                        mod_name,
+                        field_name
+                    ));
+                }
+                // Check function type signature compatibility
+                if let Some(expected_type) = module.get_function_type(*type_idx) {
+                    if let Some(source_type) =
+                        source_module.get_function_signature(export.index)
+                    {
+                        let expected_params: Vec<wrt_foundation::types::ValueType> =
+                            expected_type.params.iter().copied().collect();
+                        let expected_results: Vec<wrt_foundation::types::ValueType> =
+                            expected_type.results.iter().copied().collect();
+                        let source_params: Vec<wrt_foundation::types::ValueType> =
+                            source_type.params.iter().copied().collect();
+                        let source_results: Vec<wrt_foundation::types::ValueType> =
+                            source_type.results.iter().copied().collect();
+
+                        if expected_params != source_params
+                            || expected_results != source_results
+                        {
+                            return Err(anyhow::anyhow!(
+                                "incompatible import type: {}::{}",
+                                mod_name,
+                                field_name
+                            ));
+                        }
+                    }
+                }
+            },
+            RuntimeImportDesc::Table(import_table_type) => {
+                if export.kind != ExportKind::Table {
+                    return Err(anyhow::anyhow!(
+                        "incompatible import type: {}::{}",
+                        mod_name,
+                        field_name
+                    ));
+                }
+                // Check table type compatibility via the engine instance
+                if let Some(source_instance_id) = self.instance_ids.get(mod_name) {
+                    if let Some(source_instance) =
+                        self.engine.get_instance(*source_instance_id)
+                    {
+                        if let Ok(table_wrapper) =
+                            source_instance.table(export.index)
+                        {
+                            if table_wrapper.element_type()
+                                != import_table_type.element_type
+                            {
+                                return Err(anyhow::anyhow!(
+                                    "incompatible import type: {}::{}",
+                                    mod_name,
+                                    field_name
+                                ));
+                            }
+                            let actual_limits = &table_wrapper.inner().ty.limits;
+                            if !limits_match(
+                                actual_limits.min,
+                                actual_limits.max,
+                                import_table_type.limits.min,
+                                import_table_type.limits.max,
+                            ) {
+                                return Err(anyhow::anyhow!(
+                                    "incompatible import type: {}::{}",
+                                    mod_name,
+                                    field_name
+                                ));
+                            }
+                        }
+                    }
+                }
+            },
+            RuntimeImportDesc::Memory(import_mem_type) => {
+                if export.kind != ExportKind::Memory {
+                    return Err(anyhow::anyhow!(
+                        "incompatible import type: {}::{}",
+                        mod_name,
+                        field_name
+                    ));
+                }
+                // Check memory limits and memory64 compatibility via the engine instance
+                if let Some(source_instance_id) = self.instance_ids.get(mod_name) {
+                    if let Some(source_instance) =
+                        self.engine.get_instance(*source_instance_id)
+                    {
+                        if let Ok(mem_wrapper) =
+                            source_instance.memory(export.index)
+                        {
+                            let actual_ty = &mem_wrapper.inner().ty;
+                            // Check memory64 flag must match
+                            if actual_ty.memory64 != import_mem_type.memory64 {
+                                return Err(anyhow::anyhow!(
+                                    "incompatible import type: {}::{}",
+                                    mod_name,
+                                    field_name
+                                ));
+                            }
+                            if !limits_match(
+                                actual_ty.limits.min,
+                                actual_ty.limits.max,
+                                import_mem_type.limits.min,
+                                import_mem_type.limits.max,
+                            ) {
+                                return Err(anyhow::anyhow!(
+                                    "incompatible import type: {}::{}",
+                                    mod_name,
+                                    field_name
+                                ));
+                            }
+                        }
+                    }
+                }
+            },
+            RuntimeImportDesc::Global(import_global_type) => {
+                if export.kind != ExportKind::Global {
+                    return Err(anyhow::anyhow!(
+                        "incompatible import type: {}::{}",
+                        mod_name,
+                        field_name
+                    ));
+                }
+                // Check global type compatibility via the engine instance
+                if let Some(source_instance_id) = self.instance_ids.get(mod_name) {
+                    if let Some(source_instance) =
+                        self.engine.get_instance(*source_instance_id)
+                    {
+                        if let Ok(global_wrapper) =
+                            source_instance.global(export.index)
+                        {
+                            if global_wrapper.value_type()
+                                != import_global_type.value_type
+                                || global_wrapper.is_mutable()
+                                    != import_global_type.mutable
+                            {
+                                return Err(anyhow::anyhow!(
+                                    "incompatible import type: {}::{}",
+                                    mod_name,
+                                    field_name
+                                ));
+                            }
+                        }
+                    }
+                }
+            },
+            RuntimeImportDesc::Tag(import_tag_type) => {
+                if export.kind != ExportKind::Tag {
+                    return Err(anyhow::anyhow!(
+                        "incompatible import type: {}::{}",
+                        mod_name,
+                        field_name
+                    ));
+                }
+                // Check tag type compatibility by comparing function signatures
+                if let Some(expected_func_type) =
+                    module.get_function_type(import_tag_type.type_idx)
+                {
+                    let source_tag_idx = export.index;
+                    if let Some(source_tag_type) =
+                        source_module.get_tag_type(source_tag_idx)
+                    {
+                        if let Some(source_func_type) =
+                            source_module.get_function_type(source_tag_type.type_idx)
+                        {
+                            let expected_params: Vec<wrt_foundation::types::ValueType> =
+                                expected_func_type.params.iter().copied().collect();
+                            let source_params: Vec<wrt_foundation::types::ValueType> =
+                                source_func_type.params.iter().copied().collect();
+                            if expected_params != source_params {
+                                return Err(anyhow::anyhow!(
+                                    "incompatible import type: {}::{}",
+                                    mod_name,
+                                    field_name
+                                ));
+                            }
+                        }
+                    }
+                }
+            },
+            _ => {
+                // Other import types (Extern, Resource) - skip validation
+            },
+        }
+
+        Ok(())
+    }
+
     /// Link function imports from registered modules
     ///
     /// This method sets up cross-instance function linking for imports
@@ -651,6 +1063,78 @@ impl WastEngine {
         }
 
         Ok(())
+    }
+}
+
+/// Represents the type of export that the spectest module provides.
+enum SpectestExport {
+    /// A function with the given parameter and result types
+    Function(Vec<wrt_foundation::types::ValueType>, Vec<wrt_foundation::types::ValueType>),
+    /// A global with the given value type and mutability
+    Global(wrt_foundation::types::ValueType, bool),
+    /// A table with the given min and max limits (always funcref)
+    Table(u32, Option<u32>),
+    /// A memory with the given min and max limits
+    Memory(u32, Option<u32>),
+    /// A tag with the given parameter types
+    Tag(Vec<wrt_foundation::types::ValueType>),
+}
+
+/// Returns information about what the spectest module exports for a given field name.
+///
+/// The spectest module provides:
+/// - Functions: print, print_i32, print_i64, print_f32, print_f64, print_i32_f32, print_f64_f64
+/// - Globals: global_i32, global_i64, global_f32, global_f64 (all immutable)
+/// - Table: table (10 20 funcref)
+/// - Memory: memory (1 2)
+fn get_spectest_export_kind(field_name: &str) -> Option<SpectestExport> {
+    use wrt_foundation::types::ValueType;
+
+    match field_name {
+        "print" => Some(SpectestExport::Function(vec![], vec![])),
+        "print_i32" => Some(SpectestExport::Function(vec![ValueType::I32], vec![])),
+        "print_i64" => Some(SpectestExport::Function(vec![ValueType::I64], vec![])),
+        "print_f32" => Some(SpectestExport::Function(vec![ValueType::F32], vec![])),
+        "print_f64" => Some(SpectestExport::Function(vec![ValueType::F64], vec![])),
+        "print_i32_f32" => Some(SpectestExport::Function(
+            vec![ValueType::I32, ValueType::F32],
+            vec![],
+        )),
+        "print_f64_f64" => Some(SpectestExport::Function(
+            vec![ValueType::F64, ValueType::F64],
+            vec![],
+        )),
+        "global_i32" => Some(SpectestExport::Global(ValueType::I32, false)),
+        "global_i64" => Some(SpectestExport::Global(ValueType::I64, false)),
+        "global_f32" => Some(SpectestExport::Global(ValueType::F32, false)),
+        "global_f64" => Some(SpectestExport::Global(ValueType::F64, false)),
+        "table" => Some(SpectestExport::Table(10, Some(20))),
+        "memory" => Some(SpectestExport::Memory(1, Some(2))),
+        _ => None,
+    }
+}
+
+/// Check WebAssembly limits compatibility per the spec.
+///
+/// Per the WebAssembly specification, actual limits match import limits iff:
+/// - actual.min >= import.min
+/// - If import.max is Some(m): actual.max must be Some(m') AND m' <= m
+fn limits_match(
+    actual_min: u32,
+    actual_max: Option<u32>,
+    import_min: u32,
+    import_max: Option<u32>,
+) -> bool {
+    if actual_min < import_min {
+        return false;
+    }
+    if let Some(imp_max) = import_max {
+        match actual_max {
+            Some(act_max) => act_max <= imp_max,
+            None => false, // Import requires a max but actual has none
+        }
+    } else {
+        true // Import has no max constraint
     }
 }
 
@@ -1169,7 +1653,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "nullfuncref returns I32(-1) instead of FuncRef(None) - needs runtime fix"]
     fn test_nullfuncref_global_execution() {
         use wast::{
             Wat,

--- a/wrt-build-core/src/wast_execution.rs
+++ b/wrt-build-core/src/wast_execution.rs
@@ -448,6 +448,7 @@ impl WastEngine {
                     let spectest_table_type = TableType {
                         element_type: RefType::Funcref,
                         limits: Limits { min: 10, max: Some(20) },
+                        table64: false,
                     };
                     let table = Table::new(spectest_table_type).map_err(|e| {
                         anyhow::anyhow!("Failed to create spectest table: {:?}", e)

--- a/wrt-build-core/src/wast_validator.rs
+++ b/wrt-build-core/src/wast_validator.rs
@@ -576,11 +576,14 @@ impl WastModuleValidator {
                 // Control flow
                 0x00 => {
                     // unreachable
+                    // Per spec: after unconditional branch/trap, stack becomes polymorphic
+                    // Truncate stack to frame base so subsequent pops are polymorphic
                     if let Some(frame) = frames.last_mut() {
                         if frame.reachable {
-                            frame.unreachable_height = Some(stack.len());
+                            frame.unreachable_height = Some(frame.stack_height);
                         }
                         frame.reachable = false;
+                        stack.truncate(frame.stack_height);
                     }
                 },
                 0x01 => {
@@ -860,12 +863,13 @@ impl WastModuleValidator {
                         }
                     }
 
-                    // Mark current frame as unreachable
+                    // Mark current frame as unreachable and truncate stack
                     if let Some(frame) = frames.last_mut() {
                         if frame.reachable {
-                            frame.unreachable_height = Some(stack.len());
+                            frame.unreachable_height = Some(frame.stack_height);
                         }
                         frame.reachable = false;
+                        stack.truncate(frame.stack_height);
                     }
                 },
                 0x09 => {
@@ -882,12 +886,13 @@ impl WastModuleValidator {
                         return Err(anyhow!("rethrow: not in try block"));
                     }
 
-                    // Mark current frame as unreachable
+                    // Mark current frame as unreachable and truncate stack
                     if let Some(frame) = frames.last_mut() {
                         if frame.reachable {
-                            frame.unreachable_height = Some(stack.len());
+                            frame.unreachable_height = Some(frame.stack_height);
                         }
                         frame.reachable = false;
+                        stack.truncate(frame.stack_height);
                     }
                 },
                 0x0A => {
@@ -904,12 +909,13 @@ impl WastModuleValidator {
                         return Err(anyhow!("type mismatch"));
                     }
 
-                    // Mark current frame as unreachable
+                    // Mark current frame as unreachable and truncate stack
                     if let Some(frame) = frames.last_mut() {
                         if frame.reachable {
-                            frame.unreachable_height = Some(stack.len());
+                            frame.unreachable_height = Some(frame.stack_height);
                         }
                         frame.reachable = false;
+                        stack.truncate(frame.stack_height);
                     }
                 },
 
@@ -1005,12 +1011,13 @@ impl WastModuleValidator {
                         Self::is_unreachable(&frames),
                     )?;
 
-                    // Mark current frame as unreachable
+                    // Mark current frame as unreachable and truncate stack
                     if let Some(frame) = frames.last_mut() {
                         if frame.reachable {
-                            frame.unreachable_height = Some(stack.len());
+                            frame.unreachable_height = Some(frame.stack_height);
                         }
                         frame.reachable = false;
+                        stack.truncate(frame.stack_height);
                     }
                 },
                 0x0D => {
@@ -1128,12 +1135,13 @@ impl WastModuleValidator {
                         Self::is_unreachable(&frames),
                     )?;
 
-                    // Mark current frame as unreachable
+                    // Mark current frame as unreachable and truncate stack
                     if let Some(frame) = frames.last_mut() {
                         if frame.reachable {
-                            frame.unreachable_height = Some(stack.len());
+                            frame.unreachable_height = Some(frame.stack_height);
                         }
                         frame.reachable = false;
+                        stack.truncate(frame.stack_height);
                     }
                 },
                 0x0F => {
@@ -1152,11 +1160,13 @@ impl WastModuleValidator {
                         }
                     }
 
+                    // Mark current frame as unreachable and truncate stack
                     if let Some(frame) = frames.last_mut() {
                         if frame.reachable {
-                            frame.unreachable_height = Some(stack.len());
+                            frame.unreachable_height = Some(frame.stack_height);
                         }
                         frame.reachable = false;
+                        stack.truncate(frame.stack_height);
                     }
                 },
                 0x10 => {
@@ -1218,10 +1228,15 @@ impl WastModuleValidator {
                     let func_type = &module.types[type_idx as usize];
                     let frame_height = Self::current_frame_height(&frames);
 
-                    // Pop table index (must be i32)
+                    // Pop table index (i32 or i64 for table64)
+                    let idx_type = if Self::is_table64(module, table_idx) {
+                        StackType::I64
+                    } else {
+                        StackType::I32
+                    };
                     if !Self::pop_type(
                         &mut stack,
-                        StackType::I32,
+                        idx_type,
                         frame_height,
                         Self::is_unreachable(&frames),
                     ) {
@@ -1289,12 +1304,13 @@ impl WastModuleValidator {
                     }
 
                     // return_call is a terminating instruction (like return)
-                    // Mark current frame as unreachable
+                    // Mark current frame as unreachable and truncate stack
                     if let Some(frame) = frames.last_mut() {
                         if frame.reachable {
-                            frame.unreachable_height = Some(stack.len());
+                            frame.unreachable_height = Some(frame.stack_height);
                         }
                         frame.reachable = false;
+                        stack.truncate(frame.stack_height);
                     }
                 },
                 0x13 => {
@@ -1340,10 +1356,15 @@ impl WastModuleValidator {
 
                     let frame_height = Self::current_frame_height(&frames);
 
-                    // Pop table index (must be i32)
+                    // Pop table index (i32 or i64 for table64)
+                    let idx_type = if Self::is_table64(module, table_idx) {
+                        StackType::I64
+                    } else {
+                        StackType::I32
+                    };
                     if !Self::pop_type(
                         &mut stack,
-                        StackType::I32,
+                        idx_type,
                         frame_height,
                         Self::is_unreachable(&frames),
                     ) {
@@ -1364,12 +1385,13 @@ impl WastModuleValidator {
                     }
 
                     // return_call_indirect is a terminating instruction (like return)
-                    // Mark current frame as unreachable
+                    // Mark current frame as unreachable and truncate stack
                     if let Some(frame) = frames.last_mut() {
                         if frame.reachable {
-                            frame.unreachable_height = Some(stack.len());
+                            frame.unreachable_height = Some(frame.stack_height);
                         }
                         frame.reachable = false;
+                        stack.truncate(frame.stack_height);
                     }
                 },
 
@@ -1965,7 +1987,8 @@ impl WastModuleValidator {
                     }
                 },
                 0x25 => {
-                    // table.get: [i32] -> [t] where t is the table element type
+                    // table.get: [at] -> [t] where t is the table element type
+                    // at = i64 for table64, i32 otherwise
                     let (table_idx, new_offset) = Self::parse_varuint32(code, offset)?;
                     offset = new_offset;
 
@@ -1977,8 +2000,13 @@ impl WastModuleValidator {
                     let frame_height = Self::current_frame_height(&frames);
                     let unreachable = Self::is_unreachable(&frames);
 
-                    // Pop index (must be i32)
-                    if !Self::pop_type(&mut stack, StackType::I32, frame_height, unreachable) {
+                    // Pop index (i32 or i64 for table64)
+                    let idx_type = if Self::is_table64(module, table_idx) {
+                        StackType::I64
+                    } else {
+                        StackType::I32
+                    };
+                    if !Self::pop_type(&mut stack, idx_type, frame_height, unreachable) {
                         return Err(anyhow!("type mismatch"));
                     }
 
@@ -1991,7 +2019,8 @@ impl WastModuleValidator {
                     }
                 },
                 0x26 => {
-                    // table.set: [i32, t] -> [] where t is the table element type
+                    // table.set: [at, t] -> [] where t is the table element type
+                    // at = i64 for table64, i32 otherwise
                     let (table_idx, new_offset) = Self::parse_varuint32(code, offset)?;
                     offset = new_offset;
 
@@ -2027,8 +2056,13 @@ impl WastModuleValidator {
                         return Err(anyhow!("type mismatch"));
                     }
 
-                    // Pop index (must be i32)
-                    if !Self::pop_type(&mut stack, StackType::I32, frame_height, unreachable) {
+                    // Pop index (i32 or i64 for table64)
+                    let idx_type = if Self::is_table64(module, table_idx) {
+                        StackType::I64
+                    } else {
+                        StackType::I32
+                    };
+                    if !Self::pop_type(&mut stack, idx_type, frame_height, unreachable) {
                         return Err(anyhow!("type mismatch"));
                     }
                 },
@@ -2782,7 +2816,8 @@ impl WastModuleValidator {
                             }
                             stack.push(StackType::I64);
                         },
-                        // memory.init (0x08): [i32, i32, i32] -> []
+                        // memory.init (0x08): [at, i32, i32] -> []
+                        // at = memory's index type (i64 for memory64, i32 otherwise)
                         0x08 => {
                             let (data_idx, new_offset) = Self::parse_varuint32(code, offset)?;
                             offset = new_offset;
@@ -2796,7 +2831,12 @@ impl WastModuleValidator {
                             if mem_idx as usize >= Self::total_memories(module) {
                                 return Err(anyhow!("unknown memory"));
                             }
-                            // Pop n (length), s (source offset), d (dest offset) in reverse
+                            let idx_type = if Self::is_memory64(module, mem_idx) {
+                                StackType::I64
+                            } else {
+                                StackType::I32
+                            };
+                            // Pop n (length: i32), s (source offset: i32), d (dest offset: at) in reverse
                             if !Self::pop_type(
                                 &mut stack,
                                 StackType::I32,
@@ -2815,7 +2855,7 @@ impl WastModuleValidator {
                             }
                             if !Self::pop_type(
                                 &mut stack,
-                                StackType::I32,
+                                idx_type,
                                 frame_height,
                                 unreachable,
                             ) {
@@ -2831,7 +2871,8 @@ impl WastModuleValidator {
                                 return Err(anyhow!("unknown data segment"));
                             }
                         },
-                        // memory.copy (0x0A): [i32, i32, i32] -> []
+                        // memory.copy (0x0A): [at_d, at_s, n] -> []
+                        // n type = i64 if either src or dst is memory64
                         0x0A => {
                             let (dst_mem, new_offset) = Self::parse_varuint32(code, offset)?;
                             offset = new_offset;
@@ -2844,10 +2885,16 @@ impl WastModuleValidator {
                             if src_mem as usize >= Self::total_memories(module) {
                                 return Err(anyhow!("unknown memory"));
                             }
+                            let dst_is_64 = Self::is_memory64(module, dst_mem);
+                            let src_is_64 = Self::is_memory64(module, src_mem);
+                            let dst_type = if dst_is_64 { StackType::I64 } else { StackType::I32 };
+                            let src_type = if src_is_64 { StackType::I64 } else { StackType::I32 };
+                            // Length type: i64 if either memory is memory64
+                            let len_type = if dst_is_64 || src_is_64 { StackType::I64 } else { StackType::I32 };
                             // Pop n (length), s (source), d (dest) in reverse
                             if !Self::pop_type(
                                 &mut stack,
-                                StackType::I32,
+                                len_type,
                                 frame_height,
                                 unreachable,
                             ) {
@@ -2855,7 +2902,7 @@ impl WastModuleValidator {
                             }
                             if !Self::pop_type(
                                 &mut stack,
-                                StackType::I32,
+                                src_type,
                                 frame_height,
                                 unreachable,
                             ) {
@@ -2863,14 +2910,15 @@ impl WastModuleValidator {
                             }
                             if !Self::pop_type(
                                 &mut stack,
-                                StackType::I32,
+                                dst_type,
                                 frame_height,
                                 unreachable,
                             ) {
                                 return Err(anyhow!("type mismatch"));
                             }
                         },
-                        // memory.fill (0x0B): [i32, i32, i32] -> []
+                        // memory.fill (0x0B): [at, i32, at] -> []
+                        // at = memory's index type (i64 for memory64, i32 otherwise)
                         0x0B => {
                             let (mem_idx, new_offset) = Self::parse_varuint32(code, offset)?;
                             offset = new_offset;
@@ -2878,10 +2926,15 @@ impl WastModuleValidator {
                             if mem_idx as usize >= Self::total_memories(module) {
                                 return Err(anyhow!("unknown memory"));
                             }
-                            // Pop n (length), val (value), d (dest) in reverse
+                            let idx_type = if Self::is_memory64(module, mem_idx) {
+                                StackType::I64
+                            } else {
+                                StackType::I32
+                            };
+                            // Pop n (length: at), val (value: i32), d (dest: at) in reverse
                             if !Self::pop_type(
                                 &mut stack,
-                                StackType::I32,
+                                idx_type,
                                 frame_height,
                                 unreachable,
                             ) {
@@ -2897,14 +2950,15 @@ impl WastModuleValidator {
                             }
                             if !Self::pop_type(
                                 &mut stack,
-                                StackType::I32,
+                                idx_type,
                                 frame_height,
                                 unreachable,
                             ) {
                                 return Err(anyhow!("type mismatch"));
                             }
                         },
-                        // table.init (0x0C): [i32, i32, i32] -> []
+                        // table.init (0x0C): [at, i32, i32] -> []
+                        // at = table's index type (i64 for table64, i32 otherwise)
                         0x0C => {
                             let (elem_idx, new_offset) = Self::parse_varuint32(code, offset)?;
                             offset = new_offset;
@@ -2918,7 +2972,12 @@ impl WastModuleValidator {
                             if table_idx as usize >= Self::total_tables(module) {
                                 return Err(anyhow!("unknown table"));
                             }
-                            // Pop n, s, d in reverse
+                            let idx_type = if Self::is_table64(module, table_idx) {
+                                StackType::I64
+                            } else {
+                                StackType::I32
+                            };
+                            // Pop n (length: i32), s (source: i32), d (dest: at) in reverse
                             if !Self::pop_type(
                                 &mut stack,
                                 StackType::I32,
@@ -2937,7 +2996,7 @@ impl WastModuleValidator {
                             }
                             if !Self::pop_type(
                                 &mut stack,
-                                StackType::I32,
+                                idx_type,
                                 frame_height,
                                 unreachable,
                             ) {
@@ -2953,7 +3012,8 @@ impl WastModuleValidator {
                                 return Err(anyhow!("unknown elem segment"));
                             }
                         },
-                        // table.copy (0x0E): [i32, i32, i32] -> []
+                        // table.copy (0x0E): [at_d, at_s, n] -> []
+                        // n type = i64 if either src or dst is table64
                         0x0E => {
                             let (dst_table, new_offset) = Self::parse_varuint32(code, offset)?;
                             offset = new_offset;
@@ -2966,10 +3026,16 @@ impl WastModuleValidator {
                             if src_table as usize >= Self::total_tables(module) {
                                 return Err(anyhow!("unknown table"));
                             }
-                            // Pop n, s, d in reverse
+                            let dst_is_64 = Self::is_table64(module, dst_table);
+                            let src_is_64 = Self::is_table64(module, src_table);
+                            let dst_type = if dst_is_64 { StackType::I64 } else { StackType::I32 };
+                            let src_type = if src_is_64 { StackType::I64 } else { StackType::I32 };
+                            // Length type: i64 if either table is table64
+                            let len_type = if dst_is_64 || src_is_64 { StackType::I64 } else { StackType::I32 };
+                            // Pop n (length), s (source), d (dest) in reverse
                             if !Self::pop_type(
                                 &mut stack,
-                                StackType::I32,
+                                len_type,
                                 frame_height,
                                 unreachable,
                             ) {
@@ -2977,7 +3043,7 @@ impl WastModuleValidator {
                             }
                             if !Self::pop_type(
                                 &mut stack,
-                                StackType::I32,
+                                src_type,
                                 frame_height,
                                 unreachable,
                             ) {
@@ -2985,14 +3051,15 @@ impl WastModuleValidator {
                             }
                             if !Self::pop_type(
                                 &mut stack,
-                                StackType::I32,
+                                dst_type,
                                 frame_height,
                                 unreachable,
                             ) {
                                 return Err(anyhow!("type mismatch"));
                             }
                         },
-                        // table.grow (0x0F): [ref, i32] -> [i32]
+                        // table.grow (0x0F): [ref, at] -> [at]
+                        // at = i64 for table64, i32 otherwise
                         0x0F => {
                             let (table_idx, new_offset) = Self::parse_varuint32(code, offset)?;
                             offset = new_offset;
@@ -3011,10 +3078,16 @@ impl WastModuleValidator {
                                 StackType::Unknown
                             };
 
-                            // Pop n (delta)
+                            let idx_type = if Self::is_table64(module, table_idx) {
+                                StackType::I64
+                            } else {
+                                StackType::I32
+                            };
+
+                            // Pop n (delta: at)
                             if !Self::pop_type(
                                 &mut stack,
-                                StackType::I32,
+                                idx_type,
                                 frame_height,
                                 unreachable,
                             ) {
@@ -3033,9 +3106,10 @@ impl WastModuleValidator {
                             } else if !unreachable {
                                 return Err(anyhow!("type mismatch"));
                             }
-                            stack.push(StackType::I32);
+                            stack.push(idx_type);
                         },
-                        // table.size (0x10): [] -> [i32]
+                        // table.size (0x10): [] -> [at]
+                        // at = i64 for table64, i32 otherwise
                         0x10 => {
                             let (table_idx, new_offset) = Self::parse_varuint32(code, offset)?;
                             offset = new_offset;
@@ -3043,9 +3117,15 @@ impl WastModuleValidator {
                             if table_idx as usize >= Self::total_tables(module) {
                                 return Err(anyhow!("unknown table"));
                             }
-                            stack.push(StackType::I32);
+                            let idx_type = if Self::is_table64(module, table_idx) {
+                                StackType::I64
+                            } else {
+                                StackType::I32
+                            };
+                            stack.push(idx_type);
                         },
-                        // table.fill (0x11): [i32, ref, i32] -> []
+                        // table.fill (0x11): [at, ref, at] -> []
+                        // at = i64 for table64, i32 otherwise
                         0x11 => {
                             let (table_idx, new_offset) = Self::parse_varuint32(code, offset)?;
                             offset = new_offset;
@@ -3064,10 +3144,16 @@ impl WastModuleValidator {
                                 StackType::Unknown
                             };
 
-                            // Pop n (length)
+                            let idx_type = if Self::is_table64(module, table_idx) {
+                                StackType::I64
+                            } else {
+                                StackType::I32
+                            };
+
+                            // Pop n (length: at)
                             if !Self::pop_type(
                                 &mut stack,
-                                StackType::I32,
+                                idx_type,
                                 frame_height,
                                 unreachable,
                             ) {
@@ -3086,10 +3172,10 @@ impl WastModuleValidator {
                             } else if !unreachable {
                                 return Err(anyhow!("type mismatch"));
                             }
-                            // Pop i (dest)
+                            // Pop i (dest: at)
                             if !Self::pop_type(
                                 &mut stack,
-                                StackType::I32,
+                                idx_type,
                                 frame_height,
                                 unreachable,
                             ) {
@@ -3518,6 +3604,25 @@ impl WastModuleValidator {
 
                     stack.push(StackType::FuncRef);
                 },
+                // SIMD prefix (0xFD) - handle v128.const
+                0xFD => {
+                    // Read the SIMD sub-opcode (LEB128 encoded)
+                    let (simd_opcode, new_pos) = Self::read_leb128_unsigned(init_bytes, pos)?;
+                    pos = new_pos;
+                    match simd_opcode {
+                        // v128.const = 0x0C: [] -> [v128] - 16 byte immediate
+                        0x0C => {
+                            if pos + 16 > init_bytes.len() {
+                                return Err(anyhow!("Truncated v128.const in constant expression"));
+                            }
+                            pos += 16;
+                            stack.push(StackType::V128);
+                        },
+                        _ => {
+                            return Err(anyhow!("constant expression required"));
+                        },
+                    }
+                },
                 // Extended constant expressions (WebAssembly 2.0)
                 // i32.add, i32.sub, i32.mul - pop 2 i32, push 1 i32
                 0x6A | 0x6B | 0x6C => {
@@ -3670,7 +3775,6 @@ impl WastModuleValidator {
     /// Memory indices include both imported and defined memories:
     /// - Indices 0..N-1 are imported memories
     /// - Indices N+ are defined memories
-    #[allow(dead_code)]
     fn is_memory64(module: &Module, mem_idx: u32) -> bool {
         let num_mem_imports = Self::count_memory_imports(module);
 
@@ -3735,6 +3839,32 @@ impl WastModuleValidator {
             // This is a defined table
             let defined_idx = table_idx as usize - num_table_imports;
             module.tables.get(defined_idx).map(|t| t.element_type)
+        }
+    }
+
+    /// Check if a table at the given index uses 64-bit indexing (Table64)
+    /// Table indices include both imported and defined tables:
+    /// - Indices 0..N-1 are imported tables
+    /// - Indices N+ are defined tables
+    fn is_table64(module: &Module, table_idx: u32) -> bool {
+        let num_table_imports = Self::count_table_imports(module);
+
+        if (table_idx as usize) < num_table_imports {
+            // This is an imported table - find it in imports Vec
+            let mut import_idx = 0;
+            for import in &module.imports {
+                if let ImportDesc::Table(table_type) = &import.desc {
+                    if import_idx == table_idx as usize {
+                        return table_type.table64;
+                    }
+                    import_idx += 1;
+                }
+            }
+            false
+        } else {
+            // This is a defined table
+            let defined_idx = table_idx as usize - num_table_imports;
+            module.tables.get(defined_idx).map_or(false, |t| t.table64)
         }
     }
 

--- a/wrt-build-core/src/wast_validator.rs
+++ b/wrt-build-core/src/wast_validator.rs
@@ -381,13 +381,16 @@ impl WastModuleValidator {
                         return Err(anyhow!("size minimum must not be greater than maximum"));
                     }
                 }
-                // Check memory size bounds (65536 pages max)
-                if memory.limits.min > WASM_MAX_MEMORY_PAGES {
-                    return Err(anyhow!("memory size"));
-                }
-                if let Some(max) = memory.limits.max {
-                    if max > WASM_MAX_MEMORY_PAGES {
+                // Check memory size bounds (65536 pages max for memory32)
+                // memory64 supports much larger sizes
+                if !memory.memory64 {
+                    if memory.limits.min > WASM_MAX_MEMORY_PAGES {
                         return Err(anyhow!("memory size"));
+                    }
+                    if let Some(max) = memory.limits.max {
+                        if max > WASM_MAX_MEMORY_PAGES {
+                            return Err(anyhow!("memory size"));
+                        }
                     }
                 }
             }
@@ -401,13 +404,16 @@ impl WastModuleValidator {
                     return Err(anyhow!("size minimum must not be greater than maximum"));
                 }
             }
-            // Check memory size bounds (65536 pages max)
-            if memory.limits.min > WASM_MAX_MEMORY_PAGES {
-                return Err(anyhow!("memory size"));
-            }
-            if let Some(max) = memory.limits.max {
-                if max > WASM_MAX_MEMORY_PAGES {
+            // Check memory size bounds (65536 pages max for memory32)
+            // memory64 supports much larger sizes
+            if !memory.memory64 {
+                if memory.limits.min > WASM_MAX_MEMORY_PAGES {
                     return Err(anyhow!("memory size"));
+                }
+                if let Some(max) = memory.limits.max {
+                    if max > WASM_MAX_MEMORY_PAGES {
+                        return Err(anyhow!("memory size"));
+                    }
                 }
             }
         }

--- a/wrt-build-core/src/wast_validator.rs
+++ b/wrt-build-core/src/wast_validator.rs
@@ -13,7 +13,7 @@
 use anyhow::{Context, Result, anyhow};
 use std::collections::HashSet;
 use wrt_format::module::{Function, Global, ImportDesc, Module};
-use wrt_format::pure_format_types::{PureElementInit, PureElementMode, PureElementSegment};
+use wrt_format::pure_format_types::{PureDataMode, PureElementInit, PureElementMode, PureElementSegment};
 use wrt_format::types::RefType;
 use wrt_foundation::ValueType;
 
@@ -127,6 +127,7 @@ impl StackType {
         match rt {
             wrt_foundation::RefType::Funcref => StackType::FuncRef,
             wrt_foundation::RefType::Externref => StackType::ExternRef,
+            wrt_foundation::RefType::Gc(_) => StackType::FuncRef, // GC ref types treated as funcref for validation
         }
     }
 }
@@ -199,8 +200,15 @@ impl WastModuleValidator {
         // Validate start function
         Self::validate_start_function(module)?;
 
-        // Validate export names are unique
+        // Validate export names are unique and indices are valid
         Self::validate_export_names(module)?;
+        Self::validate_export_indices(module)?;
+
+        // Validate element segment table references
+        Self::validate_element_segment_tables(module)?;
+
+        // Validate data segment memory references
+        Self::validate_data_segment_memories(module)?;
 
         Ok(())
     }
@@ -212,6 +220,74 @@ impl WastModuleValidator {
         for export in &module.exports {
             if !seen_names.insert(export.name.as_str()) {
                 return Err(anyhow!("duplicate export name"));
+            }
+        }
+        Ok(())
+    }
+
+    /// Validate that all export indices reference valid items
+    fn validate_export_indices(module: &Module) -> Result<()> {
+        let total_funcs = Self::total_functions(module);
+        let total_tables = Self::total_tables(module);
+        let total_memories = Self::total_memories(module);
+        let total_globals = Self::total_globals(module);
+        let total_tags = Self::total_tags(module);
+
+        for export in &module.exports {
+            match export.kind {
+                wrt_format::module::ExportKind::Function => {
+                    if (export.index as usize) >= total_funcs {
+                        return Err(anyhow!("unknown function"));
+                    }
+                },
+                wrt_format::module::ExportKind::Table => {
+                    if (export.index as usize) >= total_tables {
+                        return Err(anyhow!("unknown table"));
+                    }
+                },
+                wrt_format::module::ExportKind::Memory => {
+                    if (export.index as usize) >= total_memories {
+                        return Err(anyhow!("unknown memory"));
+                    }
+                },
+                wrt_format::module::ExportKind::Global => {
+                    if (export.index as usize) >= total_globals {
+                        return Err(anyhow!("unknown global"));
+                    }
+                },
+                wrt_format::module::ExportKind::Tag => {
+                    if (export.index as usize) >= total_tags {
+                        return Err(anyhow!("unknown tag"));
+                    }
+                },
+            }
+        }
+        Ok(())
+    }
+
+    /// Validate that active element segments reference valid tables
+    fn validate_element_segment_tables(module: &Module) -> Result<()> {
+        let total_tables = Self::total_tables(module);
+
+        for elem in &module.elements {
+            if let PureElementMode::Active { table_index, .. } = &elem.mode {
+                if (*table_index as usize) >= total_tables {
+                    return Err(anyhow!("unknown table"));
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Validate that active data segments reference valid memories
+    fn validate_data_segment_memories(module: &Module) -> Result<()> {
+        let total_memories = Self::total_memories(module);
+
+        for data in &module.data {
+            if let PureDataMode::Active { memory_index, .. } = &data.mode {
+                if (*memory_index as usize) >= total_memories {
+                    return Err(anyhow!("unknown memory"));
+                }
             }
         }
         Ok(())
@@ -1088,8 +1164,8 @@ impl WastModuleValidator {
                     let (func_idx, new_offset) = Self::parse_varuint32(code, offset)?;
                     offset = new_offset;
 
-                    if func_idx as usize >= module.functions.len() + module.imports.len() {
-                        return Err(anyhow!("call: invalid function index {}", func_idx));
+                    if func_idx as usize >= Self::total_functions(module) {
+                        return Err(anyhow!("unknown function"));
                     }
 
                     // Pop arguments and push results
@@ -1175,6 +1251,11 @@ impl WastModuleValidator {
                     // Parse function index
                     let (func_idx, new_offset) = Self::parse_varuint32(code, offset)?;
                     offset = new_offset;
+
+                    // Validate function index
+                    if func_idx as usize >= Self::total_functions(module) {
+                        return Err(anyhow!("unknown function"));
+                    }
 
                     // Get the called function's type (handles both imports and local functions)
                     let called_func_type = Self::get_function_type(module, func_idx)?;
@@ -1451,7 +1532,7 @@ impl WastModuleValidator {
                     if !Self::has_memory(module) {
                         return Err(anyhow!("unknown memory"));
                     }
-                    let (mem_idx, new_offset) = Self::parse_memarg(code, offset, module)?;
+                    let (mem_idx, new_offset) = Self::parse_memarg_for_opcode(code, offset, module, opcode)?;
                     offset = new_offset;
                     let frame_height = Self::current_frame_height(&frames);
                     let addr_type = if Self::is_memory64(module, mem_idx) {
@@ -1474,7 +1555,7 @@ impl WastModuleValidator {
                     if !Self::has_memory(module) {
                         return Err(anyhow!("unknown memory"));
                     }
-                    let (mem_idx, new_offset) = Self::parse_memarg(code, offset, module)?;
+                    let (mem_idx, new_offset) = Self::parse_memarg_for_opcode(code, offset, module, opcode)?;
                     offset = new_offset;
                     let frame_height = Self::current_frame_height(&frames);
                     let addr_type = if Self::is_memory64(module, mem_idx) {
@@ -1497,7 +1578,7 @@ impl WastModuleValidator {
                     if !Self::has_memory(module) {
                         return Err(anyhow!("unknown memory"));
                     }
-                    let (mem_idx, new_offset) = Self::parse_memarg(code, offset, module)?;
+                    let (mem_idx, new_offset) = Self::parse_memarg_for_opcode(code, offset, module, opcode)?;
                     offset = new_offset;
                     let frame_height = Self::current_frame_height(&frames);
                     let addr_type = if Self::is_memory64(module, mem_idx) {
@@ -1520,7 +1601,7 @@ impl WastModuleValidator {
                     if !Self::has_memory(module) {
                         return Err(anyhow!("unknown memory"));
                     }
-                    let (mem_idx, new_offset) = Self::parse_memarg(code, offset, module)?;
+                    let (mem_idx, new_offset) = Self::parse_memarg_for_opcode(code, offset, module, opcode)?;
                     offset = new_offset;
                     let frame_height = Self::current_frame_height(&frames);
                     let addr_type = if Self::is_memory64(module, mem_idx) {
@@ -1544,7 +1625,7 @@ impl WastModuleValidator {
                     if !Self::has_memory(module) {
                         return Err(anyhow!("unknown memory"));
                     }
-                    let (mem_idx, new_offset) = Self::parse_memarg(code, offset, module)?;
+                    let (mem_idx, new_offset) = Self::parse_memarg_for_opcode(code, offset, module, opcode)?;
                     offset = new_offset;
                     let frame_height = Self::current_frame_height(&frames);
                     let addr_type = if Self::is_memory64(module, mem_idx) {
@@ -1573,7 +1654,7 @@ impl WastModuleValidator {
                     if !Self::has_memory(module) {
                         return Err(anyhow!("unknown memory"));
                     }
-                    let (mem_idx, new_offset) = Self::parse_memarg(code, offset, module)?;
+                    let (mem_idx, new_offset) = Self::parse_memarg_for_opcode(code, offset, module, opcode)?;
                     offset = new_offset;
                     let frame_height = Self::current_frame_height(&frames);
                     // Pop value (i32)
@@ -1605,7 +1686,7 @@ impl WastModuleValidator {
                     if !Self::has_memory(module) {
                         return Err(anyhow!("unknown memory"));
                     }
-                    let (mem_idx, new_offset) = Self::parse_memarg(code, offset, module)?;
+                    let (mem_idx, new_offset) = Self::parse_memarg_for_opcode(code, offset, module, opcode)?;
                     offset = new_offset;
                     let frame_height = Self::current_frame_height(&frames);
                     // Pop value (i64)
@@ -1637,7 +1718,7 @@ impl WastModuleValidator {
                     if !Self::has_memory(module) {
                         return Err(anyhow!("unknown memory"));
                     }
-                    let (mem_idx, new_offset) = Self::parse_memarg(code, offset, module)?;
+                    let (mem_idx, new_offset) = Self::parse_memarg_for_opcode(code, offset, module, opcode)?;
                     offset = new_offset;
                     let frame_height = Self::current_frame_height(&frames);
                     // Pop value (f32)
@@ -1669,7 +1750,7 @@ impl WastModuleValidator {
                     if !Self::has_memory(module) {
                         return Err(anyhow!("unknown memory"));
                     }
-                    let (mem_idx, new_offset) = Self::parse_memarg(code, offset, module)?;
+                    let (mem_idx, new_offset) = Self::parse_memarg_for_opcode(code, offset, module, opcode)?;
                     offset = new_offset;
                     let frame_height = Self::current_frame_height(&frames);
                     // Pop value (f64)
@@ -1701,7 +1782,7 @@ impl WastModuleValidator {
                     if !Self::has_memory(module) {
                         return Err(anyhow!("unknown memory"));
                     }
-                    let (mem_idx, new_offset) = Self::parse_memarg(code, offset, module)?;
+                    let (mem_idx, new_offset) = Self::parse_memarg_for_opcode(code, offset, module, opcode)?;
                     offset = new_offset;
                     let frame_height = Self::current_frame_height(&frames);
                     // Pop value type based on opcode
@@ -1736,9 +1817,6 @@ impl WastModuleValidator {
                 0x3F => {
                     // memory.size - push i32/i64 (current memory size in pages)
                     // For memory64, returns i64; otherwise i32
-                    if !Self::has_memory(module) {
-                        return Err(anyhow!("unknown memory"));
-                    }
                     // Read memory index (usually 0x00 for default memory)
                     let mem_idx = if offset < code.len() {
                         let idx = code[offset] as u32;
@@ -1747,6 +1825,10 @@ impl WastModuleValidator {
                     } else {
                         0
                     };
+                    // Validate memory index
+                    if mem_idx as usize >= Self::total_memories(module) {
+                        return Err(anyhow!("unknown memory"));
+                    }
                     // Memory64 returns i64, regular memory returns i32
                     if Self::is_memory64(module, mem_idx) {
                         stack.push(StackType::I64);
@@ -1757,9 +1839,6 @@ impl WastModuleValidator {
                 0x40 => {
                     // memory.grow - pop i32/i64 (delta pages), push i32/i64 (previous size or -1)
                     // For memory64, takes and returns i64; otherwise i32
-                    if !Self::has_memory(module) {
-                        return Err(anyhow!("unknown memory"));
-                    }
                     // Read memory index (usually 0x00 for default memory)
                     let mem_idx = if offset < code.len() {
                         let idx = code[offset] as u32;
@@ -1768,6 +1847,10 @@ impl WastModuleValidator {
                     } else {
                         0
                     };
+                    // Validate memory index
+                    if mem_idx as usize >= Self::total_memories(module) {
+                        return Err(anyhow!("unknown memory"));
+                    }
                     let frame_height = Self::current_frame_height(&frames);
                     // Memory64 uses i64 for delta and result, regular uses i32
                     let size_type = if Self::is_memory64(module, mem_idx) {
@@ -2701,11 +2784,18 @@ impl WastModuleValidator {
                         },
                         // memory.init (0x08): [i32, i32, i32] -> []
                         0x08 => {
-                            // Skip data_idx and mem_idx
-                            let (_data_idx, new_offset) = Self::parse_varuint32(code, offset)?;
+                            let (data_idx, new_offset) = Self::parse_varuint32(code, offset)?;
                             offset = new_offset;
-                            let (_mem_idx, new_offset) = Self::parse_varuint32(code, offset)?;
+                            let (mem_idx, new_offset) = Self::parse_varuint32(code, offset)?;
                             offset = new_offset;
+                            // Validate data segment index
+                            if data_idx as usize >= module.data.len() {
+                                return Err(anyhow!("unknown data segment"));
+                            }
+                            // Validate memory index
+                            if mem_idx as usize >= Self::total_memories(module) {
+                                return Err(anyhow!("unknown memory"));
+                            }
                             // Pop n (length), s (source offset), d (dest offset) in reverse
                             if !Self::pop_type(
                                 &mut stack,
@@ -2734,15 +2824,26 @@ impl WastModuleValidator {
                         },
                         // data.drop (0x09): [] -> []
                         0x09 => {
-                            let (_data_idx, new_offset) = Self::parse_varuint32(code, offset)?;
+                            let (data_idx, new_offset) = Self::parse_varuint32(code, offset)?;
                             offset = new_offset;
+                            // Validate data segment index
+                            if data_idx as usize >= module.data.len() {
+                                return Err(anyhow!("unknown data segment"));
+                            }
                         },
                         // memory.copy (0x0A): [i32, i32, i32] -> []
                         0x0A => {
-                            let (_dst_mem, new_offset) = Self::parse_varuint32(code, offset)?;
+                            let (dst_mem, new_offset) = Self::parse_varuint32(code, offset)?;
                             offset = new_offset;
-                            let (_src_mem, new_offset) = Self::parse_varuint32(code, offset)?;
+                            let (src_mem, new_offset) = Self::parse_varuint32(code, offset)?;
                             offset = new_offset;
+                            // Validate both memory indices
+                            if dst_mem as usize >= Self::total_memories(module) {
+                                return Err(anyhow!("unknown memory"));
+                            }
+                            if src_mem as usize >= Self::total_memories(module) {
+                                return Err(anyhow!("unknown memory"));
+                            }
                             // Pop n (length), s (source), d (dest) in reverse
                             if !Self::pop_type(
                                 &mut stack,
@@ -2771,8 +2872,12 @@ impl WastModuleValidator {
                         },
                         // memory.fill (0x0B): [i32, i32, i32] -> []
                         0x0B => {
-                            let (_mem_idx, new_offset) = Self::parse_varuint32(code, offset)?;
+                            let (mem_idx, new_offset) = Self::parse_varuint32(code, offset)?;
                             offset = new_offset;
+                            // Validate memory index
+                            if mem_idx as usize >= Self::total_memories(module) {
+                                return Err(anyhow!("unknown memory"));
+                            }
                             // Pop n (length), val (value), d (dest) in reverse
                             if !Self::pop_type(
                                 &mut stack,
@@ -2801,10 +2906,18 @@ impl WastModuleValidator {
                         },
                         // table.init (0x0C): [i32, i32, i32] -> []
                         0x0C => {
-                            let (_elem_idx, new_offset) = Self::parse_varuint32(code, offset)?;
+                            let (elem_idx, new_offset) = Self::parse_varuint32(code, offset)?;
                             offset = new_offset;
-                            let (_table_idx, new_offset) = Self::parse_varuint32(code, offset)?;
+                            let (table_idx, new_offset) = Self::parse_varuint32(code, offset)?;
                             offset = new_offset;
+                            // Validate element segment index
+                            if elem_idx as usize >= module.elements.len() {
+                                return Err(anyhow!("unknown elem segment"));
+                            }
+                            // Validate table index
+                            if table_idx as usize >= Self::total_tables(module) {
+                                return Err(anyhow!("unknown table"));
+                            }
                             // Pop n, s, d in reverse
                             if !Self::pop_type(
                                 &mut stack,
@@ -2833,15 +2946,26 @@ impl WastModuleValidator {
                         },
                         // elem.drop (0x0D): [] -> []
                         0x0D => {
-                            let (_elem_idx, new_offset) = Self::parse_varuint32(code, offset)?;
+                            let (elem_idx, new_offset) = Self::parse_varuint32(code, offset)?;
                             offset = new_offset;
+                            // Validate element segment index
+                            if elem_idx as usize >= module.elements.len() {
+                                return Err(anyhow!("unknown elem segment"));
+                            }
                         },
                         // table.copy (0x0E): [i32, i32, i32] -> []
                         0x0E => {
-                            let (_dst_table, new_offset) = Self::parse_varuint32(code, offset)?;
+                            let (dst_table, new_offset) = Self::parse_varuint32(code, offset)?;
                             offset = new_offset;
-                            let (_src_table, new_offset) = Self::parse_varuint32(code, offset)?;
+                            let (src_table, new_offset) = Self::parse_varuint32(code, offset)?;
                             offset = new_offset;
+                            // Validate both table indices
+                            if dst_table as usize >= Self::total_tables(module) {
+                                return Err(anyhow!("unknown table"));
+                            }
+                            if src_table as usize >= Self::total_tables(module) {
+                                return Err(anyhow!("unknown table"));
+                            }
                             // Pop n, s, d in reverse
                             if !Self::pop_type(
                                 &mut stack,
@@ -2913,8 +3037,12 @@ impl WastModuleValidator {
                         },
                         // table.size (0x10): [] -> [i32]
                         0x10 => {
-                            let (_table_idx, new_offset) = Self::parse_varuint32(code, offset)?;
+                            let (table_idx, new_offset) = Self::parse_varuint32(code, offset)?;
                             offset = new_offset;
+                            // Validate table index
+                            if table_idx as usize >= Self::total_tables(module) {
+                                return Err(anyhow!("unknown table"));
+                            }
                             stack.push(StackType::I32);
                         },
                         // table.fill (0x11): [i32, ref, i32] -> []
@@ -2983,9 +3111,10 @@ impl WastModuleValidator {
                     match simd_opcode {
                         // v128.load variants (0x00-0x0A): [i32] -> [v128]
                         0x00..=0x0A => {
-                            let (_, o) = Self::parse_varuint32(code, offset)?; // align
+                            let (align, o) = Self::parse_varuint32(code, offset)?;
                             let (_, o) = Self::parse_varuint32(code, o)?;      // offset
                             offset = o;
+                            Self::validate_simd_alignment(simd_opcode, align)?;
                             if !Self::pop_type(&mut stack, StackType::I32, frame_height, unreachable) {
                                 return Err(anyhow!("type mismatch"));
                             }
@@ -2993,8 +3122,9 @@ impl WastModuleValidator {
                         },
                         // v128.store (0x0B): [i32, v128] -> []
                         0x0B => {
-                            let (_, o) = Self::parse_varuint32(code, offset)?;
+                            let (align, o) = Self::parse_varuint32(code, offset)?;
                             let (_, o) = Self::parse_varuint32(code, o)?;
+                            Self::validate_simd_alignment(simd_opcode, align)?;
                             offset = o;
                             if !Self::pop_type(&mut stack, StackType::V128, frame_height, unreachable) {
                                 return Err(anyhow!("type mismatch"));
@@ -3161,8 +3291,9 @@ impl WastModuleValidator {
                         },
                         // v128.load*_lane (0x54-0x57): [i32, v128] -> [v128]
                         0x54..=0x57 => {
-                            let (_, o) = Self::parse_varuint32(code, offset)?;
+                            let (align, o) = Self::parse_varuint32(code, offset)?;
                             let (_, o) = Self::parse_varuint32(code, o)?;
+                            Self::validate_simd_alignment(simd_opcode, align)?;
                             offset = o;
                             if offset >= code.len() { return Err(anyhow!("unexpected end")); }
                             offset += 1;
@@ -3176,8 +3307,9 @@ impl WastModuleValidator {
                         },
                         // v128.store*_lane (0x58-0x5B): [i32, v128] -> []
                         0x58..=0x5B => {
-                            let (_, o) = Self::parse_varuint32(code, offset)?;
+                            let (align, o) = Self::parse_varuint32(code, offset)?;
                             let (_, o) = Self::parse_varuint32(code, o)?;
+                            Self::validate_simd_alignment(simd_opcode, align)?;
                             offset = o;
                             if offset >= code.len() { return Err(anyhow!("unexpected end")); }
                             offset += 1;
@@ -3190,8 +3322,9 @@ impl WastModuleValidator {
                         },
                         // v128.load32_zero, v128.load64_zero (0x5C, 0x5D): [i32] -> [v128]
                         0x5C | 0x5D => {
-                            let (_, o) = Self::parse_varuint32(code, offset)?;
+                            let (align, o) = Self::parse_varuint32(code, offset)?;
                             let (_, o) = Self::parse_varuint32(code, o)?;
+                            Self::validate_simd_alignment(simd_opcode, align)?;
                             offset = o;
                             if !Self::pop_type(&mut stack, StackType::I32, frame_height, unreachable) {
                                 return Err(anyhow!("type mismatch"));
@@ -3670,8 +3803,10 @@ impl WastModuleValidator {
     }
 
     /// Get the total number of functions (imports + defined)
+    /// Note: The decoder pushes placeholder entries into module.functions for imported functions,
+    /// so module.functions.len() already includes both imports and defined functions.
     fn total_functions(module: &Module) -> usize {
-        Self::count_function_imports(module) + module.functions.len()
+        module.functions.len()
     }
 
     /// Count the number of tag imports in a module
@@ -3905,6 +4040,63 @@ impl WastModuleValidator {
         Ok(())
     }
 
+    /// Get the maximum allowed alignment (as log2) for a SIMD memory operation opcode
+    /// SIMD opcodes are the sub-opcode after the 0xFD prefix
+    /// Returns None if the opcode is not a SIMD memory operation
+    fn max_alignment_for_simd_opcode(simd_opcode: u32) -> Option<u32> {
+        match simd_opcode {
+            // v128.load (16 bytes): max align = 4 (2^4 = 16)
+            0x00 => Some(4),
+            // v128.load8x8_s, v128.load8x8_u (8 bytes): max align = 3
+            0x01 | 0x02 => Some(3),
+            // v128.load16x4_s, v128.load16x4_u (8 bytes): max align = 3
+            0x03 | 0x04 => Some(3),
+            // v128.load32x2_s, v128.load32x2_u (8 bytes): max align = 3
+            0x05 | 0x06 => Some(3),
+            // v128.load8_splat (1 byte): max align = 0
+            0x07 => Some(0),
+            // v128.load16_splat (2 bytes): max align = 1
+            0x08 => Some(1),
+            // v128.load32_splat (4 bytes): max align = 2
+            0x09 => Some(2),
+            // v128.load64_splat (8 bytes): max align = 3
+            0x0A => Some(3),
+            // v128.store (16 bytes): max align = 4
+            0x0B => Some(4),
+            // v128.load8_lane (1 byte): max align = 0
+            0x54 => Some(0),
+            // v128.load16_lane (2 bytes): max align = 1
+            0x55 => Some(1),
+            // v128.load32_lane (4 bytes): max align = 2
+            0x56 => Some(2),
+            // v128.load64_lane (8 bytes): max align = 3
+            0x57 => Some(3),
+            // v128.store8_lane (1 byte): max align = 0
+            0x58 => Some(0),
+            // v128.store16_lane (2 bytes): max align = 1
+            0x59 => Some(1),
+            // v128.store32_lane (4 bytes): max align = 2
+            0x5A => Some(2),
+            // v128.store64_lane (8 bytes): max align = 3
+            0x5B => Some(3),
+            // v128.load32_zero (4 bytes): max align = 2
+            0x5C => Some(2),
+            // v128.load64_zero (8 bytes): max align = 3
+            0x5D => Some(3),
+            _ => None,
+        }
+    }
+
+    /// Validate that a SIMD memory operation's alignment doesn't exceed the natural alignment
+    fn validate_simd_alignment(simd_opcode: u32, align: u32) -> Result<()> {
+        if let Some(max_align) = Self::max_alignment_for_simd_opcode(simd_opcode) {
+            if align > max_align {
+                return Err(anyhow!("alignment must not be larger than natural"));
+            }
+        }
+        Ok(())
+    }
+
     /// Pop a value from the stack, checking its type
     /// The `min_height` parameter is the stack height at the current frame's entry -
     /// we cannot pop below this level (those values belong to the parent frame)
@@ -4023,10 +4215,24 @@ impl WastModuleValidator {
     /// Parse memory arguments (memarg) for load/store instructions
     /// Returns (mem_idx, offset_parsed), advancing the code offset
     /// For memory64, the offset is encoded as u64 instead of u32
+    /// Also validates alignment against the natural alignment for the given opcode,
+    /// and validates that the memory index is in range.
     fn parse_memarg(
         code: &[u8],
         offset: usize,
         module: &Module,
+    ) -> Result<(u32, usize)> {
+        Self::parse_memarg_for_opcode(code, offset, module, 0xFF)
+    }
+
+    /// Parse memory arguments with opcode-specific alignment validation.
+    /// The opcode parameter is used to check alignment constraints.
+    /// Returns (mem_idx, offset_parsed).
+    fn parse_memarg_for_opcode(
+        code: &[u8],
+        offset: usize,
+        module: &Module,
+        opcode: u8,
     ) -> Result<(u32, usize)> {
         // Parse alignment (encoded as power of 2 with optional memory index flag)
         let (align_with_flags, new_offset) = Self::parse_varuint32(code, offset)?;
@@ -4034,13 +4240,26 @@ impl WastModuleValidator {
 
         // Check for multi-memory flag (bit 6 of alignment)
         // When set, the memory index follows the alignment
-        let mem_idx = if (align_with_flags & 0x40) != 0 {
+        let has_mem_idx_flag = (align_with_flags & 0x40) != 0;
+        let align = align_with_flags & 0x3F; // Lower 6 bits are the alignment
+
+        let mem_idx = if has_mem_idx_flag {
             let (idx, new_off) = Self::parse_varuint32(code, current_offset)?;
             current_offset = new_off;
             idx
         } else {
             0 // Default to memory 0
         };
+
+        // Validate memory index is in range
+        if mem_idx as usize >= Self::total_memories(module) {
+            return Err(anyhow!("unknown memory"));
+        }
+
+        // Validate alignment against natural alignment for this opcode
+        if opcode != 0xFF {
+            Self::validate_alignment(opcode, align)?;
+        }
 
         // Parse offset - for memory64, this is encoded as u64
         if Self::is_memory64(module, mem_idx) {

--- a/wrt-build-core/src/wast_values.rs
+++ b/wrt-build-core/src/wast_values.rs
@@ -268,7 +268,43 @@ pub fn values_equal(actual: &Value, expected: &Value) -> bool {
             let b_val = b.value();
             if a_val.is_nan() && b_val.is_nan() { true } else { a == b }
         },
-        (Value::V128(a), Value::V128(b)) => a == b,
+        (Value::V128(a), Value::V128(b)) => {
+            if a == b {
+                return true;
+            }
+            // V128 bytes don't match exactly -- check NaN-aware comparison.
+            // WAST tests use NanPattern for float lanes within V128.
+            // Try f64x2 interpretation: if both lanes match (exact or both-NaN), succeed.
+            let f64x2_match = (0..2).all(|i| {
+                let off = i * 8;
+                let mut ab = [0u8; 8];
+                let mut bb = [0u8; 8];
+                ab.copy_from_slice(&a.bytes[off..off + 8]);
+                bb.copy_from_slice(&b.bytes[off..off + 8]);
+                if ab == bb {
+                    return true;
+                }
+                let fa = f64::from_le_bytes(ab);
+                let fb = f64::from_le_bytes(bb);
+                fa.is_nan() && fb.is_nan()
+            });
+            if f64x2_match {
+                return true;
+            }
+            // Try f32x4 interpretation
+            let f32x4_match = (0..4).all(|i| {
+                let off = i * 4;
+                let ab = [a.bytes[off], a.bytes[off+1], a.bytes[off+2], a.bytes[off+3]];
+                let bb = [b.bytes[off], b.bytes[off+1], b.bytes[off+2], b.bytes[off+3]];
+                if ab == bb {
+                    return true;
+                }
+                let fa = f32::from_le_bytes(ab);
+                let fb = f32::from_le_bytes(bb);
+                fa.is_nan() && fb.is_nan()
+            });
+            f32x4_match
+        },
         (Value::Ref(a), Value::Ref(b)) => a == b,
         // FuncRef comparison
         // Handle "any funcref" pattern (u32::MAX sentinel)

--- a/wrt-component/src/adapter.rs
+++ b/wrt-component/src/adapter.rs
@@ -357,6 +357,7 @@ impl CoreModuleAdapter {
                         max: mem_adapter.limits.max,
                     },
                     shared: mem_adapter.shared,
+                    memory64: false,
                 })?),
                 kind: ExportKind::Value {
                     value_index: mem_adapter.core_index,

--- a/wrt-component/src/adapter.rs
+++ b/wrt-component/src/adapter.rs
@@ -378,6 +378,7 @@ impl CoreModuleAdapter {
                         max: table_adapter.limits.max,
                     },
                     element_type: RefType::Funcref,
+                    table64: false,
                 },
                 table: wrt_runtime::table::Table::new(wrt_foundation::types::TableType {
                     limits: wrt_foundation::types::Limits {
@@ -385,6 +386,7 @@ impl CoreModuleAdapter {
                         max: table_adapter.limits.max,
                     },
                     element_type: RefType::Funcref,
+                    table64: false,
                 })?,
             };
 
@@ -396,6 +398,7 @@ impl CoreModuleAdapter {
                         max: table_adapter.limits.max,
                     },
                     element_type: RefType::Funcref,
+                    table64: false,
                 },
                 table: BoundedVec::new(),
             };

--- a/wrt-component/src/components/component.rs
+++ b/wrt-component/src/components/component.rs
@@ -638,8 +638,9 @@ impl MemoryValue {
     pub fn new(ty: MemoryType) -> Result<Self> {
         // Convert MemoryType to CoreMemoryType for Memory::new
         let core_ty = wrt_runtime::CoreMemoryType {
-            limits: ty.limits,
-            shared: ty.shared,
+            limits:   ty.limits,
+            shared:   ty.shared,
+            memory64: ty.memory64,
         };
         let memory = Memory::new(core_ty)?;
         Ok(Self {
@@ -665,8 +666,9 @@ impl MemoryValue {
     pub fn new_with_name(ty: MemoryType, name: &str) -> Result<Self> {
         // Convert MemoryType to CoreMemoryType for Memory::new_with_name
         let core_ty = wrt_runtime::CoreMemoryType {
-            limits: ty.limits,
-            shared: ty.shared,
+            limits:   ty.limits,
+            shared:   ty.shared,
+            memory64: ty.memory64,
         };
         let memory = Memory::new_with_name(core_ty, name)?;
         Ok(Self {

--- a/wrt-decoder/src/sections.rs
+++ b/wrt-decoder/src/sections.rs
@@ -615,6 +615,7 @@ pub mod parsers {
             wrt_foundation::TableType {
                 element_type: ref_type,
                 limits: foundation_limits,
+                table64: limits.memory64,
             },
             offset,
         ))

--- a/wrt-decoder/src/sections_no_std.rs
+++ b/wrt-decoder/src/sections_no_std.rs
@@ -445,6 +445,7 @@ pub mod parsers {
             let wrt_table_type = WrtTableType {
                 element_type: table_type.element_type,
                 limits: table_type.limits,
+                table64: table_type.table64,
             };
 
             tables

--- a/wrt-decoder/src/streaming_decoder.rs
+++ b/wrt-decoder/src/streaming_decoder.rs
@@ -829,6 +829,16 @@ impl<'a> StreamingDecoder<'a> {
                     } else {
                         None
                     };
+
+                    // Validate that min <= max per the WebAssembly specification
+                    if let Some(max_val) = max {
+                        if min > max_val {
+                            return Err(Error::validation_error(
+                                "size minimum must not be greater than maximum",
+                            ));
+                        }
+                    }
+
                     #[cfg(feature = "tracing")]
                     trace!(import_index = i, min = min, max = ?max, "import: table");
 
@@ -1180,6 +1190,15 @@ impl<'a> StreamingDecoder<'a> {
             } else {
                 None
             };
+
+            // Validate that min <= max per the WebAssembly specification
+            if let Some(max_val) = max {
+                if min > max_val {
+                    return Err(Error::validation_error(
+                        "size minimum must not be greater than maximum",
+                    ));
+                }
+            }
 
             // Parse and validate init expression if present (ends with 0x0B)
             if has_init_expr {

--- a/wrt-decoder/src/streaming_decoder.rs
+++ b/wrt-decoder/src/streaming_decoder.rs
@@ -946,6 +946,7 @@ impl<'a> StreamingDecoder<'a> {
                         let memory_type = MemoryType {
                             limits,
                             shared: flags & 0x02 != 0, // bit 1 = shared
+                            memory64: flags & 0x04 != 0, // bit 2 = memory64
                         };
 
                         let import = Import {
@@ -1380,6 +1381,7 @@ impl<'a> StreamingDecoder<'a> {
             let memory_type = wrt_foundation::types::MemoryType {
                 limits: wrt_foundation::types::Limits { min, max },
                 shared,
+                memory64: is_memory64,
             };
 
             // Add to module

--- a/wrt-decoder/src/streaming_decoder.rs
+++ b/wrt-decoder/src/streaming_decoder.rs
@@ -807,12 +807,9 @@ impl<'a> StreamingDecoder<'a> {
                 },
                 0x01 => {
                     // Table import - need to parse table type
-                    // ref_type (1 byte) + limits (flags + min, optional max)
-                    if offset >= data.len() {
-                        return Err(Error::parse_error("Unexpected end of table import"));
-                    }
-                    let ref_type_byte = data[offset];
-                    offset += 1;
+                    // ref_type (may be multi-byte for GC types) + limits (flags + min, optional max)
+                    let (ref_value_type, new_offset) = self.parse_value_type(data, offset)?;
+                    offset = new_offset;
 
                     // Parse limits
                     if offset >= data.len() {
@@ -848,12 +845,10 @@ impl<'a> StreamingDecoder<'a> {
                         use wrt_format::module::{Import, ImportDesc};
                         use wrt_foundation::types::{Limits, RefType, TableType};
 
-                        // Convert ref_type byte to RefType
-                        let ref_type = match ref_type_byte {
-                            0x70 => RefType::Funcref,
-                            0x6F => RefType::Externref,
-                            _ => RefType::Funcref, // Default for unknown
-                        };
+                        // Convert parsed ValueType to RefType
+                        let ref_type = RefType::try_from(ref_value_type).map_err(|_| {
+                            Error::parse_error("Unknown table element type in import")
+                        })?;
 
                         let limits = Limits { min, max };
 
@@ -978,12 +973,13 @@ impl<'a> StreamingDecoder<'a> {
                 },
                 0x03 => {
                     // Global import - need to parse global type
-                    // value_type (1 byte) + mutability (1 byte)
-                    if offset + 1 >= data.len() {
+                    // value_type (may be multi-byte for GC types) + mutability (1 byte)
+                    let (value_type, new_offset) = self.parse_value_type(data, offset)?;
+                    offset = new_offset;
+
+                    if offset >= data.len() {
                         return Err(Error::parse_error("Unexpected end of global import"));
                     }
-                    let value_type_byte = data[offset];
-                    offset += 1;
                     let mutability_byte = data[offset];
                     offset += 1;
 
@@ -991,19 +987,6 @@ impl<'a> StreamingDecoder<'a> {
                     if mutability_byte != 0x00 && mutability_byte != 0x01 {
                         return Err(Error::parse_error("malformed mutability"));
                     }
-
-                    // Parse value type
-                    let value_type = match value_type_byte {
-                        0x7F => wrt_foundation::ValueType::I32,
-                        0x7E => wrt_foundation::ValueType::I64,
-                        0x7D => wrt_foundation::ValueType::F32,
-                        0x7C => wrt_foundation::ValueType::F64,
-                        0x7B => wrt_foundation::ValueType::V128,
-                        0x70 => wrt_foundation::ValueType::FuncRef,
-                        0x6F => wrt_foundation::ValueType::ExternRef,
-                        0x69 => wrt_foundation::ValueType::ExnRef,
-                        _ => return Err(Error::parse_error("Invalid global import value type")),
-                    };
 
                     #[cfg(feature = "tracing")]
                     trace!(import_index = i, value_type = ?value_type, mutable = (mutability_byte != 0), "import: global");
@@ -1162,22 +1145,13 @@ impl<'a> StreamingDecoder<'a> {
                 offset += 1;
             }
 
-            // Now parse the ref_type
-            if offset >= data.len() {
-                return Err(Error::parse_error(
-                    "Unexpected end of table section (ref_type)",
-                ));
-            }
-            let ref_type_byte = data[offset];
-            offset += 1;
+            // Now parse the ref_type using the full GC-aware parser
+            let (value_type, new_offset) = self.parse_value_type(data, offset)?;
+            offset = new_offset;
 
-            let element_type = match ref_type_byte {
-                0x70 => RefType::Funcref,   // funcref
-                0x6F => RefType::Externref, // externref
-                _ => {
-                    return Err(Error::parse_error("Unknown table element type"));
-                },
-            };
+            let element_type = RefType::try_from(value_type).map_err(|_| {
+                Error::parse_error("Unknown table element type")
+            })?;
 
             // Parse limits (flags + min, optional max)
             if offset >= data.len() {
@@ -1742,13 +1716,11 @@ impl<'a> StreamingDecoder<'a> {
                 },
                 1 => {
                     // Passive, element type, expressions
-                    let elem_type = data[offset];
-                    offset += 1;
-                    let ref_type = match elem_type {
-                        0x70 => wrt_format::types::RefType::Funcref,
-                        0x6F => wrt_format::types::RefType::Externref,
-                        _ => wrt_format::types::RefType::Funcref,
-                    };
+                    let (vt, new_offset) = self.parse_value_type(data, offset)?;
+                    offset = new_offset;
+                    let ref_type = wrt_format::types::RefType::try_from(vt).map_err(|_| {
+                        Error::parse_error("Invalid element segment reference type")
+                    })?;
                     #[cfg(feature = "tracing")]
                     trace!(elem_idx = elem_idx, ref_type = ?ref_type, "element: passive");
                     (PureElementMode::Passive, Vec::new(), ref_type)
@@ -1789,13 +1761,11 @@ impl<'a> StreamingDecoder<'a> {
                 },
                 3 => {
                     // Declarative, element type, expressions
-                    let elem_type = data[offset];
-                    offset += 1;
-                    let ref_type = match elem_type {
-                        0x70 => wrt_format::types::RefType::Funcref,
-                        0x6F => wrt_format::types::RefType::Externref,
-                        _ => wrt_format::types::RefType::Funcref,
-                    };
+                    let (vt, new_offset) = self.parse_value_type(data, offset)?;
+                    offset = new_offset;
+                    let ref_type = wrt_format::types::RefType::try_from(vt).map_err(|_| {
+                        Error::parse_error("Invalid element segment reference type")
+                    })?;
                     #[cfg(feature = "tracing")]
                     trace!(elem_idx = elem_idx, ref_type = ?ref_type, "element: declarative");
                     (PureElementMode::Declared, Vec::new(), ref_type)
@@ -1825,13 +1795,11 @@ impl<'a> StreamingDecoder<'a> {
                 },
                 5 => {
                     // Passive, expressions with type
-                    let ref_type_byte = data[offset];
-                    offset += 1;
-                    let ref_type = match ref_type_byte {
-                        0x70 => wrt_format::types::RefType::Funcref,
-                        0x6F => wrt_format::types::RefType::Externref,
-                        _ => wrt_format::types::RefType::Funcref,
-                    };
+                    let (vt, new_offset) = self.parse_value_type(data, offset)?;
+                    offset = new_offset;
+                    let ref_type = wrt_format::types::RefType::try_from(vt).map_err(|_| {
+                        Error::parse_error("Invalid element segment reference type")
+                    })?;
                     #[cfg(feature = "tracing")]
                     trace!(elem_idx = elem_idx, ref_type = ?ref_type, "element: passive with type");
                     (PureElementMode::Passive, Vec::new(), ref_type)
@@ -1848,18 +1816,11 @@ impl<'a> StreamingDecoder<'a> {
                     let offset_expr_bytes: Vec<u8> = data[expr_start..offset].to_vec();
 
                     // Parse ref_type (comes after offset expression, before items)
-                    if offset >= data.len() {
-                        return Err(Error::parse_error(
-                            "Unexpected end of element segment (ref_type)",
-                        ));
-                    }
-                    let ref_type_byte = data[offset];
-                    offset += 1;
-                    let ref_type = match ref_type_byte {
-                        0x70 => wrt_format::types::RefType::Funcref,
-                        0x6F => wrt_format::types::RefType::Externref,
-                        _ => wrt_format::types::RefType::Funcref,
-                    };
+                    let (vt, new_offset) = self.parse_value_type(data, offset)?;
+                    offset = new_offset;
+                    let ref_type = wrt_format::types::RefType::try_from(vt).map_err(|_| {
+                        Error::parse_error("Invalid element segment reference type")
+                    })?;
 
                     #[cfg(feature = "tracing")]
                     trace!(elem_idx = elem_idx, table_index = table_index, offset_expr_len = offset_expr_bytes.len(), ref_type = ?ref_type, "element: active with expressions");
@@ -1875,13 +1836,11 @@ impl<'a> StreamingDecoder<'a> {
                 },
                 7 => {
                     // Declarative, expressions with type
-                    let ref_type_byte = data[offset];
-                    offset += 1;
-                    let ref_type = match ref_type_byte {
-                        0x70 => wrt_format::types::RefType::Funcref,
-                        0x6F => wrt_format::types::RefType::Externref,
-                        _ => wrt_format::types::RefType::Funcref,
-                    };
+                    let (vt, new_offset) = self.parse_value_type(data, offset)?;
+                    offset = new_offset;
+                    let ref_type = wrt_format::types::RefType::try_from(vt).map_err(|_| {
+                        Error::parse_error("Invalid element segment reference type")
+                    })?;
                     #[cfg(feature = "tracing")]
                     trace!(elem_idx = elem_idx, ref_type = ?ref_type, "element: declarative with type");
                     (PureElementMode::Declared, Vec::new(), ref_type)
@@ -2050,34 +2009,40 @@ impl<'a> StreamingDecoder<'a> {
 
             // Code section index i corresponds to module-defined function at index (num_imports + i)
             let func_index = num_imports + i as usize;
+
+            // Parse local variable declarations first (requires &self for parse_value_type)
+            // We collect locals into a temporary vec to avoid borrow conflicts with self.module
+            let mut parsed_locals: Vec<(u32, wrt_foundation::types::ValueType)> = Vec::new();
+            let mut total_locals_count: usize = 0;
+            for _ in 0..local_count {
+                let (count, bytes) = read_leb128_u32(&data[body_start..body_end], body_offset)?;
+                body_offset += bytes;
+
+                if body_offset >= body_size as usize {
+                    return Err(Error::parse_error("Unexpected end of function body"));
+                }
+
+                // Use the full GC-aware value type parser for local types
+                let (vt, new_abs_offset) =
+                    self.parse_value_type(data, body_start + body_offset)?;
+                body_offset = new_abs_offset - body_start;
+
+                // Validate total locals against platform limits before allocation
+                total_locals_count += count as usize;
+                if total_locals_count > limits::MAX_FUNCTION_LOCALS {
+                    return Err(Error::parse_error(
+                        "Function exceeds maximum local count for platform",
+                    ));
+                }
+
+                parsed_locals.push((count, vt));
+            }
+
+            // Now apply the parsed locals to the function (requires &mut self.module)
             if let Some(func) = self.module.functions.get_mut(func_index) {
-                // Parse local variable declarations
-                for _ in 0..local_count {
-                    let (count, bytes) = read_leb128_u32(&data[body_start..body_end], body_offset)?;
-                    body_offset += bytes;
-
-                    if body_offset >= body_size as usize {
-                        return Err(Error::parse_error("Unexpected end of function body"));
-                    }
-
-                    let value_type = data[body_start + body_offset];
-                    body_offset += 1;
-
-                    // Convert to ValueType and add to locals
-                    let vt = match value_type {
-                        0x7F => wrt_foundation::types::ValueType::I32,
-                        0x7E => wrt_foundation::types::ValueType::I64,
-                        0x7D => wrt_foundation::types::ValueType::F32,
-                        0x7C => wrt_foundation::types::ValueType::F64,
-                        0x7B => wrt_foundation::types::ValueType::V128,
-                        0x70 => wrt_foundation::types::ValueType::FuncRef,
-                        0x6F => wrt_foundation::types::ValueType::ExternRef,
-                        0x69 => wrt_foundation::types::ValueType::ExnRef,
-                        _ => return Err(Error::parse_error("Invalid local type")),
-                    };
-
-                    // Validate total locals against platform limits before allocation
-                    let new_total = func.locals.len() + count as usize;
+                for (count, vt) in &parsed_locals {
+                    // Validate total locals including existing ones
+                    let new_total = func.locals.len() + *count as usize;
                     if new_total > limits::MAX_FUNCTION_LOCALS {
                         return Err(Error::parse_error(
                             "Function exceeds maximum local count for platform",
@@ -2089,12 +2054,12 @@ impl<'a> StreamingDecoder<'a> {
                         AllocationPhase::Decode,
                         "streaming_decoder:func_locals",
                         "locals",
-                        count as usize
+                        *count as usize
                     );
 
                     // Add 'count' locals of this type
-                    for _ in 0..count {
-                        func.locals.push(vt);
+                    for _ in 0..*count {
+                        func.locals.push(*vt);
                     }
                 }
 

--- a/wrt-decoder/src/streaming_decoder.rs
+++ b/wrt-decoder/src/streaming_decoder.rs
@@ -900,20 +900,26 @@ impl<'a> StreamingDecoder<'a> {
                         };
 
                         // Validate memory64 limits
-                        if min64 > MAX_MEMORY_PAGES as u64 {
+                        // memory64 supports up to 2^48 pages (each 64KB = 2^16 bytes, total 2^64 bytes)
+                        const MAX_MEMORY64_PAGES: u64 = 1u64 << 48;
+                        if min64 > MAX_MEMORY64_PAGES {
                             return Err(Error::validation_error(
-                                "memory size must be at most 65536 pages (4 GiB)",
+                                "memory size must be at most 2^48 pages (16 EiB)",
                             ));
                         }
                         if let Some(max64) = max64 {
-                            if max64 > MAX_MEMORY_PAGES as u64 {
+                            if max64 > MAX_MEMORY64_PAGES {
                                 return Err(Error::validation_error(
-                                    "memory size must be at most 65536 pages (4 GiB)",
+                                    "memory size must be at most 2^48 pages (16 EiB)",
                                 ));
                             }
                         }
 
-                        (min64 as u32, max64.map(|v| v as u32))
+                        // Truncate to u32 for now (our runtime doesn't support >4GB anyway)
+                        // but accept the module as valid
+                        let min_clamped = if min64 > u32::MAX as u64 { u32::MAX } else { min64 as u32 };
+                        let max_clamped = max64.map(|v| if v > u32::MAX as u64 { u32::MAX } else { v as u32 });
+                        (min_clamped, max_clamped)
                     } else {
                         let (min, bytes_read) = read_leb128_u32(data, offset)?;
                         offset += bytes_read;
@@ -1346,22 +1352,27 @@ impl<'a> StreamingDecoder<'a> {
                     None
                 };
 
-                // Validate memory64 limits (still have a limit, though higher)
-                // For non-memory64 tests, values > 65536 pages should fail
-                if min64 > MAX_MEMORY_PAGES as u64 {
+                // Validate memory64 limits
+                // memory64 supports up to 2^48 pages (each 64KB = 2^16 bytes, total 2^64 bytes)
+                const MAX_MEMORY64_PAGES: u64 = 1u64 << 48;
+                if min64 > MAX_MEMORY64_PAGES {
                     return Err(Error::validation_error(
-                        "memory size must be at most 65536 pages (4 GiB)",
+                        "memory size must be at most 2^48 pages (16 EiB)",
                     ));
                 }
                 if let Some(max64) = max64 {
-                    if max64 > MAX_MEMORY_PAGES as u64 {
+                    if max64 > MAX_MEMORY64_PAGES {
                         return Err(Error::validation_error(
-                            "memory size must be at most 65536 pages (4 GiB)",
+                            "memory size must be at most 2^48 pages (16 EiB)",
                         ));
                     }
                 }
 
-                (min64 as u32, max64.map(|v| v as u32))
+                // Truncate to u32 for now (our runtime doesn't support >4GB anyway)
+                // but accept the module as valid
+                let min_clamped = if min64 > u32::MAX as u64 { u32::MAX } else { min64 as u32 };
+                let max_clamped = max64.map(|v| if v > u32::MAX as u64 { u32::MAX } else { v as u32 });
+                (min_clamped, max_clamped)
             } else {
                 let (min, bytes_read) = read_leb128_u32(data, offset)?;
                 offset += bytes_read;
@@ -1383,16 +1394,20 @@ impl<'a> StreamingDecoder<'a> {
                 return Err(Error::validation_error("shared memory must have maximum"));
             }
 
-            if min > MAX_MEMORY_PAGES {
-                return Err(Error::validation_error(
-                    "memory size must be at most 65536 pages (4 GiB)",
-                ));
-            }
-            if let Some(max_val) = max {
-                if max_val > MAX_MEMORY_PAGES {
+            // Only validate against 65536 limit for non-memory64 memories
+            // memory64 limits were already validated above
+            if !is_memory64 {
+                if min > MAX_MEMORY_PAGES {
                     return Err(Error::validation_error(
                         "memory size must be at most 65536 pages (4 GiB)",
                     ));
+                }
+                if let Some(max_val) = max {
+                    if max_val > MAX_MEMORY_PAGES {
+                        return Err(Error::validation_error(
+                            "memory size must be at most 65536 pages (4 GiB)",
+                        ));
+                    }
                 }
             }
 

--- a/wrt-decoder/src/streaming_decoder.rs
+++ b/wrt-decoder/src/streaming_decoder.rs
@@ -855,6 +855,7 @@ impl<'a> StreamingDecoder<'a> {
                         let table_type = TableType {
                             element_type: ref_type,
                             limits,
+                            table64: flags & 0x04 != 0,
                         };
 
                         let import = Import {
@@ -1263,7 +1264,7 @@ impl<'a> StreamingDecoder<'a> {
             trace!(table_index = i, element_type = ?element_type, min = min, max = ?max, "table parsed");
 
             // Create table type and add to module
-            let table_type = TableType::new(element_type, Limits { min, max });
+            let table_type = TableType::new_with_table64(element_type, Limits { min, max }, flags & 0x04 != 0);
             self.module.tables.push(table_type);
 
             #[cfg(feature = "tracing")]
@@ -1288,12 +1289,8 @@ impl<'a> StreamingDecoder<'a> {
         #[cfg(feature = "tracing")]
         trace!(count = count, "process_memory_section");
 
-        // WebAssembly core spec: only one memory is allowed without the multi-memory proposal
-        // Total memories = imported memories + defined memories
-        let total_memories = self.num_memory_imports + count as usize;
-        if total_memories > 1 {
-            return Err(Error::validation_error("multiple memories"));
-        }
+        // Multi-memory proposal is now part of the WebAssembly spec.
+        // Multiple memories are allowed.
 
         // Process each memory one at a time
         for i in 0..count {

--- a/wrt-format/src/binary.rs
+++ b/wrt-format/src/binary.rs
@@ -2301,11 +2301,9 @@ pub mod with_alloc {
                 })?;
                 offset += 1;
                 let value_type = ValueType::from_binary(rt_byte)?;
-                element_type = match value_type {
-                    ValueType::FuncRef => RefType::Funcref,
-                    ValueType::ExternRef => RefType::Externref,
-                    _ => return Err(parse_error("Invalid ref type for element")),
-                };
+                element_type = RefType::try_from(value_type).map_err(|_| {
+                    parse_error("Invalid ref type for element")
+                })?;
 
                 let (exprs_vec, next_offset) = read_vector(bytes, offset, parse_init_expr)
                     .map_err(|e| {
@@ -2354,11 +2352,9 @@ pub mod with_alloc {
                 })?;
                 offset += 1;
                 let value_type = ValueType::from_binary(rt_byte)?;
-                element_type = match value_type {
-                    ValueType::FuncRef => RefType::Funcref,
-                    ValueType::ExternRef => RefType::Externref,
-                    _ => return Err(parse_error("Invalid ref type for element")),
-                };
+                element_type = RefType::try_from(value_type).map_err(|_| {
+                    parse_error("Invalid ref type for element")
+                })?;
 
                 let (exprs_vec, next_offset) = read_vector(bytes, offset, parse_init_expr)
                     .map_err(|e| {
@@ -2395,11 +2391,9 @@ pub mod with_alloc {
                 })?;
                 offset += 1;
                 let value_type = ValueType::from_binary(rt_byte)?;
-                element_type = match value_type {
-                    ValueType::FuncRef => RefType::Funcref,
-                    ValueType::ExternRef => RefType::Externref,
-                    _ => return Err(parse_error("Invalid ref type for element")),
-                };
+                element_type = RefType::try_from(value_type).map_err(|_| {
+                    parse_error("Invalid ref type for element")
+                })?;
 
                 let (exprs_vec, next_offset) = read_vector(bytes, offset, parse_init_expr)
                     .map_err(|e| {

--- a/wrt-format/src/pure_format_types.rs
+++ b/wrt-format/src/pure_format_types.rs
@@ -568,6 +568,7 @@ impl wrt_foundation::traits::ToBytes for PureElementSegment {
         let element_type_byte = match self.element_type {
             crate::types::RefType::Funcref => 0u8,
             crate::types::RefType::Externref => 1u8,
+            crate::types::RefType::Gc(_) => 1u8, // GC ref types serialize as externref for binary format
         };
         writer.write_all(&[element_type_byte])?;
         self.mode.to_bytes_with_provider(writer, provider)?;

--- a/wrt-foundation/src/clean_core_types.rs
+++ b/wrt-foundation/src/clean_core_types.rs
@@ -31,9 +31,11 @@ mod types {
     #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
     pub struct CoreMemoryType {
         /// Memory limits
-        pub limits: crate::types::Limits,
+        pub limits:   crate::types::Limits,
         /// Whether the memory is shared
-        pub shared: bool,
+        pub shared:   bool,
+        /// Memory64 extension - uses i64 addresses instead of i32
+        pub memory64: bool,
     }
 
     /// Clean core WebAssembly table type without provider parameters

--- a/wrt-foundation/src/clean_core_types.rs
+++ b/wrt-foundation/src/clean_core_types.rs
@@ -45,6 +45,8 @@ mod types {
         pub element_type: crate::types::RefType,
         /// Table size limits
         pub limits:       crate::types::Limits,
+        /// Table64 extension - uses i64 indices instead of i32
+        pub table64:      bool,
     }
 
     /// Clean core WebAssembly global type without provider parameters

--- a/wrt-foundation/src/clean_types.rs
+++ b/wrt-foundation/src/clean_types.rs
@@ -377,6 +377,8 @@ mod types {
         pub element_type: RefType,
         /// Table limits
         pub limits:       Limits,
+        /// Table64 extension - uses i64 indices instead of i32
+        pub table64:      bool,
     }
 
     impl Default for TableType {
@@ -384,6 +386,7 @@ mod types {
             Self {
                 element_type: RefType::FuncRef,
                 limits:       Limits::default(),
+                table64:      false,
             }
         }
     }

--- a/wrt-foundation/src/conversion.rs
+++ b/wrt-foundation/src/conversion.rs
@@ -43,6 +43,7 @@ pub fn ref_type_to_val_type(ref_type: RefType) -> CoreValueType {
     match ref_type {
         RefType::Funcref => CoreValueType::FuncRef,
         RefType::Externref => CoreValueType::ExternRef,
+        RefType::Gc(gc) => gc.to_value_type(),
     }
 }
 

--- a/wrt-foundation/src/types.rs
+++ b/wrt-foundation/src/types.rs
@@ -1227,12 +1227,15 @@ impl FromBytes for FuncType {
 // Display and Debug impls follow...
 
 /// Memory argument for load/store instructions
+///
+/// The offset field is u64 to support the memory64 proposal where
+/// memory offsets can be 64-bit values.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct MemArg {
     /// The alignment exponent (2^align_exponent bytes)
     pub align_exponent: u32,
-    /// The offset to add to the address
-    pub offset:         u32,
+    /// The offset to add to the address (u64 for memory64 support)
+    pub offset:         u64,
     /// The memory index (0 for single memory)
     pub memory_index:   u32,
 }
@@ -1254,7 +1257,7 @@ impl ToBytes for MemArg {
         _provider: &PStream,
     ) -> wrt_error::Result<()> {
         writer.write_u32_le(self.align_exponent)?;
-        writer.write_u32_le(self.offset)?;
+        writer.write_u64_le(self.offset)?;
         writer.write_u32_le(self.memory_index)
     }
 
@@ -1271,7 +1274,7 @@ impl FromBytes for MemArg {
         _provider: &PStream,
     ) -> wrt_error::Result<Self> {
         let align_exponent = reader.read_u32_le()?;
-        let offset = reader.read_u32_le()?;
+        let offset = reader.read_u64_le()?;
         let memory_index = reader.read_u32_le()?;
         Ok(Self {
             align_exponent,
@@ -1405,6 +1408,12 @@ pub enum Instruction<P: MemoryProvider + Clone + core::fmt::Debug + PartialEq + 
     // Tail call instructions (0x12 and 0x13 opcodes)
     ReturnCall(FuncIdx),
     ReturnCallIndirect(TypeIdx, TableIdx),
+
+    // Typed function references (0x14 and 0x15 opcodes)
+    /// call_ref: call function from typed reference on stack (opcode 0x14)
+    CallRef(TypeIdx),
+    /// return_call_ref: tail call function from typed reference on stack (opcode 0x15)
+    ReturnCallRef(TypeIdx),
 
     // Exception handling instructions (exception handling proposal)
     /// Throw exception with specified tag (opcode 0x08)
@@ -1965,6 +1974,49 @@ pub enum Instruction<P: MemoryProvider + Clone + core::fmt::Debug + PartialEq + 
     /// i31.get_u: extract i32 with zero extension (0xFB 0x1E)
     I31GetU,
 
+    // =========================================================================
+    // SIMD Instructions (0xFD prefix) - WebAssembly SIMD Proposal
+    // =========================================================================
+
+    /// v128.const: 128-bit constant (0xFD 0x0C)
+    V128Const {
+        /// 16 bytes of constant data
+        bytes: [u8; 16],
+    },
+    /// SIMD operation with no immediates (arithmetic, comparison, bitwise, etc.)
+    SimdOp {
+        /// The sub-opcode after the 0xFD prefix
+        opcode: u32,
+    },
+    /// SIMD memory operation with memarg (load/store variants)
+    SimdMemOp {
+        /// The sub-opcode after the 0xFD prefix
+        opcode: u32,
+        /// Memory argument (alignment and offset)
+        memarg: MemArg,
+    },
+    /// i8x16.shuffle with 16 lane indices (0xFD 0x0D)
+    SimdShuffle {
+        /// 16 lane index bytes
+        lanes: [u8; 16],
+    },
+    /// SIMD lane operation with lane index (extract/replace lane)
+    SimdLaneOp {
+        /// The sub-opcode after the 0xFD prefix
+        opcode: u32,
+        /// Lane index byte
+        lane:   u8,
+    },
+    /// SIMD memory lane operation with memarg and lane index (load_lane/store_lane)
+    SimdMemLaneOp {
+        /// The sub-opcode after the 0xFD prefix
+        opcode: u32,
+        /// Memory argument (alignment and offset)
+        memarg: MemArg,
+        /// Lane index byte
+        lane:   u8,
+    },
+
     #[doc(hidden)]
     _Phantom(core::marker::PhantomData<P>),
 }
@@ -2037,6 +2089,14 @@ impl<P: MemoryProvider + Default + Clone + core::fmt::Debug + PartialEq + Eq + D
                 type_idx.update_checksum(checksum);
                 table_idx.update_checksum(checksum);
             },
+            Instruction::CallRef(type_idx) => {
+                checksum.update_slice(&[0x14]); // call_ref opcode
+                type_idx.update_checksum(checksum);
+            },
+            Instruction::ReturnCallRef(type_idx) => {
+                checksum.update_slice(&[0x15]); // return_call_ref opcode
+                type_idx.update_checksum(checksum);
+            },
             Instruction::BrOnNull(label_idx) => {
                 checksum.update_slice(&[0xD5]); // br_on_null opcode
                 label_idx.update_checksum(checksum);
@@ -2049,10 +2109,10 @@ impl<P: MemoryProvider + Default + Clone + core::fmt::Debug + PartialEq + Eq + D
                 checksum.update_slice(&[0xD1]); // ref.is_null opcode
             },
             Instruction::RefAsNonNull => {
-                checksum.update_slice(&[0xD3]); // ref.as_non_null opcode
+                checksum.update_slice(&[0xD4]); // ref.as_non_null opcode
             },
             Instruction::RefEq => {
-                checksum.update_slice(&[0xD2]); // ref.eq opcode
+                checksum.update_slice(&[0xD3]); // ref.eq opcode
             },
             Instruction::LocalGet(idx)
             | Instruction::LocalSet(idx)
@@ -2435,6 +2495,36 @@ impl<P: MemoryProvider + Default + Clone + core::fmt::Debug + PartialEq + Eq + D
                 checksum.update_slice(&[0xFE, 0x03]);
             },
 
+            // SIMD instructions (0xFD prefix)
+            Instruction::V128Const { bytes } => {
+                checksum.update_slice(&[0xFD, 0x0C]);
+                checksum.update_slice(bytes);
+            },
+            Instruction::SimdOp { opcode } => {
+                checksum.update_slice(&[0xFD]);
+                opcode.update_checksum(checksum);
+            },
+            Instruction::SimdMemOp { opcode, memarg } => {
+                checksum.update_slice(&[0xFD]);
+                opcode.update_checksum(checksum);
+                memarg.update_checksum(checksum);
+            },
+            Instruction::SimdShuffle { lanes } => {
+                checksum.update_slice(&[0xFD, 0x0D]);
+                checksum.update_slice(lanes);
+            },
+            Instruction::SimdLaneOp { opcode, lane } => {
+                checksum.update_slice(&[0xFD]);
+                opcode.update_checksum(checksum);
+                lane.update_checksum(checksum);
+            },
+            Instruction::SimdMemLaneOp { opcode, memarg, lane } => {
+                checksum.update_slice(&[0xFD]);
+                opcode.update_checksum(checksum);
+                memarg.update_checksum(checksum);
+                lane.update_checksum(checksum);
+            },
+
             // All other instructions - use a placeholder checksum for now
             _ => {
                 // For now, just use a simple placeholder
@@ -2508,6 +2598,14 @@ impl<PInstr: MemoryProvider + Default + Clone + core::fmt::Debug + PartialEq + E
                 writer.write_u32_le(*type_idx)?;
                 writer.write_u32_le(*table_idx)?;
             },
+            Instruction::CallRef(type_idx) => {
+                writer.write_u8(0x14)?; // call_ref opcode
+                writer.write_u32_le(*type_idx)?;
+            },
+            Instruction::ReturnCallRef(type_idx) => {
+                writer.write_u8(0x15)?; // return_call_ref opcode
+                writer.write_u32_le(*type_idx)?;
+            },
             Instruction::BrOnNull(label_idx) => {
                 writer.write_u8(0xD5)?; // br_on_null opcode
                 writer.write_u32_le(*label_idx)?;
@@ -2517,8 +2615,8 @@ impl<PInstr: MemoryProvider + Default + Clone + core::fmt::Debug + PartialEq + E
                 writer.write_u32_le(*label_idx)?;
             },
             Instruction::RefIsNull => writer.write_u8(0xD1)?, // ref.is_null opcode
-            Instruction::RefAsNonNull => writer.write_u8(0xD3)?, // ref.as_non_null opcode
-            Instruction::RefEq => writer.write_u8(0xD2)?,     // ref.eq opcode
+            Instruction::RefAsNonNull => writer.write_u8(0xD4)?, // ref.as_non_null opcode
+            Instruction::RefEq => writer.write_u8(0xD3)?,     // ref.eq opcode
             Instruction::LocalGet(idx) => {
                 writer.write_u8(0x20)?;
                 writer.write_u32_le(*idx)?;
@@ -2896,6 +2994,42 @@ impl<PInstr: MemoryProvider + Default + Clone + core::fmt::Debug + PartialEq + E
             Instruction::AtomicFence => {
                 writer.write_u8(0xFE)?;
                 writer.write_u8(0x03)?;
+            },
+
+            // SIMD instructions (0xFD prefix)
+            Instruction::V128Const { bytes } => {
+                writer.write_u8(0xFD)?;
+                writer.write_u8(0x0C)?;
+                for &b in bytes {
+                    writer.write_u8(b)?;
+                }
+            },
+            Instruction::SimdOp { opcode } => {
+                writer.write_u8(0xFD)?;
+                writer.write_u32_le(*opcode)?;
+            },
+            Instruction::SimdMemOp { opcode, memarg } => {
+                writer.write_u8(0xFD)?;
+                writer.write_u32_le(*opcode)?;
+                memarg.to_bytes_with_provider(writer, stream_provider)?;
+            },
+            Instruction::SimdShuffle { lanes } => {
+                writer.write_u8(0xFD)?;
+                writer.write_u8(0x0D)?;
+                for &b in lanes {
+                    writer.write_u8(b)?;
+                }
+            },
+            Instruction::SimdLaneOp { opcode, lane } => {
+                writer.write_u8(0xFD)?;
+                writer.write_u32_le(*opcode)?;
+                writer.write_u8(*lane)?;
+            },
+            Instruction::SimdMemLaneOp { opcode, memarg, lane } => {
+                writer.write_u8(0xFD)?;
+                writer.write_u32_le(*opcode)?;
+                memarg.to_bytes_with_provider(writer, stream_provider)?;
+                writer.write_u8(*lane)?;
             },
 
             // ... many more instructions

--- a/wrt-foundation/src/types.rs
+++ b/wrt-foundation/src/types.rs
@@ -3953,6 +3953,8 @@ pub struct TableType {
     /// The size limits of the table, specifying initial and optional maximum
     /// size.
     pub limits:       Limits,
+    /// Table64 extension - uses i64 indices instead of i32
+    pub table64:      bool,
 }
 
 // Generic constructor, still valid as it doesn't depend on P.
@@ -3964,6 +3966,16 @@ impl TableType {
         Self {
             element_type,
             limits,
+            table64: false,
+        }
+    }
+
+    /// Creates a new `TableType` with all options including table64.
+    pub const fn new_with_table64(element_type: RefType, limits: Limits, table64: bool) -> Self {
+        Self {
+            element_type,
+            limits,
+            table64,
         }
     }
 }
@@ -3973,6 +3985,7 @@ impl Checksummable for TableType {
     fn update_checksum(&self, checksum: &mut Checksum) {
         self.element_type.update_checksum(checksum);
         self.limits.update_checksum(checksum);
+        self.table64.update_checksum(checksum);
     }
 }
 
@@ -3984,6 +3997,7 @@ impl ToBytes for TableType {
     ) -> wrt_error::Result<()> {
         self.element_type.to_bytes_with_provider(writer, provider)?;
         self.limits.to_bytes_with_provider(writer, provider)?;
+        self.table64.to_bytes_with_provider(writer, provider)?;
         Ok(())
     }
     // Default to_bytes method will be used if #cfg(feature = "default-provider") is
@@ -3997,9 +4011,11 @@ impl FromBytes for TableType {
     ) -> wrt_error::Result<Self> {
         let element_type = RefType::from_bytes_with_provider(reader, provider)?;
         let limits = Limits::from_bytes_with_provider(reader, provider)?;
+        let table64 = bool::from_bytes_with_provider(reader, provider)?;
         Ok(TableType {
             element_type,
             limits,
+            table64,
         })
     }
     // Default from_bytes method will be used if #cfg(feature = "default-provider")

--- a/wrt-foundation/src/types.rs
+++ b/wrt-foundation/src/types.rs
@@ -547,6 +547,12 @@ pub enum RefType {
     Funcref,
     /// External reference type
     Externref,
+    /// GC reference type with full heap type and nullability support.
+    /// This variant enables tables, element segments, and locals to use
+    /// any reference type from the GC proposal (anyref, eqref, i31ref,
+    /// structref, arrayref, nullref, nullfuncref, nullexternref, or
+    /// typed references like (ref null $type_idx)).
+    Gc(GcRefType),
 }
 
 impl RefType {
@@ -555,6 +561,7 @@ impl RefType {
         match self {
             RefType::Funcref => ValueType::FuncRef,
             RefType::Externref => ValueType::ExternRef,
+            RefType::Gc(gc) => gc.to_value_type(),
         }
     }
 
@@ -562,6 +569,13 @@ impl RefType {
         match vt {
             ValueType::FuncRef => Ok(RefType::Funcref),
             ValueType::ExternRef => Ok(RefType::Externref),
+            ValueType::AnyRef => Ok(RefType::Gc(GcRefType::ANYREF)),
+            ValueType::EqRef => Ok(RefType::Gc(GcRefType::EQREF)),
+            ValueType::I31Ref => Ok(RefType::Gc(GcRefType::I31REF)),
+            ValueType::StructRef(idx) => Ok(RefType::Gc(GcRefType::new(true, HeapType::Concrete(idx)))),
+            ValueType::ArrayRef(idx) => Ok(RefType::Gc(GcRefType::new(true, HeapType::Concrete(idx)))),
+            ValueType::NullFuncRef => Ok(RefType::Gc(GcRefType::NULLFUNCREF)),
+            ValueType::ExnRef => Ok(RefType::Gc(GcRefType::EXNREF)),
             _ => Err(Error::runtime_execution_error(
                 "Invalid ValueType for RefType conversion",
             )),
@@ -612,6 +626,7 @@ impl From<RefType> for ValueType {
         match rt {
             RefType::Funcref => ValueType::FuncRef,
             RefType::Externref => ValueType::ExternRef,
+            RefType::Gc(gc) => gc.to_value_type(),
         }
     }
 }
@@ -624,6 +639,14 @@ impl TryFrom<ValueType> for RefType {
         match vt {
             ValueType::FuncRef => Ok(RefType::Funcref),
             ValueType::ExternRef => Ok(RefType::Externref),
+            ValueType::AnyRef => Ok(RefType::Gc(GcRefType::ANYREF)),
+            ValueType::EqRef => Ok(RefType::Gc(GcRefType::EQREF)),
+            ValueType::I31Ref => Ok(RefType::Gc(GcRefType::I31REF)),
+            ValueType::StructRef(idx) => Ok(RefType::Gc(GcRefType::new(true, HeapType::Concrete(idx)))),
+            ValueType::ArrayRef(idx) => Ok(RefType::Gc(GcRefType::new(true, HeapType::Concrete(idx)))),
+            ValueType::NullFuncRef => Ok(RefType::Gc(GcRefType::NULLFUNCREF)),
+            ValueType::ExnRef => Ok(RefType::Gc(GcRefType::EXNREF)),
+            ValueType::TypedFuncRef(idx, nullable) => Ok(RefType::Gc(GcRefType::new(nullable, HeapType::Concrete(idx)))),
             _ => Err(Error::runtime_execution_error(
                 "Invalid ValueType for RefType try_from conversion",
             )),
@@ -791,6 +814,7 @@ impl GcRefType {
         match rt {
             RefType::Funcref => Self::FUNCREF,
             RefType::Externref => Self::EXTERNREF,
+            RefType::Gc(gc) => gc,
         }
     }
 
@@ -804,6 +828,37 @@ impl GcRefType {
             }
         } else {
             None // MVP RefType is always nullable
+        }
+    }
+
+    /// Convert GC reference type to ValueType
+    #[must_use]
+    pub fn to_value_type(self) -> ValueType {
+        match self.heap_type {
+            HeapType::Func => {
+                if self.nullable {
+                    ValueType::FuncRef
+                } else {
+                    ValueType::TypedFuncRef(0, false) // non-nullable func
+                }
+            }
+            HeapType::Extern => ValueType::ExternRef,
+            HeapType::Any => ValueType::AnyRef,
+            HeapType::Eq => ValueType::EqRef,
+            HeapType::I31 => ValueType::I31Ref,
+            HeapType::Struct => ValueType::StructRef(0),
+            HeapType::Array => ValueType::ArrayRef(0),
+            HeapType::Exn => ValueType::ExnRef,
+            HeapType::NoFunc => ValueType::NullFuncRef,
+            HeapType::NoExtern => ValueType::ExternRef, // closest approximation
+            HeapType::None => ValueType::AnyRef, // closest approximation for nullref
+            HeapType::Concrete(idx) => {
+                if self.nullable {
+                    ValueType::TypedFuncRef(idx, true)
+                } else {
+                    ValueType::TypedFuncRef(idx, false)
+                }
+            }
         }
     }
 

--- a/wrt-instructions/src/const_expr.rs
+++ b/wrt-instructions/src/const_expr.rs
@@ -216,6 +216,7 @@ impl ConstExprSequence {
                     let value = match ref_type {
                         RefType::Funcref => Value::FuncRef(None),
                         RefType::Externref => Value::ExternRef(None),
+                        RefType::Gc(_) => Value::FuncRef(None), // GC null ref
                     };
 
                     #[cfg(feature = "std")]
@@ -396,10 +397,7 @@ impl Validate for ConstExpr {
                 Ok(())
             },
             ConstExpr::RefNull(ref_type) => {
-                let val_type = match ref_type {
-                    RefType::Funcref => ValueType::FuncRef,
-                    RefType::Externref => ValueType::ExternRef,
-                };
+                let val_type = ref_type.to_value_type();
                 ctx.push_type(val_type)?;
                 Ok(())
             },

--- a/wrt-instructions/src/reference_ops.rs
+++ b/wrt-instructions/src/reference_ops.rs
@@ -60,6 +60,12 @@ impl RefNull {
         match self.ref_type {
             RefType::Funcref => Ok(Value::FuncRef(None)),
             RefType::Externref => Ok(Value::ExternRef(None)),
+            RefType::Gc(_) => {
+                // GC reference types: null reference for any GC type
+                // For now, represent as a null funcref since GC value representation
+                // is not yet fully implemented in the runtime
+                Ok(Value::FuncRef(None))
+            }
         }
     }
 }
@@ -531,10 +537,7 @@ mod tests {
 
 impl Validate for RefNull {
     fn validate(&self, ctx: &mut ValidationContext) -> Result<()> {
-        let ref_type = match self.ref_type {
-            RefType::Funcref => ValueType::FuncRef,
-            RefType::Externref => ValueType::ExternRef,
-        };
+        let ref_type = self.ref_type.to_value_type();
         validate_ref_op("ref.null", Some(ref_type), ctx)
     }
 }

--- a/wrt-runtime/src/atomic_runtime.rs
+++ b/wrt-runtime/src/atomic_runtime.rs
@@ -307,7 +307,7 @@ pub fn atomic_i32_load(
     addr: u32,
 ) -> Result<i32> {
     let memarg = wrt_foundation::MemArg {
-        offset: addr,
+        offset: addr as u64,
         align_exponent: 2,
         memory_index: 0,
     }; // 2^2 = 4-byte alignment
@@ -331,7 +331,7 @@ pub fn atomic_i32_store(
     value: i32,
 ) -> Result<()> {
     let memarg = wrt_foundation::MemArg {
-        offset: addr,
+        offset: addr as u64,
         align_exponent: 2,
         memory_index: 0,
     }; // 2^2 = 4-byte alignment
@@ -353,7 +353,7 @@ pub fn atomic_i32_compare_and_swap(
     replacement: i32,
 ) -> Result<i32> {
     let memarg = wrt_foundation::MemArg {
-        offset: addr,
+        offset: addr as u64,
         align_exponent: 2,
         memory_index: 0,
     }; // 2^2 = 4-byte alignment
@@ -385,7 +385,7 @@ pub fn atomic_i32_fetch_add(
     value: i32,
 ) -> Result<i32> {
     let memarg = wrt_foundation::MemArg {
-        offset: addr,
+        offset: addr as u64,
         align_exponent: 2,
         memory_index: 0,
     }; // 2^2 = 4-byte alignment

--- a/wrt-runtime/src/instruction_parser.rs
+++ b/wrt-runtime/src/instruction_parser.rs
@@ -289,6 +289,18 @@ fn parse_instruction_with_provider(
             consumed += table_bytes;
             Instruction::ReturnCallIndirect(type_idx, table_idx)
         },
+        0x14 => {
+            // CallRef (typed function references): type_idx (LEB128 u32)
+            let (type_idx, bytes) = read_leb128_u32(bytecode, offset + 1)?;
+            consumed += bytes;
+            Instruction::CallRef(type_idx)
+        },
+        0x15 => {
+            // ReturnCallRef (typed function references): type_idx (LEB128 u32)
+            let (type_idx, bytes) = read_leb128_u32(bytecode, offset + 1)?;
+            consumed += bytes;
+            Instruction::ReturnCallRef(type_idx)
+        },
 
         // Exception handling instructions (continued)
         0x18 => {
@@ -431,7 +443,7 @@ fn parse_instruction_with_provider(
         // Memory instructions
         0x28 => {
             let (align, bytes1) = read_leb128_u32(bytecode, offset + 1)?;
-            let (offset, bytes2) = read_leb128_u32(bytecode, offset + 1 + bytes1)?;
+            let (offset, bytes2) = read_leb128_u64(bytecode, offset + 1 + bytes1)?;
             consumed += bytes1 + bytes2;
             Instruction::I32Load(MemArg {
                 align_exponent: align,
@@ -441,7 +453,7 @@ fn parse_instruction_with_provider(
         },
         0x29 => {
             let (align, bytes1) = read_leb128_u32(bytecode, offset + 1)?;
-            let (offset, bytes2) = read_leb128_u32(bytecode, offset + 1 + bytes1)?;
+            let (offset, bytes2) = read_leb128_u64(bytecode, offset + 1 + bytes1)?;
             consumed += bytes1 + bytes2;
             Instruction::I64Load(MemArg {
                 align_exponent: align,
@@ -451,7 +463,7 @@ fn parse_instruction_with_provider(
         },
         0x2A => {
             let (align, bytes1) = read_leb128_u32(bytecode, offset + 1)?;
-            let (offset, bytes2) = read_leb128_u32(bytecode, offset + 1 + bytes1)?;
+            let (offset, bytes2) = read_leb128_u64(bytecode, offset + 1 + bytes1)?;
             consumed += bytes1 + bytes2;
             Instruction::F32Load(MemArg {
                 align_exponent: align,
@@ -461,7 +473,7 @@ fn parse_instruction_with_provider(
         },
         0x2B => {
             let (align, bytes1) = read_leb128_u32(bytecode, offset + 1)?;
-            let (offset, bytes2) = read_leb128_u32(bytecode, offset + 1 + bytes1)?;
+            let (offset, bytes2) = read_leb128_u64(bytecode, offset + 1 + bytes1)?;
             consumed += bytes1 + bytes2;
             Instruction::F64Load(MemArg {
                 align_exponent: align,
@@ -471,7 +483,7 @@ fn parse_instruction_with_provider(
         },
         0x2C => {
             let (align, bytes1) = read_leb128_u32(bytecode, offset + 1)?;
-            let (offset, bytes2) = read_leb128_u32(bytecode, offset + 1 + bytes1)?;
+            let (offset, bytes2) = read_leb128_u64(bytecode, offset + 1 + bytes1)?;
             consumed += bytes1 + bytes2;
             Instruction::I32Load8S(MemArg {
                 align_exponent: align,
@@ -481,7 +493,7 @@ fn parse_instruction_with_provider(
         },
         0x2D => {
             let (align, bytes1) = read_leb128_u32(bytecode, offset + 1)?;
-            let (offset, bytes2) = read_leb128_u32(bytecode, offset + 1 + bytes1)?;
+            let (offset, bytes2) = read_leb128_u64(bytecode, offset + 1 + bytes1)?;
             consumed += bytes1 + bytes2;
             Instruction::I32Load8U(MemArg {
                 align_exponent: align,
@@ -491,7 +503,7 @@ fn parse_instruction_with_provider(
         },
         0x2E => {
             let (align, bytes1) = read_leb128_u32(bytecode, offset + 1)?;
-            let (offset, bytes2) = read_leb128_u32(bytecode, offset + 1 + bytes1)?;
+            let (offset, bytes2) = read_leb128_u64(bytecode, offset + 1 + bytes1)?;
             consumed += bytes1 + bytes2;
             Instruction::I32Load16S(MemArg {
                 align_exponent: align,
@@ -501,7 +513,7 @@ fn parse_instruction_with_provider(
         },
         0x2F => {
             let (align, bytes1) = read_leb128_u32(bytecode, offset + 1)?;
-            let (offset, bytes2) = read_leb128_u32(bytecode, offset + 1 + bytes1)?;
+            let (offset, bytes2) = read_leb128_u64(bytecode, offset + 1 + bytes1)?;
             consumed += bytes1 + bytes2;
             Instruction::I32Load16U(MemArg {
                 align_exponent: align,
@@ -511,7 +523,7 @@ fn parse_instruction_with_provider(
         },
         0x30 => {
             let (align, bytes1) = read_leb128_u32(bytecode, offset + 1)?;
-            let (offset, bytes2) = read_leb128_u32(bytecode, offset + 1 + bytes1)?;
+            let (offset, bytes2) = read_leb128_u64(bytecode, offset + 1 + bytes1)?;
             consumed += bytes1 + bytes2;
             Instruction::I64Load8S(MemArg {
                 align_exponent: align,
@@ -521,7 +533,7 @@ fn parse_instruction_with_provider(
         },
         0x31 => {
             let (align, bytes1) = read_leb128_u32(bytecode, offset + 1)?;
-            let (offset, bytes2) = read_leb128_u32(bytecode, offset + 1 + bytes1)?;
+            let (offset, bytes2) = read_leb128_u64(bytecode, offset + 1 + bytes1)?;
             consumed += bytes1 + bytes2;
             Instruction::I64Load8U(MemArg {
                 align_exponent: align,
@@ -531,7 +543,7 @@ fn parse_instruction_with_provider(
         },
         0x32 => {
             let (align, bytes1) = read_leb128_u32(bytecode, offset + 1)?;
-            let (offset, bytes2) = read_leb128_u32(bytecode, offset + 1 + bytes1)?;
+            let (offset, bytes2) = read_leb128_u64(bytecode, offset + 1 + bytes1)?;
             consumed += bytes1 + bytes2;
             Instruction::I64Load16S(MemArg {
                 align_exponent: align,
@@ -541,7 +553,7 @@ fn parse_instruction_with_provider(
         },
         0x33 => {
             let (align, bytes1) = read_leb128_u32(bytecode, offset + 1)?;
-            let (offset, bytes2) = read_leb128_u32(bytecode, offset + 1 + bytes1)?;
+            let (offset, bytes2) = read_leb128_u64(bytecode, offset + 1 + bytes1)?;
             consumed += bytes1 + bytes2;
             Instruction::I64Load16U(MemArg {
                 align_exponent: align,
@@ -551,7 +563,7 @@ fn parse_instruction_with_provider(
         },
         0x34 => {
             let (align, bytes1) = read_leb128_u32(bytecode, offset + 1)?;
-            let (offset, bytes2) = read_leb128_u32(bytecode, offset + 1 + bytes1)?;
+            let (offset, bytes2) = read_leb128_u64(bytecode, offset + 1 + bytes1)?;
             consumed += bytes1 + bytes2;
             Instruction::I64Load32S(MemArg {
                 align_exponent: align,
@@ -561,7 +573,7 @@ fn parse_instruction_with_provider(
         },
         0x35 => {
             let (align, bytes1) = read_leb128_u32(bytecode, offset + 1)?;
-            let (offset, bytes2) = read_leb128_u32(bytecode, offset + 1 + bytes1)?;
+            let (offset, bytes2) = read_leb128_u64(bytecode, offset + 1 + bytes1)?;
             consumed += bytes1 + bytes2;
             Instruction::I64Load32U(MemArg {
                 align_exponent: align,
@@ -571,7 +583,7 @@ fn parse_instruction_with_provider(
         },
         0x36 => {
             let (align, bytes1) = read_leb128_u32(bytecode, offset + 1)?;
-            let (offset, bytes2) = read_leb128_u32(bytecode, offset + 1 + bytes1)?;
+            let (offset, bytes2) = read_leb128_u64(bytecode, offset + 1 + bytes1)?;
             consumed += bytes1 + bytes2;
             Instruction::I32Store(MemArg {
                 align_exponent: align,
@@ -581,7 +593,7 @@ fn parse_instruction_with_provider(
         },
         0x37 => {
             let (align, bytes1) = read_leb128_u32(bytecode, offset + 1)?;
-            let (offset, bytes2) = read_leb128_u32(bytecode, offset + 1 + bytes1)?;
+            let (offset, bytes2) = read_leb128_u64(bytecode, offset + 1 + bytes1)?;
             consumed += bytes1 + bytes2;
             Instruction::I64Store(MemArg {
                 align_exponent: align,
@@ -591,7 +603,7 @@ fn parse_instruction_with_provider(
         },
         0x38 => {
             let (align, bytes1) = read_leb128_u32(bytecode, offset + 1)?;
-            let (offset, bytes2) = read_leb128_u32(bytecode, offset + 1 + bytes1)?;
+            let (offset, bytes2) = read_leb128_u64(bytecode, offset + 1 + bytes1)?;
             consumed += bytes1 + bytes2;
             Instruction::F32Store(MemArg {
                 align_exponent: align,
@@ -601,7 +613,7 @@ fn parse_instruction_with_provider(
         },
         0x39 => {
             let (align, bytes1) = read_leb128_u32(bytecode, offset + 1)?;
-            let (offset, bytes2) = read_leb128_u32(bytecode, offset + 1 + bytes1)?;
+            let (offset, bytes2) = read_leb128_u64(bytecode, offset + 1 + bytes1)?;
             consumed += bytes1 + bytes2;
             Instruction::F64Store(MemArg {
                 align_exponent: align,
@@ -612,7 +624,7 @@ fn parse_instruction_with_provider(
         0x3A => {
             // i32.store8
             let (align, bytes1) = read_leb128_u32(bytecode, offset + 1)?;
-            let (offset, bytes2) = read_leb128_u32(bytecode, offset + 1 + bytes1)?;
+            let (offset, bytes2) = read_leb128_u64(bytecode, offset + 1 + bytes1)?;
             consumed += bytes1 + bytes2;
             Instruction::I32Store8(MemArg {
                 align_exponent: align,
@@ -623,7 +635,7 @@ fn parse_instruction_with_provider(
         0x3B => {
             // i32.store16
             let (align, bytes1) = read_leb128_u32(bytecode, offset + 1)?;
-            let (offset, bytes2) = read_leb128_u32(bytecode, offset + 1 + bytes1)?;
+            let (offset, bytes2) = read_leb128_u64(bytecode, offset + 1 + bytes1)?;
             consumed += bytes1 + bytes2;
             Instruction::I32Store16(MemArg {
                 align_exponent: align,
@@ -634,7 +646,7 @@ fn parse_instruction_with_provider(
         0x3C => {
             // i64.store8
             let (align, bytes1) = read_leb128_u32(bytecode, offset + 1)?;
-            let (offset, bytes2) = read_leb128_u32(bytecode, offset + 1 + bytes1)?;
+            let (offset, bytes2) = read_leb128_u64(bytecode, offset + 1 + bytes1)?;
             consumed += bytes1 + bytes2;
             Instruction::I64Store8(MemArg {
                 align_exponent: align,
@@ -645,7 +657,7 @@ fn parse_instruction_with_provider(
         0x3D => {
             // i64.store16
             let (align, bytes1) = read_leb128_u32(bytecode, offset + 1)?;
-            let (offset, bytes2) = read_leb128_u32(bytecode, offset + 1 + bytes1)?;
+            let (offset, bytes2) = read_leb128_u64(bytecode, offset + 1 + bytes1)?;
             consumed += bytes1 + bytes2;
             Instruction::I64Store16(MemArg {
                 align_exponent: align,
@@ -656,7 +668,7 @@ fn parse_instruction_with_provider(
         0x3E => {
             // i64.store32
             let (align, bytes1) = read_leb128_u32(bytecode, offset + 1)?;
-            let (offset, bytes2) = read_leb128_u32(bytecode, offset + 1 + bytes1)?;
+            let (offset, bytes2) = read_leb128_u64(bytecode, offset + 1 + bytes1)?;
             consumed += bytes1 + bytes2;
             Instruction::I64Store32(MemArg {
                 align_exponent: align,
@@ -906,6 +918,26 @@ fn parse_instruction_with_provider(
             let (func_idx, bytes) = read_leb128_u32(bytecode, offset + 1)?;
             consumed += bytes;
             Instruction::RefFunc(func_idx)
+        },
+        0xD3 => {
+            // ref.eq - compare two references for equality (GC proposal)
+            Instruction::RefEq
+        },
+        0xD4 => {
+            // ref.as_non_null - assert reference is not null (typed function references)
+            Instruction::RefAsNonNull
+        },
+        0xD5 => {
+            // br_on_null - branch if reference is null (typed function references)
+            let (label_idx, bytes) = read_leb128_u32(bytecode, offset + 1)?;
+            consumed += bytes;
+            Instruction::BrOnNull(label_idx)
+        },
+        0xD6 => {
+            // br_on_non_null - branch if reference is not null (typed function references)
+            let (label_idx, bytes) = read_leb128_u32(bytecode, offset + 1)?;
+            consumed += bytes;
+            Instruction::BrOnNonNull(label_idx)
         },
 
         // Multi-byte opcodes (bulk memory, SIMD, etc.)
@@ -1265,6 +1297,260 @@ fn parse_instruction_with_provider(
             }
         }
 
+        // Atomic instructions (0xFE prefix) - WebAssembly Threads Proposal
+        0xFE => {
+            // Atomic instructions use 0xFE prefix followed by LEB128-encoded sub-opcode
+            let (atomic_opcode, opcode_bytes) = read_leb128_u32(bytecode, offset + 1)?;
+            consumed += opcode_bytes;
+
+            match atomic_opcode {
+                // atomic.fence - special case: reads 1 byte (must be 0x00)
+                0x03 => {
+                    if offset + consumed >= bytecode.len() {
+                        return Err(Error::parse_error("Unexpected end in atomic.fence"));
+                    }
+                    let fence_byte = bytecode[offset + consumed];
+                    consumed += 1;
+                    if fence_byte != 0x00 {
+                        return Err(Error::parse_error("Invalid atomic.fence byte, expected 0x00"));
+                    }
+                    Instruction::AtomicFence
+                }
+
+                // All other atomic instructions read a memarg (align as LEB128 u32, offset as LEB128 u64)
+                _ => {
+                    let (align, bytes1) = read_leb128_u32(bytecode, offset + consumed)?;
+                    consumed += bytes1;
+                    let (mem_offset, bytes2) = read_leb128_u64(bytecode, offset + consumed)?;
+                    consumed += bytes2;
+                    let memarg = MemArg {
+                        align_exponent: align,
+                        offset: mem_offset,
+                        memory_index: 0,
+                    };
+
+                    match atomic_opcode {
+                        // Atomic notify/wait
+                        0x00 => Instruction::MemoryAtomicNotify { memarg },
+                        0x01 => Instruction::MemoryAtomicWait32 { memarg },
+                        0x02 => Instruction::MemoryAtomicWait64 { memarg },
+
+                        // Atomic loads
+                        0x10 => Instruction::I32AtomicLoad { memarg },
+                        0x11 => Instruction::I64AtomicLoad { memarg },
+                        0x12 => Instruction::I32AtomicLoad8U { memarg },
+                        0x13 => Instruction::I32AtomicLoad16U { memarg },
+                        0x14 => Instruction::I64AtomicLoad8U { memarg },
+                        0x15 => Instruction::I64AtomicLoad16U { memarg },
+                        0x16 => Instruction::I64AtomicLoad32U { memarg },
+
+                        // Atomic stores
+                        0x17 => Instruction::I32AtomicStore { memarg },
+                        0x18 => Instruction::I64AtomicStore { memarg },
+                        0x19 => Instruction::I32AtomicStore8 { memarg },
+                        0x1A => Instruction::I32AtomicStore16 { memarg },
+                        0x1B => Instruction::I64AtomicStore8 { memarg },
+                        0x1C => Instruction::I64AtomicStore16 { memarg },
+                        0x1D => Instruction::I64AtomicStore32 { memarg },
+
+                        // Atomic RMW: add
+                        0x1E => Instruction::I32AtomicRmwAdd { memarg },
+                        0x1F => Instruction::I64AtomicRmwAdd { memarg },
+                        0x20 => Instruction::I32AtomicRmw8AddU { memarg },
+                        0x21 => Instruction::I32AtomicRmw16AddU { memarg },
+                        0x22 => Instruction::I64AtomicRmw8AddU { memarg },
+                        0x23 => Instruction::I64AtomicRmw16AddU { memarg },
+                        0x24 => Instruction::I64AtomicRmw32AddU { memarg },
+
+                        // Atomic RMW: sub
+                        0x25 => Instruction::I32AtomicRmwSub { memarg },
+                        0x26 => Instruction::I64AtomicRmwSub { memarg },
+                        0x27 => Instruction::I32AtomicRmw8SubU { memarg },
+                        0x28 => Instruction::I32AtomicRmw16SubU { memarg },
+                        0x29 => Instruction::I64AtomicRmw8SubU { memarg },
+                        0x2A => Instruction::I64AtomicRmw16SubU { memarg },
+                        0x2B => Instruction::I64AtomicRmw32SubU { memarg },
+
+                        // Atomic RMW: and
+                        0x2C => Instruction::I32AtomicRmwAnd { memarg },
+                        0x2D => Instruction::I64AtomicRmwAnd { memarg },
+                        0x2E => Instruction::I32AtomicRmw8AndU { memarg },
+                        0x2F => Instruction::I32AtomicRmw16AndU { memarg },
+                        0x30 => Instruction::I64AtomicRmw8AndU { memarg },
+                        0x31 => Instruction::I64AtomicRmw16AndU { memarg },
+                        0x32 => Instruction::I64AtomicRmw32AndU { memarg },
+
+                        // Atomic RMW: or
+                        0x33 => Instruction::I32AtomicRmwOr { memarg },
+                        0x34 => Instruction::I64AtomicRmwOr { memarg },
+                        0x35 => Instruction::I32AtomicRmw8OrU { memarg },
+                        0x36 => Instruction::I32AtomicRmw16OrU { memarg },
+                        0x37 => Instruction::I64AtomicRmw8OrU { memarg },
+                        0x38 => Instruction::I64AtomicRmw16OrU { memarg },
+                        0x39 => Instruction::I64AtomicRmw32OrU { memarg },
+
+                        // Atomic RMW: xor
+                        0x3A => Instruction::I32AtomicRmwXor { memarg },
+                        0x3B => Instruction::I64AtomicRmwXor { memarg },
+                        0x3C => Instruction::I32AtomicRmw8XorU { memarg },
+                        0x3D => Instruction::I32AtomicRmw16XorU { memarg },
+                        0x3E => Instruction::I64AtomicRmw8XorU { memarg },
+                        0x3F => Instruction::I64AtomicRmw16XorU { memarg },
+                        0x40 => Instruction::I64AtomicRmw32XorU { memarg },
+
+                        // Atomic RMW: xchg
+                        0x41 => Instruction::I32AtomicRmwXchg { memarg },
+                        0x42 => Instruction::I64AtomicRmwXchg { memarg },
+                        0x43 => Instruction::I32AtomicRmw8XchgU { memarg },
+                        0x44 => Instruction::I32AtomicRmw16XchgU { memarg },
+                        0x45 => Instruction::I64AtomicRmw8XchgU { memarg },
+                        0x46 => Instruction::I64AtomicRmw16XchgU { memarg },
+                        0x47 => Instruction::I64AtomicRmw32XchgU { memarg },
+
+                        // Atomic RMW: cmpxchg
+                        0x48 => Instruction::I32AtomicRmwCmpxchg { memarg },
+                        0x49 => Instruction::I64AtomicRmwCmpxchg { memarg },
+                        0x4A => Instruction::I32AtomicRmw8CmpxchgU { memarg },
+                        0x4B => Instruction::I32AtomicRmw16CmpxchgU { memarg },
+                        0x4C => Instruction::I64AtomicRmw8CmpxchgU { memarg },
+                        0x4D => Instruction::I64AtomicRmw16CmpxchgU { memarg },
+                        0x4E => Instruction::I64AtomicRmw32CmpxchgU { memarg },
+
+                        _ => {
+                            #[cfg(feature = "tracing")]
+                            wrt_foundation::tracing::warn!(atomic_opcode = format!("0xFE 0x{:02X}", atomic_opcode), offset = offset, "Unknown atomic opcode");
+                            return Err(Error::parse_error("Unknown atomic instruction opcode"));
+                        }
+                    }
+                }
+            }
+        }
+
+        // SIMD instructions (0xFD prefix) - WebAssembly SIMD Proposal
+        0xFD => {
+            // SIMD instructions use 0xFD prefix followed by LEB128-encoded sub-opcode
+            let (simd_opcode, opcode_bytes) = read_leb128_u32(bytecode, offset + 1)?;
+            consumed += opcode_bytes;
+
+            match simd_opcode {
+                // Memory operations with memarg (v128.load variants and v128.store)
+                0x00..=0x0B => {
+                    let (align, bytes1) = read_leb128_u32(bytecode, offset + consumed)?;
+                    consumed += bytes1;
+                    let (mem_offset, bytes2) = read_leb128_u64(bytecode, offset + consumed)?;
+                    consumed += bytes2;
+                    Instruction::SimdMemOp {
+                        opcode: simd_opcode,
+                        memarg: MemArg {
+                            align_exponent: align,
+                            offset: mem_offset,
+                            memory_index: 0,
+                        },
+                    }
+                }
+
+                // v128.const: 16 bytes of immediate data
+                0x0C => {
+                    if offset + consumed + 16 > bytecode.len() {
+                        return Err(Error::parse_error("Unexpected end in v128.const"));
+                    }
+                    let mut bytes = [0u8; 16];
+                    bytes.copy_from_slice(&bytecode[offset + consumed..offset + consumed + 16]);
+                    consumed += 16;
+                    Instruction::V128Const { bytes }
+                }
+
+                // i8x16.shuffle: 16 bytes of lane indices
+                0x0D => {
+                    if offset + consumed + 16 > bytecode.len() {
+                        return Err(Error::parse_error("Unexpected end in i8x16.shuffle"));
+                    }
+                    let mut lanes = [0u8; 16];
+                    lanes.copy_from_slice(&bytecode[offset + consumed..offset + consumed + 16]);
+                    consumed += 16;
+                    Instruction::SimdShuffle { lanes }
+                }
+
+                // No-immediate operations: swizzle and splats
+                0x0E..=0x14 => {
+                    Instruction::SimdOp { opcode: simd_opcode }
+                }
+
+                // Lane extract/replace operations: 1 byte lane index
+                0x15..=0x22 => {
+                    if offset + consumed >= bytecode.len() {
+                        return Err(Error::parse_error("Unexpected end in SIMD lane operation"));
+                    }
+                    let lane = bytecode[offset + consumed];
+                    consumed += 1;
+                    Instruction::SimdLaneOp { opcode: simd_opcode, lane }
+                }
+
+                // No-immediate arithmetic operations (comparisons, arithmetic, bitwise, etc.)
+                0x23..=0x53 => {
+                    Instruction::SimdOp { opcode: simd_opcode }
+                }
+
+                // Memory + lane operations: v128.load*_lane, v128.store*_lane
+                // (memarg followed by 1 byte lane index)
+                0x54..=0x5B => {
+                    let (align, bytes1) = read_leb128_u32(bytecode, offset + consumed)?;
+                    consumed += bytes1;
+                    let (mem_offset, bytes2) = read_leb128_u64(bytecode, offset + consumed)?;
+                    consumed += bytes2;
+                    if offset + consumed >= bytecode.len() {
+                        return Err(Error::parse_error("Unexpected end in SIMD memory lane operation"));
+                    }
+                    let lane = bytecode[offset + consumed];
+                    consumed += 1;
+                    Instruction::SimdMemLaneOp {
+                        opcode: simd_opcode,
+                        memarg: MemArg {
+                            align_exponent: align,
+                            offset: mem_offset,
+                            memory_index: 0,
+                        },
+                        lane,
+                    }
+                }
+
+                // Memory operations: v128.load32_zero, v128.load64_zero
+                0x5C..=0x5D => {
+                    let (align, bytes1) = read_leb128_u32(bytecode, offset + consumed)?;
+                    consumed += bytes1;
+                    let (mem_offset, bytes2) = read_leb128_u64(bytecode, offset + consumed)?;
+                    consumed += bytes2;
+                    Instruction::SimdMemOp {
+                        opcode: simd_opcode,
+                        memarg: MemArg {
+                            align_exponent: align,
+                            offset: mem_offset,
+                            memory_index: 0,
+                        },
+                    }
+                }
+
+                // No-immediate arithmetic operations (continued)
+                // Includes i8x16.popcnt (0x62), i16x8.extadd_pairwise_*, i32x4.extadd_pairwise_*,
+                // abs, neg, all_true, bitmask, narrow, extend, shift, add, sub, mul, min, max,
+                // avgr, extmul, dot product, convert, trunc_sat, demote, promote, etc.
+                0x5E..=0xFF => {
+                    Instruction::SimdOp { opcode: simd_opcode }
+                }
+
+                // Relaxed SIMD operations (no immediates)
+                0x100..=0x112 => {
+                    Instruction::SimdOp { opcode: simd_opcode }
+                }
+
+                _ => {
+                    #[cfg(feature = "tracing")]
+                    wrt_foundation::tracing::warn!(simd_opcode = format!("0xFD 0x{:03X}", simd_opcode), offset = offset, "Unknown SIMD opcode");
+                    return Err(Error::parse_error("Unknown SIMD instruction opcode"));
+                }
+            }
+        }
+
         _ => {
             // Show context around the unknown opcode
             #[cfg(feature = "tracing")]
@@ -1310,6 +1596,13 @@ fn decode_value_type(b: u8) -> Result<wrt_foundation::types::ValueType> {
         0x6C => Ok(ValueType::I31Ref),
         0x6B => Ok(ValueType::StructRef(0)),
         0x6A => Ok(ValueType::ArrayRef(0)),
+        // Bottom types (GC proposal)
+        0x73 => Ok(ValueType::NullFuncRef),    // nofunc (bottom for funcref)
+        0x72 => Ok(ValueType::ExternRef),      // noextern (bottom for externref)
+        0x71 => Ok(ValueType::AnyRef),         // none (bottom for anyref)
+        0x74 => Ok(ValueType::ExnRef),         // noexn (bottom for exnref)
+        // Reference type prefixes (GC proposal) - for typed select etc.
+        0x63 | 0x64 => Ok(ValueType::FuncRef), // ref null ht / ref ht (simplified)
         _ => Err(Error::parse_error("Unknown value type encoding")),
     }
 }
@@ -1381,6 +1674,39 @@ pub(crate) fn read_leb128_u32(data: &[u8], offset: usize) -> Result<(u32, usize)
         shift += 7;
         if shift >= 32 {
             return Err(Error::parse_error("LEB128 value too large for u32"));
+        }
+    }
+
+    Ok((result, consumed))
+}
+
+/// Read a LEB128 encoded u64
+///
+/// Used for memory64 offsets where the offset value can be up to 2^64-1.
+pub(crate) fn read_leb128_u64(data: &[u8], offset: usize) -> Result<(u64, usize)> {
+    let mut result = 0u64;
+    let mut shift = 0;
+    let mut consumed = 0;
+
+    loop {
+        if offset + consumed >= data.len() {
+            return Err(Error::parse_error(
+                "Unexpected end of data while reading LEB128",
+            ));
+        }
+
+        let byte = data[offset + consumed];
+        consumed += 1;
+
+        result |= ((byte & 0x7F) as u64) << shift;
+
+        if byte & 0x80 == 0 {
+            break;
+        }
+
+        shift += 7;
+        if shift >= 64 {
+            return Err(Error::parse_error("LEB128 value too large for u64"));
         }
     }
 

--- a/wrt-runtime/src/instruction_parser.rs
+++ b/wrt-runtime/src/instruction_parser.rs
@@ -39,6 +39,42 @@ type InstructionVec = BoundedVec<Instruction<InstructionProvider>, 1024, Instruc
 
 type TargetVec = BoundedVec<u32, 20000, InstructionProvider>;
 
+/// Parse a memarg (memory argument) from bytecode with multi-memory support.
+///
+/// In the multi-memory proposal (now part of the WebAssembly spec), the alignment
+/// byte encodes both the alignment and an optional memory index:
+/// - Bits 0-5: alignment exponent
+/// - Bit 6: if set, a memory index (LEB128 u32) follows the alignment
+///
+/// Returns (MemArg, bytes_consumed).
+fn parse_memarg(bytecode: &[u8], start: usize) -> Result<(MemArg, usize)> {
+    let (align_with_flags, bytes1) = read_leb128_u32(bytecode, start)?;
+    let mut pos = start + bytes1;
+
+    // Check for multi-memory flag (bit 6 of alignment)
+    let has_mem_idx = (align_with_flags & 0x40) != 0;
+    let align = align_with_flags & 0x3F; // Lower 6 bits are the alignment exponent
+
+    let memory_index = if has_mem_idx {
+        let (idx, bytes_idx) = read_leb128_u32(bytecode, pos)?;
+        pos += bytes_idx;
+        idx
+    } else {
+        0
+    };
+
+    let (offset, bytes2) = read_leb128_u64(bytecode, pos)?;
+    pos += bytes2;
+
+    let total_consumed = pos - start;
+
+    Ok((MemArg {
+        align_exponent: align,
+        offset,
+        memory_index,
+    }, total_consumed))
+}
+
 /// Parse WebAssembly bytecode into runtime instructions with a provided memory provider
 pub fn parse_instructions_with_provider(
     bytecode: &[u8],
@@ -440,249 +476,138 @@ fn parse_instruction_with_provider(
             Instruction::TableSet(table_idx)
         },
 
-        // Memory instructions
+        // Memory instructions - load/store with multi-memory support
         0x28 => {
-            let (align, bytes1) = read_leb128_u32(bytecode, offset + 1)?;
-            let (offset, bytes2) = read_leb128_u64(bytecode, offset + 1 + bytes1)?;
-            consumed += bytes1 + bytes2;
-            Instruction::I32Load(MemArg {
-                align_exponent: align,
-                offset,
-                memory_index: 0,
-            })
+            let (memarg, bytes) = parse_memarg(bytecode, offset + 1)?;
+            consumed += bytes;
+            Instruction::I32Load(memarg)
         },
         0x29 => {
-            let (align, bytes1) = read_leb128_u32(bytecode, offset + 1)?;
-            let (offset, bytes2) = read_leb128_u64(bytecode, offset + 1 + bytes1)?;
-            consumed += bytes1 + bytes2;
-            Instruction::I64Load(MemArg {
-                align_exponent: align,
-                offset,
-                memory_index: 0,
-            })
+            let (memarg, bytes) = parse_memarg(bytecode, offset + 1)?;
+            consumed += bytes;
+            Instruction::I64Load(memarg)
         },
         0x2A => {
-            let (align, bytes1) = read_leb128_u32(bytecode, offset + 1)?;
-            let (offset, bytes2) = read_leb128_u64(bytecode, offset + 1 + bytes1)?;
-            consumed += bytes1 + bytes2;
-            Instruction::F32Load(MemArg {
-                align_exponent: align,
-                offset,
-                memory_index: 0,
-            })
+            let (memarg, bytes) = parse_memarg(bytecode, offset + 1)?;
+            consumed += bytes;
+            Instruction::F32Load(memarg)
         },
         0x2B => {
-            let (align, bytes1) = read_leb128_u32(bytecode, offset + 1)?;
-            let (offset, bytes2) = read_leb128_u64(bytecode, offset + 1 + bytes1)?;
-            consumed += bytes1 + bytes2;
-            Instruction::F64Load(MemArg {
-                align_exponent: align,
-                offset,
-                memory_index: 0,
-            })
+            let (memarg, bytes) = parse_memarg(bytecode, offset + 1)?;
+            consumed += bytes;
+            Instruction::F64Load(memarg)
         },
         0x2C => {
-            let (align, bytes1) = read_leb128_u32(bytecode, offset + 1)?;
-            let (offset, bytes2) = read_leb128_u64(bytecode, offset + 1 + bytes1)?;
-            consumed += bytes1 + bytes2;
-            Instruction::I32Load8S(MemArg {
-                align_exponent: align,
-                offset,
-                memory_index: 0,
-            })
+            let (memarg, bytes) = parse_memarg(bytecode, offset + 1)?;
+            consumed += bytes;
+            Instruction::I32Load8S(memarg)
         },
         0x2D => {
-            let (align, bytes1) = read_leb128_u32(bytecode, offset + 1)?;
-            let (offset, bytes2) = read_leb128_u64(bytecode, offset + 1 + bytes1)?;
-            consumed += bytes1 + bytes2;
-            Instruction::I32Load8U(MemArg {
-                align_exponent: align,
-                offset,
-                memory_index: 0,
-            })
+            let (memarg, bytes) = parse_memarg(bytecode, offset + 1)?;
+            consumed += bytes;
+            Instruction::I32Load8U(memarg)
         },
         0x2E => {
-            let (align, bytes1) = read_leb128_u32(bytecode, offset + 1)?;
-            let (offset, bytes2) = read_leb128_u64(bytecode, offset + 1 + bytes1)?;
-            consumed += bytes1 + bytes2;
-            Instruction::I32Load16S(MemArg {
-                align_exponent: align,
-                offset,
-                memory_index: 0,
-            })
+            let (memarg, bytes) = parse_memarg(bytecode, offset + 1)?;
+            consumed += bytes;
+            Instruction::I32Load16S(memarg)
         },
         0x2F => {
-            let (align, bytes1) = read_leb128_u32(bytecode, offset + 1)?;
-            let (offset, bytes2) = read_leb128_u64(bytecode, offset + 1 + bytes1)?;
-            consumed += bytes1 + bytes2;
-            Instruction::I32Load16U(MemArg {
-                align_exponent: align,
-                offset,
-                memory_index: 0,
-            })
+            let (memarg, bytes) = parse_memarg(bytecode, offset + 1)?;
+            consumed += bytes;
+            Instruction::I32Load16U(memarg)
         },
         0x30 => {
-            let (align, bytes1) = read_leb128_u32(bytecode, offset + 1)?;
-            let (offset, bytes2) = read_leb128_u64(bytecode, offset + 1 + bytes1)?;
-            consumed += bytes1 + bytes2;
-            Instruction::I64Load8S(MemArg {
-                align_exponent: align,
-                offset,
-                memory_index: 0,
-            })
+            let (memarg, bytes) = parse_memarg(bytecode, offset + 1)?;
+            consumed += bytes;
+            Instruction::I64Load8S(memarg)
         },
         0x31 => {
-            let (align, bytes1) = read_leb128_u32(bytecode, offset + 1)?;
-            let (offset, bytes2) = read_leb128_u64(bytecode, offset + 1 + bytes1)?;
-            consumed += bytes1 + bytes2;
-            Instruction::I64Load8U(MemArg {
-                align_exponent: align,
-                offset,
-                memory_index: 0,
-            })
+            let (memarg, bytes) = parse_memarg(bytecode, offset + 1)?;
+            consumed += bytes;
+            Instruction::I64Load8U(memarg)
         },
         0x32 => {
-            let (align, bytes1) = read_leb128_u32(bytecode, offset + 1)?;
-            let (offset, bytes2) = read_leb128_u64(bytecode, offset + 1 + bytes1)?;
-            consumed += bytes1 + bytes2;
-            Instruction::I64Load16S(MemArg {
-                align_exponent: align,
-                offset,
-                memory_index: 0,
-            })
+            let (memarg, bytes) = parse_memarg(bytecode, offset + 1)?;
+            consumed += bytes;
+            Instruction::I64Load16S(memarg)
         },
         0x33 => {
-            let (align, bytes1) = read_leb128_u32(bytecode, offset + 1)?;
-            let (offset, bytes2) = read_leb128_u64(bytecode, offset + 1 + bytes1)?;
-            consumed += bytes1 + bytes2;
-            Instruction::I64Load16U(MemArg {
-                align_exponent: align,
-                offset,
-                memory_index: 0,
-            })
+            let (memarg, bytes) = parse_memarg(bytecode, offset + 1)?;
+            consumed += bytes;
+            Instruction::I64Load16U(memarg)
         },
         0x34 => {
-            let (align, bytes1) = read_leb128_u32(bytecode, offset + 1)?;
-            let (offset, bytes2) = read_leb128_u64(bytecode, offset + 1 + bytes1)?;
-            consumed += bytes1 + bytes2;
-            Instruction::I64Load32S(MemArg {
-                align_exponent: align,
-                offset,
-                memory_index: 0,
-            })
+            let (memarg, bytes) = parse_memarg(bytecode, offset + 1)?;
+            consumed += bytes;
+            Instruction::I64Load32S(memarg)
         },
         0x35 => {
-            let (align, bytes1) = read_leb128_u32(bytecode, offset + 1)?;
-            let (offset, bytes2) = read_leb128_u64(bytecode, offset + 1 + bytes1)?;
-            consumed += bytes1 + bytes2;
-            Instruction::I64Load32U(MemArg {
-                align_exponent: align,
-                offset,
-                memory_index: 0,
-            })
+            let (memarg, bytes) = parse_memarg(bytecode, offset + 1)?;
+            consumed += bytes;
+            Instruction::I64Load32U(memarg)
         },
         0x36 => {
-            let (align, bytes1) = read_leb128_u32(bytecode, offset + 1)?;
-            let (offset, bytes2) = read_leb128_u64(bytecode, offset + 1 + bytes1)?;
-            consumed += bytes1 + bytes2;
-            Instruction::I32Store(MemArg {
-                align_exponent: align,
-                offset,
-                memory_index: 0,
-            })
+            let (memarg, bytes) = parse_memarg(bytecode, offset + 1)?;
+            consumed += bytes;
+            Instruction::I32Store(memarg)
         },
         0x37 => {
-            let (align, bytes1) = read_leb128_u32(bytecode, offset + 1)?;
-            let (offset, bytes2) = read_leb128_u64(bytecode, offset + 1 + bytes1)?;
-            consumed += bytes1 + bytes2;
-            Instruction::I64Store(MemArg {
-                align_exponent: align,
-                offset,
-                memory_index: 0,
-            })
+            let (memarg, bytes) = parse_memarg(bytecode, offset + 1)?;
+            consumed += bytes;
+            Instruction::I64Store(memarg)
         },
         0x38 => {
-            let (align, bytes1) = read_leb128_u32(bytecode, offset + 1)?;
-            let (offset, bytes2) = read_leb128_u64(bytecode, offset + 1 + bytes1)?;
-            consumed += bytes1 + bytes2;
-            Instruction::F32Store(MemArg {
-                align_exponent: align,
-                offset,
-                memory_index: 0,
-            })
+            let (memarg, bytes) = parse_memarg(bytecode, offset + 1)?;
+            consumed += bytes;
+            Instruction::F32Store(memarg)
         },
         0x39 => {
-            let (align, bytes1) = read_leb128_u32(bytecode, offset + 1)?;
-            let (offset, bytes2) = read_leb128_u64(bytecode, offset + 1 + bytes1)?;
-            consumed += bytes1 + bytes2;
-            Instruction::F64Store(MemArg {
-                align_exponent: align,
-                offset,
-                memory_index: 0,
-            })
+            let (memarg, bytes) = parse_memarg(bytecode, offset + 1)?;
+            consumed += bytes;
+            Instruction::F64Store(memarg)
         },
         0x3A => {
             // i32.store8
-            let (align, bytes1) = read_leb128_u32(bytecode, offset + 1)?;
-            let (offset, bytes2) = read_leb128_u64(bytecode, offset + 1 + bytes1)?;
-            consumed += bytes1 + bytes2;
-            Instruction::I32Store8(MemArg {
-                align_exponent: align,
-                offset,
-                memory_index: 0,
-            })
+            let (memarg, bytes) = parse_memarg(bytecode, offset + 1)?;
+            consumed += bytes;
+            Instruction::I32Store8(memarg)
         },
         0x3B => {
             // i32.store16
-            let (align, bytes1) = read_leb128_u32(bytecode, offset + 1)?;
-            let (offset, bytes2) = read_leb128_u64(bytecode, offset + 1 + bytes1)?;
-            consumed += bytes1 + bytes2;
-            Instruction::I32Store16(MemArg {
-                align_exponent: align,
-                offset,
-                memory_index: 0,
-            })
+            let (memarg, bytes) = parse_memarg(bytecode, offset + 1)?;
+            consumed += bytes;
+            Instruction::I32Store16(memarg)
         },
         0x3C => {
             // i64.store8
-            let (align, bytes1) = read_leb128_u32(bytecode, offset + 1)?;
-            let (offset, bytes2) = read_leb128_u64(bytecode, offset + 1 + bytes1)?;
-            consumed += bytes1 + bytes2;
-            Instruction::I64Store8(MemArg {
-                align_exponent: align,
-                offset,
-                memory_index: 0,
-            })
+            let (memarg, bytes) = parse_memarg(bytecode, offset + 1)?;
+            consumed += bytes;
+            Instruction::I64Store8(memarg)
         },
         0x3D => {
             // i64.store16
-            let (align, bytes1) = read_leb128_u32(bytecode, offset + 1)?;
-            let (offset, bytes2) = read_leb128_u64(bytecode, offset + 1 + bytes1)?;
-            consumed += bytes1 + bytes2;
-            Instruction::I64Store16(MemArg {
-                align_exponent: align,
-                offset,
-                memory_index: 0,
-            })
+            let (memarg, bytes) = parse_memarg(bytecode, offset + 1)?;
+            consumed += bytes;
+            Instruction::I64Store16(memarg)
         },
         0x3E => {
             // i64.store32
-            let (align, bytes1) = read_leb128_u32(bytecode, offset + 1)?;
-            let (offset, bytes2) = read_leb128_u64(bytecode, offset + 1 + bytes1)?;
-            consumed += bytes1 + bytes2;
-            Instruction::I64Store32(MemArg {
-                align_exponent: align,
-                offset,
-                memory_index: 0,
-            })
+            let (memarg, bytes) = parse_memarg(bytecode, offset + 1)?;
+            consumed += bytes;
+            Instruction::I64Store32(memarg)
         },
         0x3F => {
-            consumed += 1; // Skip reserved byte
-            Instruction::MemorySize(0)
+            // memory.size - the operand is the memory index (LEB128 u32)
+            let (mem_idx, bytes) = read_leb128_u32(bytecode, offset + 1)?;
+            consumed += bytes;
+            Instruction::MemorySize(mem_idx)
         },
         0x40 => {
-            consumed += 1; // Skip reserved byte
-            Instruction::MemoryGrow(0)
+            // memory.grow - the operand is the memory index (LEB128 u32)
+            let (mem_idx, bytes) = read_leb128_u32(bytecode, offset + 1)?;
+            consumed += bytes;
+            Instruction::MemoryGrow(mem_idx)
         },
 
         // Numeric instructions - Constants
@@ -1317,17 +1242,10 @@ fn parse_instruction_with_provider(
                     Instruction::AtomicFence
                 }
 
-                // All other atomic instructions read a memarg (align as LEB128 u32, offset as LEB128 u64)
+                // All other atomic instructions read a memarg with multi-memory support
                 _ => {
-                    let (align, bytes1) = read_leb128_u32(bytecode, offset + consumed)?;
-                    consumed += bytes1;
-                    let (mem_offset, bytes2) = read_leb128_u64(bytecode, offset + consumed)?;
-                    consumed += bytes2;
-                    let memarg = MemArg {
-                        align_exponent: align,
-                        offset: mem_offset,
-                        memory_index: 0,
-                    };
+                    let (memarg, bytes) = parse_memarg(bytecode, offset + consumed)?;
+                    consumed += bytes;
 
                     match atomic_opcode {
                         // Atomic notify/wait
@@ -1435,17 +1353,11 @@ fn parse_instruction_with_provider(
             match simd_opcode {
                 // Memory operations with memarg (v128.load variants and v128.store)
                 0x00..=0x0B => {
-                    let (align, bytes1) = read_leb128_u32(bytecode, offset + consumed)?;
-                    consumed += bytes1;
-                    let (mem_offset, bytes2) = read_leb128_u64(bytecode, offset + consumed)?;
-                    consumed += bytes2;
+                    let (memarg, bytes) = parse_memarg(bytecode, offset + consumed)?;
+                    consumed += bytes;
                     Instruction::SimdMemOp {
                         opcode: simd_opcode,
-                        memarg: MemArg {
-                            align_exponent: align,
-                            offset: mem_offset,
-                            memory_index: 0,
-                        },
+                        memarg,
                     }
                 }
 
@@ -1494,10 +1406,8 @@ fn parse_instruction_with_provider(
                 // Memory + lane operations: v128.load*_lane, v128.store*_lane
                 // (memarg followed by 1 byte lane index)
                 0x54..=0x5B => {
-                    let (align, bytes1) = read_leb128_u32(bytecode, offset + consumed)?;
-                    consumed += bytes1;
-                    let (mem_offset, bytes2) = read_leb128_u64(bytecode, offset + consumed)?;
-                    consumed += bytes2;
+                    let (memarg, bytes) = parse_memarg(bytecode, offset + consumed)?;
+                    consumed += bytes;
                     if offset + consumed >= bytecode.len() {
                         return Err(Error::parse_error("Unexpected end in SIMD memory lane operation"));
                     }
@@ -1505,28 +1415,18 @@ fn parse_instruction_with_provider(
                     consumed += 1;
                     Instruction::SimdMemLaneOp {
                         opcode: simd_opcode,
-                        memarg: MemArg {
-                            align_exponent: align,
-                            offset: mem_offset,
-                            memory_index: 0,
-                        },
+                        memarg,
                         lane,
                     }
                 }
 
                 // Memory operations: v128.load32_zero, v128.load64_zero
                 0x5C..=0x5D => {
-                    let (align, bytes1) = read_leb128_u32(bytecode, offset + consumed)?;
-                    consumed += bytes1;
-                    let (mem_offset, bytes2) = read_leb128_u64(bytecode, offset + consumed)?;
-                    consumed += bytes2;
+                    let (memarg, bytes) = parse_memarg(bytecode, offset + consumed)?;
+                    consumed += bytes;
                     Instruction::SimdMemOp {
                         opcode: simd_opcode,
-                        memarg: MemArg {
-                            align_exponent: align,
-                            offset: mem_offset,
-                            memory_index: 0,
-                        },
+                        memarg,
                     }
                 }
 

--- a/wrt-runtime/src/memory.rs
+++ b/wrt-runtime/src/memory.rs
@@ -517,6 +517,7 @@ impl wrt_foundation::traits::FromBytes for Memory {
                 max: if max == 0 { None } else { Some(max) },
             },
             shared: false,
+            memory64: false,
         };
         Self::new(to_core_memory_type(&memory_type)).map(|boxed| *boxed)
     }

--- a/wrt-runtime/src/memory.rs
+++ b/wrt-runtime/src/memory.rs
@@ -190,8 +190,9 @@ pub const MAX_PAGES: u32 = 65536;
 /// Convert MemoryType to CoreMemoryType
 fn to_core_memory_type(memory_type: &MemoryType) -> CoreMemoryType {
     CoreMemoryType {
-        limits: memory_type.limits,
-        shared: memory_type.shared,
+        limits:   memory_type.limits,
+        shared:   memory_type.shared,
+        memory64: memory_type.memory64,
     }
 }
 
@@ -1103,6 +1104,69 @@ impl Memory {
             {
                 use wrt_foundation::tracing::error;
                 error!("write_shared bounds check FAILED: end {} > mem_size {}", end, mem_size);
+            }
+            return Err(Error::memory_out_of_bounds("Memory write out of bounds"));
+        }
+
+        // Track access
+        self.increment_access_count(offset_usize, size);
+
+        // ASIL-B: Thread-safe write with Mutex
+        #[cfg(feature = "std")]
+        self.data.lock().unwrap().write_data(offset_usize, buffer)?;
+        #[cfg(not(feature = "std"))]
+        self.data.write().write_data(offset_usize, buffer)?;
+
+        // Update metrics
+        self.update_peak_memory();
+
+        Ok(())
+    }
+
+    /// Thread-safe write operation that accepts a 64-bit offset.
+    ///
+    /// This is needed for memory64 modules where data segment offsets
+    /// are specified as i64.const expressions. The offset is safely
+    /// converted to the internal representation.
+    ///
+    /// # Arguments
+    ///
+    /// * `offset` - The 64-bit offset to write to
+    /// * `buffer` - The buffer to write from
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the offset exceeds addressable memory or the
+    /// memory access is invalid.
+    pub fn write_shared_u64(&self, offset: u64, buffer: &[u8]) -> Result<()> {
+        // Empty write is always successful
+        if buffer.is_empty() {
+            return Ok(());
+        }
+
+        // Convert u64 offset to usize directly for bounds checking.
+        // On 64-bit platforms usize is u64, on 32-bit platforms this
+        // will fail for very large offsets (which is correct behavior).
+        let offset_usize = usize::try_from(offset)
+            .map_err(|_| Error::memory_out_of_bounds("Memory64 offset exceeds addressable range"))?;
+        let size = buffer.len();
+        let end = offset_usize
+            .checked_add(size)
+            .ok_or_else(|| Error::memory_out_of_bounds("Memory write would overflow"))?;
+
+        let mem_size = self.size_in_bytes();
+        #[cfg(feature = "tracing")]
+        {
+            use wrt_foundation::tracing::debug;
+            debug!("write_shared_u64: offset={}, size={}, end={}, mem_size={}, pages={}",
+                   offset_usize, size, end, mem_size, self.current_pages.load(Ordering::Relaxed));
+        }
+
+        if end > mem_size {
+            #[cfg(feature = "tracing")]
+            {
+                use wrt_foundation::tracing::error;
+                error!("write_shared_u64 bounds check FAILED: end {} > mem_size {}", end, mem_size);
             }
             return Err(Error::memory_out_of_bounds("Memory write out of bounds"));
         }

--- a/wrt-runtime/src/module.rs
+++ b/wrt-runtime/src/module.rs
@@ -3506,6 +3506,7 @@ impl Module {
                     let memory_type = WrtMemoryType {
                         limits: WrtLimits { min: 0, max: None },  // Will be resolved via linking
                         shared: true,  // Component Model uses shared memory
+                        memory64: false,
                     };
                     ExternType::Memory(memory_type)
                 },
@@ -3627,6 +3628,7 @@ impl Module {
                     max: max_pages,
                 },
                 shared: false,
+                memory64: false,
             };
             runtime_module
                 .push_memory(MemoryWrapper::new(Memory::new(to_core_memory_type(

--- a/wrt-runtime/src/module.rs
+++ b/wrt-runtime/src/module.rs
@@ -3496,6 +3496,7 @@ impl Module {
                     let table_type = WrtTableType {
                         element_type: WrtRefType::Funcref,
                         limits:       WrtLimits { min: 0, max: None },
+                        table64: false,
                     };
                     ExternType::Table(table_type)
                 },
@@ -3974,6 +3975,7 @@ impl Default for TableWrapper {
                 min: 0,
                 max: Some(1),
             },
+            table64: false,
         };
         Self::new(Table::new(table_type).unwrap())
     }
@@ -4431,6 +4433,7 @@ impl FromBytes for TableWrapper {
                 min: 0,
                 max: Some(1),
             },
+            table64: false,
         };
 
         let table = Table::new(table_type).map_err(|_| {

--- a/wrt-runtime/src/module.rs
+++ b/wrt-runtime/src/module.rs
@@ -151,8 +151,9 @@ type BoundedBinary = wrt_foundation::bounded::BoundedVec<u8, 65536, RuntimeProvi
 /// Convert MemoryType to CoreMemoryType
 fn to_core_memory_type(memory_type: WrtMemoryType) -> CoreMemoryType {
     CoreMemoryType {
-        limits: memory_type.limits,
-        shared: memory_type.shared,
+        limits:   memory_type.limits,
+        shared:   memory_type.shared,
+        memory64: memory_type.memory64,
     }
 }
 
@@ -4514,6 +4515,7 @@ fn value_type_to_u8(vt: WrtValueType) -> u8 {
         WrtValueType::I31Ref => 11,
         WrtValueType::AnyRef => 12,
         WrtValueType::EqRef => 13,
+        WrtValueType::NullFuncRef => 14,
         _ => 255, // fallback for other types
     }
 }
@@ -4668,6 +4670,7 @@ impl FromBytes for GlobalWrapper {
             11 => ValueType::I31Ref,
             12 => ValueType::AnyRef,
             13 => ValueType::EqRef,
+            14 => ValueType::NullFuncRef,
             _ => ValueType::I32, // Default fallback
         };
 
@@ -4693,8 +4696,9 @@ impl FromBytes for GlobalWrapper {
                 let v = ((value_high as u64) << 32) | (value_low as u64);
                 Value::F64(wrt_foundation::values::FloatBits64(v))
             },
-            ValueType::FuncRef => {
+            ValueType::FuncRef | ValueType::NullFuncRef => {
                 // 0xFFFFFFFF means None, otherwise it's an index
+                // NullFuncRef is the bottom type for funcref, uses same representation
                 if value_low == 0xFFFFFFFF {
                     Value::FuncRef(None)
                 } else {

--- a/wrt-runtime/src/module.rs
+++ b/wrt-runtime/src/module.rs
@@ -4390,7 +4390,7 @@ impl Checksummable for TableWrapper {
     fn update_checksum(&self, checksum: &mut Checksum) {
         // Use table size and element type for checksum
         checksum.update_slice(&self.0.size().to_le_bytes());
-        checksum.update_slice(&(self.0.ty.element_type as u8).to_le_bytes());
+        checksum.update_slice(&[self.0.ty.element_type.to_value_type().to_binary()]);
     }
 }
 
@@ -4405,7 +4405,7 @@ impl ToBytes for TableWrapper {
         _provider: &P,
     ) -> Result<()> {
         writer.write_all(&self.0.size().to_le_bytes())?;
-        writer.write_all(&(self.0.ty.element_type as u8).to_le_bytes())?;
+        writer.write_all(&[self.0.ty.element_type.to_value_type().to_binary()])?;
         writer.write_all(&self.0.ty.limits.min.to_le_bytes())?;
         Ok(())
     }

--- a/wrt-runtime/src/module_instance.rs
+++ b/wrt-runtime/src/module_instance.rs
@@ -934,21 +934,25 @@ impl ModuleInstance {
                 // Get the memory index (default to 0 if not specified)
                 let memory_idx = data_segment.memory_idx.unwrap_or(0);
 
-                // Get the offset expression and evaluate it
-                let offset = if let Some(ref offset_expr) = data_segment.offset_expr {
-                    // Evaluate the offset expression - for now, assume it's a constant
-                    // In a complete implementation, we'd need to evaluate the expression
-                    // Most data segments use simple i32.const instructions for offsets
+                // Get the offset expression and evaluate it.
+                // Use u64 to support both memory32 (i32.const) and memory64 (i64.const) offsets.
+                let offset: u64 = if let Some(ref offset_expr) = data_segment.offset_expr {
+                    // Evaluate the offset expression - handles both i32.const and i64.const
                     // WrtExpr has instructions field that contains parsed Instructions
                     let expr_instructions = &offset_expr.instructions;
 
-                    // Check if we have an I32Const or GlobalGet instruction
+                    // Check if we have an I32Const, I64Const, or GlobalGet instruction
                     if !expr_instructions.is_empty() {
                         match &expr_instructions[0] {
                             wrt_foundation::types::Instruction::I32Const(value) => {
                                 #[cfg(feature = "tracing")]
                                 debug!("Data segment {} has I32Const offset: {}", idx, value);
-                                *value as u32
+                                *value as u32 as u64
+                            }
+                            wrt_foundation::types::Instruction::I64Const(value) => {
+                                #[cfg(feature = "tracing")]
+                                debug!("Data segment {} has I64Const offset: {}", idx, value);
+                                *value as u64
                             }
                             wrt_foundation::types::Instruction::GlobalGet(global_idx) => {
                                 // Look up the global value for the offset
@@ -961,50 +965,55 @@ impl ModuleInstance {
                                 #[cfg(not(feature = "std"))]
                                 let globals = self.globals.lock();
 
-                                // Get the global value
+                                // Get the global value - support both I32 and I64 globals
                                 if let Some(global_wrapper) = globals.iter().nth(*global_idx as usize) {
                                     match global_wrapper.0.read() {
                                         Ok(global) => {
                                             match global.get() {
                                                 wrt_foundation::values::Value::I32(v) => {
                                                     #[cfg(feature = "tracing")]
-                                                    debug!("Data segment {} global offset value: {}", idx, v);
-                                                    *v as u32
+                                                    debug!("Data segment {} global offset value (i32): {}", idx, v);
+                                                    *v as u32 as u64
+                                                },
+                                                wrt_foundation::values::Value::I64(v) => {
+                                                    #[cfg(feature = "tracing")]
+                                                    debug!("Data segment {} global offset value (i64): {}", idx, v);
+                                                    *v as u64
                                                 },
                                                 _ => {
-                                                    #[cfg(feature = "tracing")]
-                                                    debug!("Data segment {} global has non-i32 type, using 0", idx);
-                                                    0
+                                                    return Err(Error::runtime_error(
+                                                        "Data segment global offset has unexpected type"
+                                                    ));
                                                 }
                                             }
                                         },
                                         Err(_) => {
-                                            #[cfg(feature = "tracing")]
-                                            debug!("Data segment {} failed to read global, using 0", idx);
-                                            0
+                                            return Err(Error::runtime_error(
+                                                "Failed to read global for data segment offset"
+                                            ));
                                         }
                                     }
                                 } else {
-                                    #[cfg(feature = "tracing")]
-                                    debug!("Data segment {} global index {} out of range, using 0", idx, global_idx);
-                                    0
+                                    return Err(Error::runtime_error(
+                                        "Data segment references invalid global index"
+                                    ));
                                 }
                             }
-                            _ => {
-                                // For other instructions, default to 0
-                                #[cfg(feature = "tracing")]
-                                debug!("Data segment {} has non-constant offset expression, using 0", idx);
-                                0
+                            _other => {
+                                // Unsupported offset expression instruction
+                                return Err(Error::runtime_error(
+                                    "Data segment has unsupported offset expression instruction"
+                                ));
                             }
                         }
                     } else {
                         // Empty expression means offset 0
                         #[cfg(feature = "tracing")]
                         debug!("Data segment {} has empty offset expression, using 0", idx);
-                        0
+                        0u64
                     }
                 } else {
-                    0
+                    0u64
                 };
 
                 #[cfg(feature = "tracing")]
@@ -1044,8 +1053,9 @@ impl ModuleInstance {
                     "Writing data to memory"
                 );
 
-                // Use the thread-safe write_shared method for Arc<Memory>
-                memory.write_shared(offset, init_data)?;
+                // Use the thread-safe write method for Arc<Memory>
+                // write_shared_u64 handles both memory32 (small offsets) and memory64 (large offsets)
+                memory.write_shared_u64(offset, init_data)?;
 
                 #[cfg(feature = "tracing")]
                 wrt_foundation::tracing::trace!(segment_idx = idx, "Successfully wrote data segment");

--- a/wrt-runtime/src/multi_memory.rs
+++ b/wrt-runtime/src/multi_memory.rs
@@ -202,8 +202,9 @@ impl MultiMemoryInstance {
     pub fn new(memory_index: u32, memory_type: MemoryType) -> Result<Self> {
         // Convert MemoryType to CoreMemoryType for Memory::new()
         let core_mem_type = CoreMemoryType {
-            limits: memory_type.limits,
-            shared: memory_type.shared,
+            limits:   memory_type.limits,
+            shared:   memory_type.shared,
+            memory64: memory_type.memory64,
         };
         let memory = Memory::new(core_mem_type)
             .map_err(|_| Error::runtime_execution_error("Failed to create memory instance"))?;

--- a/wrt-runtime/src/shared_memory.rs
+++ b/wrt-runtime/src/shared_memory.rs
@@ -303,7 +303,7 @@ impl SharedMemoryInstance {
 
                 // Execute atomic load
                 let memarg = MemArg {
-                    offset: address,
+                    offset: address as u64,
                     align_exponent: 2,
                     memory_index: 0,
                 }; // Assume 4-byte alignment
@@ -326,7 +326,7 @@ impl SharedMemoryInstance {
 
                 // Execute atomic store
                 let memarg = MemArg {
-                    offset: address,
+                    offset: address as u64,
                     align_exponent: 2,
                     memory_index: 0,
                 }; // Assume 4-byte alignment
@@ -351,7 +351,7 @@ impl SharedMemoryInstance {
 
                 // Execute atomic wait
                 let memarg = MemArg {
-                    offset: address,
+                    offset: address as u64,
                     align_exponent: 2,
                     memory_index: 0,
                 };
@@ -378,7 +378,7 @@ impl SharedMemoryInstance {
 
                 // Execute atomic notify
                 let memarg = MemArg {
-                    offset: address,
+                    offset: address as u64,
                     align_exponent: 2,
                     memory_index: 0,
                 };

--- a/wrt-runtime/src/shared_memory.rs
+++ b/wrt-runtime/src/shared_memory.rs
@@ -615,11 +615,12 @@ pub fn create_shared_memory(
 
     // Create memory instance
     let core_mem_type = CoreMemoryType {
-        limits: wrt_foundation::types::Limits {
+        limits:   wrt_foundation::types::Limits {
             min: memory_type.min_pages(),
             max: memory_type.max_pages(),
         },
-        shared: memory_type.is_shared(),
+        shared:   memory_type.is_shared(),
+        memory64: false,
     };
 
     let memory_impl = Memory::new(core_mem_type)

--- a/wrt-runtime/src/stackless/engine.rs
+++ b/wrt-runtime/src/stackless/engine.rs
@@ -4713,25 +4713,25 @@ impl StacklessEngine {
                     // F32 Arithmetic operations
                     Instruction::F32Add => {
                         if let (Some(Value::F32(b)), Some(Value::F32(a))) = (operand_stack.pop(), operand_stack.pop()) {
-                            let result = a.value() + b.value();
+                            let result = simd_ops::canonicalize_f32(a.value() + b.value());
                             operand_stack.push(Value::F32(FloatBits32(result.to_bits())));
                         }
                     }
                     Instruction::F32Sub => {
                         if let (Some(Value::F32(b)), Some(Value::F32(a))) = (operand_stack.pop(), operand_stack.pop()) {
-                            let result = a.value() - b.value();
+                            let result = simd_ops::canonicalize_f32(a.value() - b.value());
                             operand_stack.push(Value::F32(FloatBits32(result.to_bits())));
                         }
                     }
                     Instruction::F32Mul => {
                         if let (Some(Value::F32(b)), Some(Value::F32(a))) = (operand_stack.pop(), operand_stack.pop()) {
-                            let result = a.value() * b.value();
+                            let result = simd_ops::canonicalize_f32(a.value() * b.value());
                             operand_stack.push(Value::F32(FloatBits32(result.to_bits())));
                         }
                     }
                     Instruction::F32Div => {
                         if let (Some(Value::F32(b)), Some(Value::F32(a))) = (operand_stack.pop(), operand_stack.pop()) {
-                            let result = a.value() / b.value();
+                            let result = simd_ops::canonicalize_f32(a.value() / b.value());
                             operand_stack.push(Value::F32(FloatBits32(result.to_bits())));
                         }
                     }
@@ -4750,38 +4750,42 @@ impl StacklessEngine {
                     }
                     Instruction::F32Ceil => {
                         if let Some(Value::F32(a)) = operand_stack.pop() {
-                            let result = a.value().ceil();
+                            let result = simd_ops::canonicalize_f32(a.value().ceil());
                             operand_stack.push(Value::F32(FloatBits32(result.to_bits())));
                         }
                     }
                     Instruction::F32Floor => {
                         if let Some(Value::F32(a)) = operand_stack.pop() {
-                            let result = a.value().floor();
+                            let result = simd_ops::canonicalize_f32(a.value().floor());
                             operand_stack.push(Value::F32(FloatBits32(result.to_bits())));
                         }
                     }
                     Instruction::F32Trunc => {
                         if let Some(Value::F32(a)) = operand_stack.pop() {
-                            let result = a.value().trunc();
+                            let result = simd_ops::canonicalize_f32(a.value().trunc());
                             operand_stack.push(Value::F32(FloatBits32(result.to_bits())));
                         }
                     }
                     Instruction::F32Nearest => {
                         if let Some(Value::F32(a)) = operand_stack.pop() {
                             let f = a.value();
-                            // Round to nearest even (banker's rounding)
-                            let result = if f.fract().abs() == 0.5 {
+                            // WebAssembly nearest: round-to-nearest-even, preserving -0.0
+                            let result = if f.is_nan() || f.is_infinite() || f == 0.0 {
+                                f // preserves -0.0, +0.0, NaN, +-inf
+                            } else if f.fract().abs() == 0.5 {
                                 let floor = f.floor();
                                 if floor as i32 % 2 == 0 { floor } else { f.ceil() }
                             } else {
                                 f.round()
                             };
-                            operand_stack.push(Value::F32(FloatBits32(result.to_bits())));
+                            // Preserve sign of zero: if result is zero, sign matches input
+                            let result = if result == 0.0 && f.is_sign_negative() { -0.0_f32 } else { result };
+                            operand_stack.push(Value::F32(FloatBits32(simd_ops::canonicalize_f32(result).to_bits())));
                         }
                     }
                     Instruction::F32Sqrt => {
                         if let Some(Value::F32(a)) = operand_stack.pop() {
-                            let result = a.value().sqrt();
+                            let result = simd_ops::canonicalize_f32(a.value().sqrt());
                             operand_stack.push(Value::F32(FloatBits32(result.to_bits())));
                         }
                     }
@@ -4789,10 +4793,10 @@ impl StacklessEngine {
                         if let (Some(Value::F32(b)), Some(Value::F32(a))) = (operand_stack.pop(), operand_stack.pop()) {
                             let fa = a.value();
                             let fb = b.value();
-                            // WebAssembly spec: If either operand is NaN, return NaN
+                            // WebAssembly spec: If either operand is NaN, return canonical NaN
                             // If both are zero with different signs, return -0.0
                             let result = if fa.is_nan() || fb.is_nan() {
-                                f32::NAN
+                                f32::from_bits(0x7FC0_0000) // canonical NaN
                             } else if fa == 0.0 && fb == 0.0 {
                                 if fa.is_sign_negative() || fb.is_sign_negative() { -0.0 } else { 0.0 }
                             } else {
@@ -4805,10 +4809,10 @@ impl StacklessEngine {
                         if let (Some(Value::F32(b)), Some(Value::F32(a))) = (operand_stack.pop(), operand_stack.pop()) {
                             let fa = a.value();
                             let fb = b.value();
-                            // WebAssembly spec: If either operand is NaN, return NaN
+                            // WebAssembly spec: If either operand is NaN, return canonical NaN
                             // If both are zero with different signs, return +0.0
                             let result = if fa.is_nan() || fb.is_nan() {
-                                f32::NAN
+                                f32::from_bits(0x7FC0_0000) // canonical NaN
                             } else if fa == 0.0 && fb == 0.0 {
                                 if fa.is_sign_positive() || fb.is_sign_positive() { 0.0 } else { -0.0 }
                             } else {
@@ -4826,25 +4830,25 @@ impl StacklessEngine {
                     // F64 Arithmetic operations
                     Instruction::F64Add => {
                         if let (Some(Value::F64(b)), Some(Value::F64(a))) = (operand_stack.pop(), operand_stack.pop()) {
-                            let result = f64::from_bits(a.0) + f64::from_bits(b.0);
+                            let result = simd_ops::canonicalize_f64(f64::from_bits(a.0) + f64::from_bits(b.0));
                             operand_stack.push(Value::F64(FloatBits64(result.to_bits())));
                         }
                     }
                     Instruction::F64Sub => {
                         if let (Some(Value::F64(b)), Some(Value::F64(a))) = (operand_stack.pop(), operand_stack.pop()) {
-                            let result = f64::from_bits(a.0) - f64::from_bits(b.0);
+                            let result = simd_ops::canonicalize_f64(f64::from_bits(a.0) - f64::from_bits(b.0));
                             operand_stack.push(Value::F64(FloatBits64(result.to_bits())));
                         }
                     }
                     Instruction::F64Mul => {
                         if let (Some(Value::F64(b)), Some(Value::F64(a))) = (operand_stack.pop(), operand_stack.pop()) {
-                            let result = f64::from_bits(a.0) * f64::from_bits(b.0);
+                            let result = simd_ops::canonicalize_f64(f64::from_bits(a.0) * f64::from_bits(b.0));
                             operand_stack.push(Value::F64(FloatBits64(result.to_bits())));
                         }
                     }
                     Instruction::F64Div => {
                         if let (Some(Value::F64(b)), Some(Value::F64(a))) = (operand_stack.pop(), operand_stack.pop()) {
-                            let result = f64::from_bits(a.0) / f64::from_bits(b.0);
+                            let result = simd_ops::canonicalize_f64(f64::from_bits(a.0) / f64::from_bits(b.0));
                             operand_stack.push(Value::F64(FloatBits64(result.to_bits())));
                         }
                     }
@@ -4900,37 +4904,42 @@ impl StacklessEngine {
                     }
                     Instruction::F64Ceil => {
                         if let Some(Value::F64(a)) = operand_stack.pop() {
-                            let result = f64::from_bits(a.0).ceil();
+                            let result = simd_ops::canonicalize_f64(f64::from_bits(a.0).ceil());
                             operand_stack.push(Value::F64(FloatBits64(result.to_bits())));
                         }
                     }
                     Instruction::F64Floor => {
                         if let Some(Value::F64(a)) = operand_stack.pop() {
-                            let result = f64::from_bits(a.0).floor();
+                            let result = simd_ops::canonicalize_f64(f64::from_bits(a.0).floor());
                             operand_stack.push(Value::F64(FloatBits64(result.to_bits())));
                         }
                     }
                     Instruction::F64Trunc => {
                         if let Some(Value::F64(a)) = operand_stack.pop() {
-                            let result = f64::from_bits(a.0).trunc();
+                            let result = simd_ops::canonicalize_f64(f64::from_bits(a.0).trunc());
                             operand_stack.push(Value::F64(FloatBits64(result.to_bits())));
                         }
                     }
                     Instruction::F64Nearest => {
                         if let Some(Value::F64(a)) = operand_stack.pop() {
                             let f = f64::from_bits(a.0);
-                            let result = if f.fract().abs() == 0.5 {
+                            // WebAssembly nearest: round-to-nearest-even, preserving -0.0
+                            let result = if f.is_nan() || f.is_infinite() || f == 0.0 {
+                                f // preserves -0.0, +0.0, NaN, +-inf
+                            } else if f.fract().abs() == 0.5 {
                                 let floor = f.floor();
                                 if floor as i64 % 2 == 0 { floor } else { f.ceil() }
                             } else {
                                 f.round()
                             };
-                            operand_stack.push(Value::F64(FloatBits64(result.to_bits())));
+                            // Preserve sign of zero: if result is zero, sign matches input
+                            let result = if result == 0.0 && f.is_sign_negative() { -0.0_f64 } else { result };
+                            operand_stack.push(Value::F64(FloatBits64(simd_ops::canonicalize_f64(result).to_bits())));
                         }
                     }
                     Instruction::F64Sqrt => {
                         if let Some(Value::F64(a)) = operand_stack.pop() {
-                            let result = f64::from_bits(a.0).sqrt();
+                            let result = simd_ops::canonicalize_f64(f64::from_bits(a.0).sqrt());
                             operand_stack.push(Value::F64(FloatBits64(result.to_bits())));
                         }
                     }
@@ -4939,7 +4948,7 @@ impl StacklessEngine {
                             let fa = f64::from_bits(a.0);
                             let fb = f64::from_bits(b.0);
                             let result = if fa.is_nan() || fb.is_nan() {
-                                f64::NAN
+                                f64::from_bits(0x7FF8_0000_0000_0000) // canonical NaN
                             } else if fa == 0.0 && fb == 0.0 {
                                 if fa.is_sign_negative() || fb.is_sign_negative() { -0.0 } else { 0.0 }
                             } else {
@@ -4953,7 +4962,7 @@ impl StacklessEngine {
                             let fa = f64::from_bits(a.0);
                             let fb = f64::from_bits(b.0);
                             let result = if fa.is_nan() || fb.is_nan() {
-                                f64::NAN
+                                f64::from_bits(0x7FF8_0000_0000_0000) // canonical NaN
                             } else if fa == 0.0 && fb == 0.0 {
                                 if fa.is_sign_positive() || fb.is_sign_positive() { 0.0 } else { -0.0 }
                             } else {
@@ -5020,13 +5029,13 @@ impl StacklessEngine {
                     }
                     Instruction::F64PromoteF32 => {
                         if let Some(Value::F32(a)) = operand_stack.pop() {
-                            let result = f32::from_bits(a.0) as f64;
+                            let result = simd_ops::canonicalize_f64(f32::from_bits(a.0) as f64);
                             operand_stack.push(Value::F64(FloatBits64(result.to_bits())));
                         }
                     }
                     Instruction::F32DemoteF64 => {
                         if let Some(Value::F64(a)) = operand_stack.pop() {
-                            let result = f64::from_bits(a.0) as f32;
+                            let result = simd_ops::canonicalize_f32(f64::from_bits(a.0) as f32);
                             operand_stack.push(Value::F32(FloatBits32(result.to_bits())));
                         }
                     }
@@ -10808,7 +10817,7 @@ impl StacklessEngine {
                                     let mut result = [0u8; 16];
                                     for i in 0..4 {
                                         let f = f32::from_le_bytes([a.bytes[i*4], a.bytes[i*4+1], a.bytes[i*4+2], a.bytes[i*4+3]]);
-                                        let r = f.sqrt();
+                                        let r = simd_ops::canonicalize_f32(f.sqrt());
                                         let rb = r.to_le_bytes();
                                         result[i*4] = rb[0]; result[i*4+1] = rb[1]; result[i*4+2] = rb[2]; result[i*4+3] = rb[3];
                                     }
@@ -10826,7 +10835,7 @@ impl StacklessEngine {
                                     for i in 0..4 {
                                         let fa = f32::from_le_bytes([a.bytes[i*4], a.bytes[i*4+1], a.bytes[i*4+2], a.bytes[i*4+3]]);
                                         let fb = f32::from_le_bytes([b.bytes[i*4], b.bytes[i*4+1], b.bytes[i*4+2], b.bytes[i*4+3]]);
-                                        let r = (fa + fb).to_le_bytes();
+                                        let r = simd_ops::canonicalize_f32(fa + fb).to_le_bytes();
                                         result[i*4] = r[0]; result[i*4+1] = r[1]; result[i*4+2] = r[2]; result[i*4+3] = r[3];
                                     }
                                     operand_stack.push(Value::V128(V128::new(result)));
@@ -10839,7 +10848,7 @@ impl StacklessEngine {
                                     for i in 0..4 {
                                         let fa = f32::from_le_bytes([a.bytes[i*4], a.bytes[i*4+1], a.bytes[i*4+2], a.bytes[i*4+3]]);
                                         let fb = f32::from_le_bytes([b.bytes[i*4], b.bytes[i*4+1], b.bytes[i*4+2], b.bytes[i*4+3]]);
-                                        let r = (fa - fb).to_le_bytes();
+                                        let r = simd_ops::canonicalize_f32(fa - fb).to_le_bytes();
                                         result[i*4] = r[0]; result[i*4+1] = r[1]; result[i*4+2] = r[2]; result[i*4+3] = r[3];
                                     }
                                     operand_stack.push(Value::V128(V128::new(result)));
@@ -10852,7 +10861,7 @@ impl StacklessEngine {
                                     for i in 0..4 {
                                         let fa = f32::from_le_bytes([a.bytes[i*4], a.bytes[i*4+1], a.bytes[i*4+2], a.bytes[i*4+3]]);
                                         let fb = f32::from_le_bytes([b.bytes[i*4], b.bytes[i*4+1], b.bytes[i*4+2], b.bytes[i*4+3]]);
-                                        let r = (fa * fb).to_le_bytes();
+                                        let r = simd_ops::canonicalize_f32(fa * fb).to_le_bytes();
                                         result[i*4] = r[0]; result[i*4+1] = r[1]; result[i*4+2] = r[2]; result[i*4+3] = r[3];
                                     }
                                     operand_stack.push(Value::V128(V128::new(result)));
@@ -10865,7 +10874,7 @@ impl StacklessEngine {
                                     for i in 0..4 {
                                         let fa = f32::from_le_bytes([a.bytes[i*4], a.bytes[i*4+1], a.bytes[i*4+2], a.bytes[i*4+3]]);
                                         let fb = f32::from_le_bytes([b.bytes[i*4], b.bytes[i*4+1], b.bytes[i*4+2], b.bytes[i*4+3]]);
-                                        let r = (fa / fb).to_le_bytes();
+                                        let r = simd_ops::canonicalize_f32(fa / fb).to_le_bytes();
                                         result[i*4] = r[0]; result[i*4+1] = r[1]; result[i*4+2] = r[2]; result[i*4+3] = r[3];
                                     }
                                     operand_stack.push(Value::V128(V128::new(result)));
@@ -10883,8 +10892,7 @@ impl StacklessEngine {
                                         let fa = f32::from_le_bytes([a.bytes[i*4], a.bytes[i*4+1], a.bytes[i*4+2], a.bytes[i*4+3]]);
                                         let fb = f32::from_le_bytes([b.bytes[i*4], b.bytes[i*4+1], b.bytes[i*4+2], b.bytes[i*4+3]]);
                                         let r = if fa.is_nan() || fb.is_nan() {
-                                            // Produce a canonical NaN
-                                            f32::NAN
+                                            f32::from_bits(0x7FC0_0000) // canonical NaN
                                         } else if fa == 0.0 && fb == 0.0 {
                                             // -0 is less than +0
                                             if fa.is_sign_negative() || fb.is_sign_negative() { -0.0_f32 } else { 0.0_f32 }
@@ -10905,7 +10913,7 @@ impl StacklessEngine {
                                         let fa = f32::from_le_bytes([a.bytes[i*4], a.bytes[i*4+1], a.bytes[i*4+2], a.bytes[i*4+3]]);
                                         let fb = f32::from_le_bytes([b.bytes[i*4], b.bytes[i*4+1], b.bytes[i*4+2], b.bytes[i*4+3]]);
                                         let r = if fa.is_nan() || fb.is_nan() {
-                                            f32::NAN
+                                            f32::from_bits(0x7FC0_0000) // canonical NaN
                                         } else if fa == 0.0 && fb == 0.0 {
                                             if fa.is_sign_positive() || fb.is_sign_positive() { 0.0_f32 } else { -0.0_f32 }
                                         } else {
@@ -10987,7 +10995,7 @@ impl StacklessEngine {
                                         let mut ab = [0u8; 8];
                                         ab.copy_from_slice(&a.bytes[i*8..i*8+8]);
                                         let f = f64::from_le_bytes(ab);
-                                        let r = f.sqrt();
+                                        let r = simd_ops::canonicalize_f64(f.sqrt());
                                         result[i*8..i*8+8].copy_from_slice(&r.to_le_bytes());
                                     }
                                     operand_stack.push(Value::V128(V128::new(result)));
@@ -11008,7 +11016,7 @@ impl StacklessEngine {
                                         bb.copy_from_slice(&b.bytes[i*8..i*8+8]);
                                         let fa = f64::from_le_bytes(ab);
                                         let fb = f64::from_le_bytes(bb);
-                                        result[i*8..i*8+8].copy_from_slice(&(fa + fb).to_le_bytes());
+                                        result[i*8..i*8+8].copy_from_slice(&simd_ops::canonicalize_f64(fa + fb).to_le_bytes());
                                     }
                                     operand_stack.push(Value::V128(V128::new(result)));
                                 }
@@ -11024,7 +11032,7 @@ impl StacklessEngine {
                                         bb.copy_from_slice(&b.bytes[i*8..i*8+8]);
                                         let fa = f64::from_le_bytes(ab);
                                         let fb = f64::from_le_bytes(bb);
-                                        result[i*8..i*8+8].copy_from_slice(&(fa - fb).to_le_bytes());
+                                        result[i*8..i*8+8].copy_from_slice(&simd_ops::canonicalize_f64(fa - fb).to_le_bytes());
                                     }
                                     operand_stack.push(Value::V128(V128::new(result)));
                                 }
@@ -11040,7 +11048,7 @@ impl StacklessEngine {
                                         bb.copy_from_slice(&b.bytes[i*8..i*8+8]);
                                         let fa = f64::from_le_bytes(ab);
                                         let fb = f64::from_le_bytes(bb);
-                                        result[i*8..i*8+8].copy_from_slice(&(fa * fb).to_le_bytes());
+                                        result[i*8..i*8+8].copy_from_slice(&simd_ops::canonicalize_f64(fa * fb).to_le_bytes());
                                     }
                                     operand_stack.push(Value::V128(V128::new(result)));
                                 }
@@ -11056,7 +11064,7 @@ impl StacklessEngine {
                                         bb.copy_from_slice(&b.bytes[i*8..i*8+8]);
                                         let fa = f64::from_le_bytes(ab);
                                         let fb = f64::from_le_bytes(bb);
-                                        result[i*8..i*8+8].copy_from_slice(&(fa / fb).to_le_bytes());
+                                        result[i*8..i*8+8].copy_from_slice(&simd_ops::canonicalize_f64(fa / fb).to_le_bytes());
                                     }
                                     operand_stack.push(Value::V128(V128::new(result)));
                                 }
@@ -11077,7 +11085,7 @@ impl StacklessEngine {
                                         let fa = f64::from_le_bytes(ab);
                                         let fb = f64::from_le_bytes(bb);
                                         let r = if fa.is_nan() || fb.is_nan() {
-                                            f64::NAN
+                                            f64::from_bits(0x7FF8_0000_0000_0000) // canonical NaN
                                         } else if fa == 0.0 && fb == 0.0 {
                                             if fa.is_sign_negative() || fb.is_sign_negative() { -0.0_f64 } else { 0.0_f64 }
                                         } else {
@@ -11100,7 +11108,7 @@ impl StacklessEngine {
                                         let fa = f64::from_le_bytes(ab);
                                         let fb = f64::from_le_bytes(bb);
                                         let r = if fa.is_nan() || fb.is_nan() {
-                                            f64::NAN
+                                            f64::from_bits(0x7FF8_0000_0000_0000) // canonical NaN
                                         } else if fa == 0.0 && fb == 0.0 {
                                             if fa.is_sign_positive() || fb.is_sign_positive() { 0.0_f64 } else { -0.0_f64 }
                                         } else {
@@ -11488,12 +11496,12 @@ impl StacklessEngine {
                             }
                             0x88 => {
                                 if let Some(Value::V128(a)) = operand_stack.pop() {
-                                    operand_stack.push(Value::V128(V128::new(simd_ops::i16x8_extend_low_i8x16_u(&a.bytes))));
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::i16x8_extend_high_i8x16_s(&a.bytes))));
                                 }
                             }
                             0x89 => {
                                 if let Some(Value::V128(a)) = operand_stack.pop() {
-                                    operand_stack.push(Value::V128(V128::new(simd_ops::i16x8_extend_high_i8x16_s(&a.bytes))));
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::i16x8_extend_low_i8x16_u(&a.bytes))));
                                 }
                             }
                             0x8A => {
@@ -11639,12 +11647,12 @@ impl StacklessEngine {
                             }
                             0xA8 => {
                                 if let Some(Value::V128(a)) = operand_stack.pop() {
-                                    operand_stack.push(Value::V128(V128::new(simd_ops::i32x4_extend_low_i16x8_u(&a.bytes))));
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::i32x4_extend_high_i16x8_s(&a.bytes))));
                                 }
                             }
                             0xA9 => {
                                 if let Some(Value::V128(a)) = operand_stack.pop() {
-                                    operand_stack.push(Value::V128(V128::new(simd_ops::i32x4_extend_high_i16x8_s(&a.bytes))));
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::i32x4_extend_low_i16x8_u(&a.bytes))));
                                 }
                             }
                             0xAA => {
@@ -11764,12 +11772,12 @@ impl StacklessEngine {
                             }
                             0xC8 => {
                                 if let Some(Value::V128(a)) = operand_stack.pop() {
-                                    operand_stack.push(Value::V128(V128::new(simd_ops::i64x2_extend_low_i32x4_u(&a.bytes))));
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::i64x2_extend_high_i32x4_s(&a.bytes))));
                                 }
                             }
                             0xC9 => {
                                 if let Some(Value::V128(a)) = operand_stack.pop() {
-                                    operand_stack.push(Value::V128(V128::new(simd_ops::i64x2_extend_high_i32x4_s(&a.bytes))));
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::i64x2_extend_low_i32x4_u(&a.bytes))));
                                 }
                             }
                             0xCA => {

--- a/wrt-runtime/src/stackless/engine.rs
+++ b/wrt-runtime/src/stackless/engine.rs
@@ -473,6 +473,76 @@ fn calculate_effective_address(base: i32, offset: u64, size: u32) -> wrt_error::
     Ok(effective_addr)
 }
 
+/// Calculate effective memory address for memory64 with overflow checking.
+/// For memory64, the base address is i64 (treated as u64), and there is no 4GB limit.
+#[inline]
+fn calculate_effective_address_64(base: i64, offset: u64, size: u32) -> wrt_error::Result<u64> {
+    // Convert base to u64 (WebAssembly treats addresses as unsigned)
+    let base_u64 = base as u64;
+
+    // Check for overflow in base + offset
+    let effective_addr = base_u64
+        .checked_add(offset)
+        .ok_or_else(|| wrt_error::Error::runtime_trap("out of bounds memory access"))?;
+
+    // Check for overflow when adding access size
+    let _end_addr = effective_addr
+        .checked_add(size as u64)
+        .ok_or_else(|| wrt_error::Error::runtime_trap("out of bounds memory access"))?;
+
+    Ok(effective_addr)
+}
+
+/// Extract a memory base address from the operand stack, handling both i32 and i64.
+/// For memory64 memories, the address is i64; for memory32, it's i32.
+/// Returns (base_as_i64, is_memory64).
+#[inline]
+fn pop_memory_address(
+    operand_stack: &mut Vec<Value>,
+    instance: &Arc<crate::module_instance::ModuleInstance>,
+    memory_index: u32,
+) -> wrt_error::Result<(i64, bool)> {
+    let is_memory64 = instance.memory(memory_index)
+        .map(|mw| mw.0.ty.memory64)
+        .unwrap_or(false);
+
+    if is_memory64 {
+        match operand_stack.pop() {
+            Some(Value::I64(addr)) => Ok((addr, true)),
+            Some(other) => {
+                // Wrong type on stack - this is a validation error, but handle gracefully
+                operand_stack.push(other);
+                Err(wrt_error::Error::runtime_trap("type mismatch: expected i64 address for memory64"))
+            }
+            None => Err(wrt_error::Error::runtime_trap("stack underflow")),
+        }
+    } else {
+        match operand_stack.pop() {
+            Some(Value::I32(addr)) => Ok((addr as i64, false)),
+            Some(other) => {
+                operand_stack.push(other);
+                Err(wrt_error::Error::runtime_trap("type mismatch: expected i32 address for memory32"))
+            }
+            None => Err(wrt_error::Error::runtime_trap("stack underflow")),
+        }
+    }
+}
+
+/// Calculate the effective address from a base address, handling both memory32 and memory64.
+#[inline]
+fn effective_address_for_memory(
+    base: i64,
+    offset: u64,
+    size: u32,
+    is_memory64: bool,
+) -> wrt_error::Result<u64> {
+    if is_memory64 {
+        calculate_effective_address_64(base, offset, size)
+    } else {
+        calculate_effective_address(base as i32, offset, size)
+    }
+}
+
 impl StacklessEngine {
     /// Create a new stackless engine
     #[cfg(any(feature = "std", feature = "alloc"))]
@@ -1694,6 +1764,8 @@ impl StacklessEngine {
                                     wrt_foundation::ValueType::I64 => Value::I64(0),
                                     wrt_foundation::ValueType::F32 => Value::F32(FloatBits32(0)),
                                     wrt_foundation::ValueType::F64 => Value::F64(FloatBits64(0)),
+                                    wrt_foundation::ValueType::FuncRef => Value::FuncRef(None),
+                                    wrt_foundation::ValueType::ExternRef => Value::ExternRef(None),
                                     _ => Value::I32(0),
                                 };
                                 results.push(default_value);
@@ -1858,6 +1930,8 @@ impl StacklessEngine {
                             wrt_foundation::ValueType::I64 => Value::I64(0),
                             wrt_foundation::ValueType::F32 => Value::F32(FloatBits32(0)),
                             wrt_foundation::ValueType::F64 => Value::F64(FloatBits64(0)),
+                            wrt_foundation::ValueType::FuncRef => Value::FuncRef(None),
+                            wrt_foundation::ValueType::ExternRef => Value::ExternRef(None),
                             _ => Value::I32(0),
                         };
                         locals.push(default_value);
@@ -1877,6 +1951,8 @@ impl StacklessEngine {
                             wrt_foundation::ValueType::I64 => Value::I64(0),
                             wrt_foundation::ValueType::F32 => Value::F32(FloatBits32(0)),
                             wrt_foundation::ValueType::F64 => Value::F64(FloatBits64(0)),
+                            wrt_foundation::ValueType::FuncRef => Value::FuncRef(None),
+                            wrt_foundation::ValueType::ExternRef => Value::ExternRef(None),
                             _ => Value::I32(0),
                         };
                         for _ in 0..local_decl.count {
@@ -4091,60 +4167,45 @@ impl StacklessEngine {
                     // IMPORTANT: Use instance.memory() for initialized memory, not module.get_memory()
                     // The instance has data segments applied, the module is just a template
                     Instruction::I32Load(mem_arg) => {
-                        if let Some(Value::I32(addr)) = operand_stack.pop() {
-                            // Calculate effective address with overflow checking (4 bytes for i32)
-                            let offset = calculate_effective_address(addr, mem_arg.offset, 4)? as u32;
-                            #[cfg(feature = "tracing")]
-                            trace!("I32Load: reading from address {} (base={}, offset={})", offset, addr, mem_arg.offset);
-                            // Get memory from INSTANCE (not module) - instance has initialized data
-                            match instance.memory(mem_arg.memory_index as u32) {
-                                Ok(memory_wrapper) => {
-                                    let memory = &memory_wrapper.0;
-                                    let mut buffer = [0u8; 4];
-                                    match memory.read(offset, &mut buffer) {
-                                        Ok(()) => {
-                                            let value = i32::from_le_bytes(buffer);
-                                            #[cfg(feature = "tracing")]
-                                            trace!("I32Load: read value {} from address {}", value, offset);
-                                            operand_stack.push(Value::I32(value));
-                                        }
-                                        Err(e) => {
-                                            #[cfg(feature = "tracing")]
-                                            trace!("I32Load: memory read failed: {:?}", e);
-                                            #[cfg(feature = "tracing")]
-                                            error!(
-                                                offset = format_args!("0x{:x}", offset),
-                                                base = format_args!("0x{:x}", addr as u32),
-                                                mem_arg_offset = mem_arg.offset,
-                                                func_idx = func_idx,
-                                                pc = pc,
-                                                "[MEM-OOB] I32Load failed"
-                                            );
-                                            return Err(wrt_error::Error::runtime_trap("out of bounds memory access"));
-                                        }
+                        let (addr, is_mem64) = pop_memory_address(&mut operand_stack, &instance, mem_arg.memory_index as u32)?;
+                        let offset = effective_address_for_memory(addr, mem_arg.offset, 4, is_mem64)? as u32;
+                        #[cfg(feature = "tracing")]
+                        trace!("I32Load: reading from address {} (base={}, offset={})", offset, addr, mem_arg.offset);
+                        match instance.memory(mem_arg.memory_index as u32) {
+                            Ok(memory_wrapper) => {
+                                let memory = &memory_wrapper.0;
+                                let mut buffer = [0u8; 4];
+                                match memory.read(offset, &mut buffer) {
+                                    Ok(()) => {
+                                        let value = i32::from_le_bytes(buffer);
+                                        #[cfg(feature = "tracing")]
+                                        trace!("I32Load: read value {} from address {}", value, offset);
+                                        operand_stack.push(Value::I32(value));
+                                    }
+                                    Err(_e) => {
+                                        #[cfg(feature = "tracing")]
+                                        trace!("I32Load: memory read failed: {:?}", _e);
+                                        return Err(wrt_error::Error::runtime_trap("out of bounds memory access"));
                                     }
                                 }
-                                Err(e) => {
-                                    #[cfg(feature = "tracing")]
-                                    trace!("I32Load: failed to get memory at index {}: {:?}", mem_arg.memory_index, e);
-                                    return Err(wrt_error::Error::runtime_trap("out of bounds memory access"));
-                                }
+                            }
+                            Err(_e) => {
+                                #[cfg(feature = "tracing")]
+                                trace!("I32Load: failed to get memory at index {}: {:?}", mem_arg.memory_index, _e);
+                                return Err(wrt_error::Error::runtime_trap("out of bounds memory access"));
                             }
                         }
                     }
                     Instruction::I32Store(mem_arg) => {
-                        if let (Some(Value::I32(value)), Some(Value::I32(addr))) = (operand_stack.pop(), operand_stack.pop()) {
-                            // Calculate effective address with overflow checking (4 bytes for i32)
-                            let offset = calculate_effective_address(addr, mem_arg.offset, 4)? as u32;
+                        if let Some(Value::I32(value)) = operand_stack.pop() {
+                            let (addr, is_mem64) = pop_memory_address(&mut operand_stack, &instance, mem_arg.memory_index as u32)?;
+                            let offset = effective_address_for_memory(addr, mem_arg.offset, 4, is_mem64)? as u32;
                             #[cfg(feature = "tracing")]
                             trace!("I32Store: writing value {} to address {} (base={}, offset={})", value, offset, addr, mem_arg.offset);
-
-                            // Get memory from INSTANCE (not module) - instance has initialized data
                             match instance.memory(mem_arg.memory_index as u32) {
                                 Ok(memory_wrapper) => {
                                     let memory = &memory_wrapper.0;
                                     let bytes = value.to_le_bytes();
-                                    // ASIL-B COMPLIANT: Use write_shared for thread-safe writes
                                     match memory.write_shared(offset, &bytes) {
                                         Ok(()) => {
                                             #[cfg(feature = "tracing")]
@@ -4162,114 +4223,109 @@ impl StacklessEngine {
                         }
                     }
                     Instruction::I32Load8S(mem_arg) => {
-                        if let Some(Value::I32(addr)) = operand_stack.pop() {
-                            let offset = calculate_effective_address(addr, mem_arg.offset, 1)? as u32;
-                            #[cfg(feature = "tracing")]
-                            trace!("I32Load8S: reading from address {}", offset);
-                            match instance.memory(mem_arg.memory_index as u32) {
-                                Ok(memory_wrapper) => {
-                                    let memory = &memory_wrapper.0;
-                                    let mut buffer = [0u8; 1];
-                                    match memory.read(offset, &mut buffer) {
-                                        Ok(()) => {
-                                            let value = buffer[0] as i8 as i32; // Sign extend
-                                            #[cfg(feature = "tracing")]
-                                            trace!("I32Load8S: read value {} from address {}", value, offset);
-                                            operand_stack.push(Value::I32(value));
-                                        }
-                                        Err(_) => {
-                                            return Err(wrt_error::Error::runtime_trap("out of bounds memory access"));
-                                        }
+                        let (addr, is_mem64) = pop_memory_address(&mut operand_stack, &instance, mem_arg.memory_index as u32)?;
+                        let offset = effective_address_for_memory(addr, mem_arg.offset, 1, is_mem64)? as u32;
+                        #[cfg(feature = "tracing")]
+                        trace!("I32Load8S: reading from address {}", offset);
+                        match instance.memory(mem_arg.memory_index as u32) {
+                            Ok(memory_wrapper) => {
+                                let memory = &memory_wrapper.0;
+                                let mut buffer = [0u8; 1];
+                                match memory.read(offset, &mut buffer) {
+                                    Ok(()) => {
+                                        let value = buffer[0] as i8 as i32; // Sign extend
+                                        #[cfg(feature = "tracing")]
+                                        trace!("I32Load8S: read value {} from address {}", value, offset);
+                                        operand_stack.push(Value::I32(value));
+                                    }
+                                    Err(_) => {
+                                        return Err(wrt_error::Error::runtime_trap("out of bounds memory access"));
                                     }
                                 }
-                                Err(_) => {
-                                    return Err(wrt_error::Error::runtime_trap("out of bounds memory access"));
-                                }
+                            }
+                            Err(_) => {
+                                return Err(wrt_error::Error::runtime_trap("out of bounds memory access"));
                             }
                         }
                     }
                     Instruction::I32Load8U(mem_arg) => {
-                        if let Some(Value::I32(addr)) = operand_stack.pop() {
-                            let offset = calculate_effective_address(addr, mem_arg.offset, 1)? as u32;
-                            match instance.memory(mem_arg.memory_index as u32) {
-                                Ok(memory_wrapper) => {
-                                    let memory = &memory_wrapper.0;
-                                    let mut buffer = [0u8; 1];
-                                    match memory.read(offset, &mut buffer) {
-                                        Ok(()) => {
-                                            let value = buffer[0] as i32; // Zero extend
-                                            #[cfg(feature = "tracing")]
-                                            trace!("I32Load8U: read value {} from address {}", value, offset);
-                                            operand_stack.push(Value::I32(value));
-                                        }
-                                        Err(_) => {
-                                            return Err(wrt_error::Error::runtime_trap("out of bounds memory access"));
-                                        }
+                        let (addr, is_mem64) = pop_memory_address(&mut operand_stack, &instance, mem_arg.memory_index as u32)?;
+                        let offset = effective_address_for_memory(addr, mem_arg.offset, 1, is_mem64)? as u32;
+                        match instance.memory(mem_arg.memory_index as u32) {
+                            Ok(memory_wrapper) => {
+                                let memory = &memory_wrapper.0;
+                                let mut buffer = [0u8; 1];
+                                match memory.read(offset, &mut buffer) {
+                                    Ok(()) => {
+                                        let value = buffer[0] as i32; // Zero extend
+                                        #[cfg(feature = "tracing")]
+                                        trace!("I32Load8U: read value {} from address {}", value, offset);
+                                        operand_stack.push(Value::I32(value));
+                                    }
+                                    Err(_) => {
+                                        return Err(wrt_error::Error::runtime_trap("out of bounds memory access"));
                                     }
                                 }
-                                Err(_) => {
-                                    return Err(wrt_error::Error::runtime_trap("out of bounds memory access"));
-                                }
+                            }
+                            Err(_) => {
+                                return Err(wrt_error::Error::runtime_trap("out of bounds memory access"));
                             }
                         }
                     }
                     Instruction::I32Load16S(mem_arg) => {
-                        if let Some(Value::I32(addr)) = operand_stack.pop() {
-                            let offset = calculate_effective_address(addr, mem_arg.offset, 2)? as u32;
-                            match instance.memory(mem_arg.memory_index as u32) {
-                                Ok(memory_wrapper) => {
-                                    let memory = &memory_wrapper.0;
-                                    let mut buffer = [0u8; 2];
-                                    match memory.read(offset, &mut buffer) {
-                                        Ok(()) => {
-                                            let value = i16::from_le_bytes(buffer) as i32; // Sign extend
-                                            #[cfg(feature = "tracing")]
-                                            trace!("I32Load16S: read value {} from address {}", value, offset);
-                                            operand_stack.push(Value::I32(value));
-                                        }
-                                        Err(_) => {
-                                            return Err(wrt_error::Error::runtime_trap("out of bounds memory access"));
-                                        }
+                        let (addr, is_mem64) = pop_memory_address(&mut operand_stack, &instance, mem_arg.memory_index as u32)?;
+                        let offset = effective_address_for_memory(addr, mem_arg.offset, 2, is_mem64)? as u32;
+                        match instance.memory(mem_arg.memory_index as u32) {
+                            Ok(memory_wrapper) => {
+                                let memory = &memory_wrapper.0;
+                                let mut buffer = [0u8; 2];
+                                match memory.read(offset, &mut buffer) {
+                                    Ok(()) => {
+                                        let value = i16::from_le_bytes(buffer) as i32; // Sign extend
+                                        #[cfg(feature = "tracing")]
+                                        trace!("I32Load16S: read value {} from address {}", value, offset);
+                                        operand_stack.push(Value::I32(value));
+                                    }
+                                    Err(_) => {
+                                        return Err(wrt_error::Error::runtime_trap("out of bounds memory access"));
                                     }
                                 }
-                                Err(_) => {
-                                    return Err(wrt_error::Error::runtime_trap("out of bounds memory access"));
-                                }
+                            }
+                            Err(_) => {
+                                return Err(wrt_error::Error::runtime_trap("out of bounds memory access"));
                             }
                         }
                     }
                     Instruction::I32Load16U(mem_arg) => {
-                        if let Some(Value::I32(addr)) = operand_stack.pop() {
-                            let offset = calculate_effective_address(addr, mem_arg.offset, 2)? as u32;
-                            match instance.memory(mem_arg.memory_index as u32) {
-                                Ok(memory_wrapper) => {
-                                    let memory = &memory_wrapper.0;
-                                    let mut buffer = [0u8; 2];
-                                    match memory.read(offset, &mut buffer) {
-                                        Ok(()) => {
-                                            let value = u16::from_le_bytes(buffer) as i32; // Zero extend
-                                            #[cfg(feature = "tracing")]
-                                            trace!("I32Load16U: read value {} from address {}", value, offset);
-                                            operand_stack.push(Value::I32(value));
-                                        }
-                                        Err(_) => {
-                                            return Err(wrt_error::Error::runtime_trap("out of bounds memory access"));
-                                        }
+                        let (addr, is_mem64) = pop_memory_address(&mut operand_stack, &instance, mem_arg.memory_index as u32)?;
+                        let offset = effective_address_for_memory(addr, mem_arg.offset, 2, is_mem64)? as u32;
+                        match instance.memory(mem_arg.memory_index as u32) {
+                            Ok(memory_wrapper) => {
+                                let memory = &memory_wrapper.0;
+                                let mut buffer = [0u8; 2];
+                                match memory.read(offset, &mut buffer) {
+                                    Ok(()) => {
+                                        let value = u16::from_le_bytes(buffer) as i32; // Zero extend
+                                        #[cfg(feature = "tracing")]
+                                        trace!("I32Load16U: read value {} from address {}", value, offset);
+                                        operand_stack.push(Value::I32(value));
+                                    }
+                                    Err(_) => {
+                                        return Err(wrt_error::Error::runtime_trap("out of bounds memory access"));
                                     }
                                 }
-                                Err(_) => {
-                                    return Err(wrt_error::Error::runtime_trap("out of bounds memory access"));
-                                }
+                            }
+                            Err(_) => {
+                                return Err(wrt_error::Error::runtime_trap("out of bounds memory access"));
                             }
                         }
                     }
                     Instruction::I32Store8(mem_arg) => {
-                        if let (Some(Value::I32(value)), Some(Value::I32(addr))) = (operand_stack.pop(), operand_stack.pop()) {
-                            let offset = calculate_effective_address(addr, mem_arg.offset, 1)? as u32;
-
+                        if let Some(Value::I32(value)) = operand_stack.pop() {
+                            let (addr, is_mem64) = pop_memory_address(&mut operand_stack, &instance, mem_arg.memory_index)?;
+                            let offset = effective_address_for_memory(addr, mem_arg.offset, 1, is_mem64)? as u32;
                             #[cfg(feature = "tracing")]
                             trace!("I32Store8: writing byte {} to address {}", value & 0xFF, offset);
-
                             match instance.memory(mem_arg.memory_index) {
                                 Ok(memory_wrapper) => {
                                     let memory = &memory_wrapper.0;
@@ -4288,8 +4344,9 @@ impl StacklessEngine {
                         }
                     }
                     Instruction::I32Store16(mem_arg) => {
-                        if let (Some(Value::I32(value)), Some(Value::I32(addr))) = (operand_stack.pop(), operand_stack.pop()) {
-                            let offset = calculate_effective_address(addr, mem_arg.offset, 2)? as u32;
+                        if let Some(Value::I32(value)) = operand_stack.pop() {
+                            let (addr, is_mem64) = pop_memory_address(&mut operand_stack, &instance, mem_arg.memory_index as u32)?;
+                            let offset = effective_address_for_memory(addr, mem_arg.offset, 2, is_mem64)? as u32;
                             match instance.memory(mem_arg.memory_index as u32) {
                                 Ok(memory_wrapper) => {
                                     let memory = &memory_wrapper.0;
@@ -4311,58 +4368,37 @@ impl StacklessEngine {
                         }
                     }
                     Instruction::I64Load(mem_arg) => {
-                        if let Some(Value::I32(addr)) = operand_stack.pop() {
-                            let offset = calculate_effective_address(addr, mem_arg.offset, 8)? as u32;
-                            match instance.memory(mem_arg.memory_index as u32) {
-                                Ok(memory_wrapper) => {
-                                    let memory = &memory_wrapper.0;
-                                    let mut buffer = [0u8; 8];
-                                    match memory.read(offset, &mut buffer) {
-                                        Ok(()) => {
-                                            let value = i64::from_le_bytes(buffer);
-                                            #[cfg(feature = "tracing")]
-                                            trace!("I64Load: read value {} from address {}", value, offset);
-                                            #[cfg(all(feature = "std", feature = "tracing"))]
-                                            {
-                                                trace!(
-                                                    value = value,
-                                                    value_hex = format_args!("0x{:x}", value as u64),
-                                                    offset = format_args!("{:#x}", offset),
-                                                    "[I64Load] 64-bit load"
-                                                );
-                                                // Debug: show memory identity for datetime location
-                                                if offset >= 0xffe40 && offset <= 0xffe50 {
-                                                    // Get pointer to the actual Memory data via Arc::as_ptr
-                                                    use std::sync::Arc;
-                                                    let arc_ptr = Arc::as_ptr(&memory_wrapper.0);
-                                                    trace!(
-                                                        instance_id = instance_id,
-                                                        memory_arc_ptr = format_args!("{:p}", arc_ptr),
-                                                        "[I64Load-DEBUG] Datetime memory access"
-                                                    );
-                                                }
-                                            }
-                                            operand_stack.push(Value::I64(value));
-                                        }
-                                        Err(_) => {
-                                            return Err(wrt_error::Error::runtime_trap("out of bounds memory access"));
-                                        }
+                        let (addr, is_mem64) = pop_memory_address(&mut operand_stack, &instance, mem_arg.memory_index as u32)?;
+                        let offset = effective_address_for_memory(addr, mem_arg.offset, 8, is_mem64)? as u32;
+                        match instance.memory(mem_arg.memory_index as u32) {
+                            Ok(memory_wrapper) => {
+                                let memory = &memory_wrapper.0;
+                                let mut buffer = [0u8; 8];
+                                match memory.read(offset, &mut buffer) {
+                                    Ok(()) => {
+                                        let value = i64::from_le_bytes(buffer);
+                                        #[cfg(feature = "tracing")]
+                                        trace!("I64Load: read value {} from address {}", value, offset);
+                                        operand_stack.push(Value::I64(value));
+                                    }
+                                    Err(_) => {
+                                        return Err(wrt_error::Error::runtime_trap("out of bounds memory access"));
                                     }
                                 }
-                                Err(_) => {
-                                    return Err(wrt_error::Error::runtime_trap("out of bounds memory access"));
-                                }
+                            }
+                            Err(_) => {
+                                return Err(wrt_error::Error::runtime_trap("out of bounds memory access"));
                             }
                         }
                     }
                     Instruction::I64Store(mem_arg) => {
-                        if let (Some(Value::I64(value)), Some(Value::I32(addr))) = (operand_stack.pop(), operand_stack.pop()) {
-                            let offset = calculate_effective_address(addr, mem_arg.offset, 8)? as u32;
+                        if let Some(Value::I64(value)) = operand_stack.pop() {
+                            let (addr, is_mem64) = pop_memory_address(&mut operand_stack, &instance, mem_arg.memory_index as u32)?;
+                            let offset = effective_address_for_memory(addr, mem_arg.offset, 8, is_mem64)? as u32;
                             match instance.memory(mem_arg.memory_index as u32) {
                                 Ok(memory_wrapper) => {
                                     let memory = &memory_wrapper.0;
                                     let bytes = value.to_le_bytes();
-                                    // ASIL-B COMPLIANT: Use write_shared for thread-safe writes
                                     match memory.write_shared(offset, &bytes) {
                                         Ok(()) => {
                                             #[cfg(feature = "tracing")]
@@ -4385,194 +4421,134 @@ impl StacklessEngine {
                     // I64 Partial Load Instructions (load narrower value, extend to i64)
                     // ========================================
                     Instruction::I64Load8S(mem_arg) => {
-                        if let Some(Value::I32(addr)) = operand_stack.pop() {
-                            let offset = calculate_effective_address(addr, mem_arg.offset, 1)? as u32;
-                            #[cfg(feature = "tracing")]
-                            trace!(
-                                instance_id = instance_id,
-                                addr = addr,
-                                offset = format_args!("{:#x}", offset),
-                                "[I64Load8S] Signed byte load to i64"
-                            );
-                            match instance.memory(mem_arg.memory_index as u32) {
-                                Ok(memory_wrapper) => {
-                                    let memory = &memory_wrapper.0;
-                                    let mut buffer = [0u8; 1];
-                                    match memory.read(offset, &mut buffer) {
-                                        Ok(()) => {
-                                            let value = buffer[0] as i8 as i64; // Sign extend
-                                            #[cfg(feature = "tracing")]
-                                            trace!("I64Load8S: read value {} from address {}", value, offset);
-                                            operand_stack.push(Value::I64(value));
-                                        }
-                                        Err(_) => {
-                                            return Err(wrt_error::Error::runtime_trap("out of bounds memory access"));
-                                        }
+                        let (addr, is_mem64) = pop_memory_address(&mut operand_stack, &instance, mem_arg.memory_index as u32)?;
+                        let offset = effective_address_for_memory(addr, mem_arg.offset, 1, is_mem64)? as u32;
+                        match instance.memory(mem_arg.memory_index as u32) {
+                            Ok(memory_wrapper) => {
+                                let memory = &memory_wrapper.0;
+                                let mut buffer = [0u8; 1];
+                                match memory.read(offset, &mut buffer) {
+                                    Ok(()) => {
+                                        let value = buffer[0] as i8 as i64; // Sign extend
+                                        operand_stack.push(Value::I64(value));
+                                    }
+                                    Err(_) => {
+                                        return Err(wrt_error::Error::runtime_trap("out of bounds memory access"));
                                     }
                                 }
-                                Err(_) => {
-                                    return Err(wrt_error::Error::runtime_trap("out of bounds memory access"));
-                                }
+                            }
+                            Err(_) => {
+                                return Err(wrt_error::Error::runtime_trap("out of bounds memory access"));
                             }
                         }
                     }
                     Instruction::I64Load8U(mem_arg) => {
-                        if let Some(Value::I32(addr)) = operand_stack.pop() {
-                            let offset = calculate_effective_address(addr, mem_arg.offset, 1)? as u32;
-                            #[cfg(feature = "tracing")]
-                            trace!(
-                                instance_id = instance_id,
-                                addr = addr,
-                                offset = format_args!("{:#x}", offset),
-                                "[I64Load8U] Unsigned byte load to i64"
-                            );
-                            match instance.memory(mem_arg.memory_index as u32) {
-                                Ok(memory_wrapper) => {
-                                    let memory = &memory_wrapper.0;
-                                    let mut buffer = [0u8; 1];
-                                    match memory.read(offset, &mut buffer) {
-                                        Ok(()) => {
-                                            let value = buffer[0] as i64; // Zero extend
-                                            #[cfg(feature = "tracing")]
-                                            trace!("I64Load8U: read value {} from address {}", value, offset);
-                                            operand_stack.push(Value::I64(value));
-                                        }
-                                        Err(_) => {
-                                            return Err(wrt_error::Error::runtime_trap("out of bounds memory access"));
-                                        }
+                        let (addr, is_mem64) = pop_memory_address(&mut operand_stack, &instance, mem_arg.memory_index as u32)?;
+                        let offset = effective_address_for_memory(addr, mem_arg.offset, 1, is_mem64)? as u32;
+                        match instance.memory(mem_arg.memory_index as u32) {
+                            Ok(memory_wrapper) => {
+                                let memory = &memory_wrapper.0;
+                                let mut buffer = [0u8; 1];
+                                match memory.read(offset, &mut buffer) {
+                                    Ok(()) => {
+                                        let value = buffer[0] as i64; // Zero extend
+                                        operand_stack.push(Value::I64(value));
+                                    }
+                                    Err(_) => {
+                                        return Err(wrt_error::Error::runtime_trap("out of bounds memory access"));
                                     }
                                 }
-                                Err(_) => {
-                                    return Err(wrt_error::Error::runtime_trap("out of bounds memory access"));
-                                }
+                            }
+                            Err(_) => {
+                                return Err(wrt_error::Error::runtime_trap("out of bounds memory access"));
                             }
                         }
                     }
                     Instruction::I64Load16S(mem_arg) => {
-                        if let Some(Value::I32(addr)) = operand_stack.pop() {
-                            let offset = calculate_effective_address(addr, mem_arg.offset, 2)? as u32;
-                            #[cfg(feature = "tracing")]
-                            trace!(
-                                instance_id = instance_id,
-                                addr = addr,
-                                offset = format_args!("{:#x}", offset),
-                                "[I64Load16S] Signed 16-bit load to i64"
-                            );
-                            match instance.memory(mem_arg.memory_index as u32) {
-                                Ok(memory_wrapper) => {
-                                    let memory = &memory_wrapper.0;
-                                    let mut buffer = [0u8; 2];
-                                    match memory.read(offset, &mut buffer) {
-                                        Ok(()) => {
-                                            let value = i16::from_le_bytes(buffer) as i64; // Sign extend
-                                            #[cfg(feature = "tracing")]
-                                            trace!("I64Load16S: read value {} from address {}", value, offset);
-                                            operand_stack.push(Value::I64(value));
-                                        }
-                                        Err(_) => {
-                                            return Err(wrt_error::Error::runtime_trap("out of bounds memory access"));
-                                        }
+                        let (addr, is_mem64) = pop_memory_address(&mut operand_stack, &instance, mem_arg.memory_index as u32)?;
+                        let offset = effective_address_for_memory(addr, mem_arg.offset, 2, is_mem64)? as u32;
+                        match instance.memory(mem_arg.memory_index as u32) {
+                            Ok(memory_wrapper) => {
+                                let memory = &memory_wrapper.0;
+                                let mut buffer = [0u8; 2];
+                                match memory.read(offset, &mut buffer) {
+                                    Ok(()) => {
+                                        let value = i16::from_le_bytes(buffer) as i64; // Sign extend
+                                        operand_stack.push(Value::I64(value));
+                                    }
+                                    Err(_) => {
+                                        return Err(wrt_error::Error::runtime_trap("out of bounds memory access"));
                                     }
                                 }
-                                Err(_) => {
-                                    return Err(wrt_error::Error::runtime_trap("out of bounds memory access"));
-                                }
+                            }
+                            Err(_) => {
+                                return Err(wrt_error::Error::runtime_trap("out of bounds memory access"));
                             }
                         }
                     }
                     Instruction::I64Load16U(mem_arg) => {
-                        if let Some(Value::I32(addr)) = operand_stack.pop() {
-                            let offset = calculate_effective_address(addr, mem_arg.offset, 2)? as u32;
-                            #[cfg(feature = "tracing")]
-                            trace!(
-                                instance_id = instance_id,
-                                addr = addr,
-                                offset = format_args!("{:#x}", offset),
-                                "[I64Load16U] Unsigned 16-bit load to i64"
-                            );
-                            match instance.memory(mem_arg.memory_index as u32) {
-                                Ok(memory_wrapper) => {
-                                    let memory = &memory_wrapper.0;
-                                    let mut buffer = [0u8; 2];
-                                    match memory.read(offset, &mut buffer) {
-                                        Ok(()) => {
-                                            let value = u16::from_le_bytes(buffer) as i64; // Zero extend
-                                            #[cfg(feature = "tracing")]
-                                            trace!("I64Load16U: read value {} from address {}", value, offset);
-                                            operand_stack.push(Value::I64(value));
-                                        }
-                                        Err(_) => {
-                                            return Err(wrt_error::Error::runtime_trap("out of bounds memory access"));
-                                        }
+                        let (addr, is_mem64) = pop_memory_address(&mut operand_stack, &instance, mem_arg.memory_index as u32)?;
+                        let offset = effective_address_for_memory(addr, mem_arg.offset, 2, is_mem64)? as u32;
+                        match instance.memory(mem_arg.memory_index as u32) {
+                            Ok(memory_wrapper) => {
+                                let memory = &memory_wrapper.0;
+                                let mut buffer = [0u8; 2];
+                                match memory.read(offset, &mut buffer) {
+                                    Ok(()) => {
+                                        let value = u16::from_le_bytes(buffer) as i64; // Zero extend
+                                        operand_stack.push(Value::I64(value));
+                                    }
+                                    Err(_) => {
+                                        return Err(wrt_error::Error::runtime_trap("out of bounds memory access"));
                                     }
                                 }
-                                Err(_) => {
-                                    return Err(wrt_error::Error::runtime_trap("out of bounds memory access"));
-                                }
+                            }
+                            Err(_) => {
+                                return Err(wrt_error::Error::runtime_trap("out of bounds memory access"));
                             }
                         }
                     }
                     Instruction::I64Load32S(mem_arg) => {
-                        if let Some(Value::I32(addr)) = operand_stack.pop() {
-                            let offset = calculate_effective_address(addr, mem_arg.offset, 4)? as u32;
-                            #[cfg(feature = "tracing")]
-                            trace!(
-                                instance_id = instance_id,
-                                addr = addr,
-                                offset = format_args!("{:#x}", offset),
-                                "[I64Load32S] Signed 32-bit load to i64"
-                            );
-                            match instance.memory(mem_arg.memory_index as u32) {
-                                Ok(memory_wrapper) => {
-                                    let memory = &memory_wrapper.0;
-                                    let mut buffer = [0u8; 4];
-                                    match memory.read(offset, &mut buffer) {
-                                        Ok(()) => {
-                                            let value = i32::from_le_bytes(buffer) as i64; // Sign extend
-                                            #[cfg(feature = "tracing")]
-                                            trace!("I64Load32S: read value {} from address {}", value, offset);
-                                            operand_stack.push(Value::I64(value));
-                                        }
-                                        Err(_) => {
-                                            return Err(wrt_error::Error::runtime_trap("out of bounds memory access"));
-                                        }
+                        let (addr, is_mem64) = pop_memory_address(&mut operand_stack, &instance, mem_arg.memory_index as u32)?;
+                        let offset = effective_address_for_memory(addr, mem_arg.offset, 4, is_mem64)? as u32;
+                        match instance.memory(mem_arg.memory_index as u32) {
+                            Ok(memory_wrapper) => {
+                                let memory = &memory_wrapper.0;
+                                let mut buffer = [0u8; 4];
+                                match memory.read(offset, &mut buffer) {
+                                    Ok(()) => {
+                                        let value = i32::from_le_bytes(buffer) as i64; // Sign extend
+                                        operand_stack.push(Value::I64(value));
+                                    }
+                                    Err(_) => {
+                                        return Err(wrt_error::Error::runtime_trap("out of bounds memory access"));
                                     }
                                 }
-                                Err(_) => {
-                                    return Err(wrt_error::Error::runtime_trap("out of bounds memory access"));
-                                }
+                            }
+                            Err(_) => {
+                                return Err(wrt_error::Error::runtime_trap("out of bounds memory access"));
                             }
                         }
                     }
                     Instruction::I64Load32U(mem_arg) => {
-                        if let Some(Value::I32(addr)) = operand_stack.pop() {
-                            let offset = calculate_effective_address(addr, mem_arg.offset, 4)? as u32;
-                            #[cfg(feature = "tracing")]
-                            trace!(
-                                instance_id = instance_id,
-                                addr = addr,
-                                offset = format_args!("{:#x}", offset),
-                                "[I64Load32U] Unsigned 32-bit load to i64"
-                            );
-                            match instance.memory(mem_arg.memory_index as u32) {
-                                Ok(memory_wrapper) => {
-                                    let memory = &memory_wrapper.0;
-                                    let mut buffer = [0u8; 4];
-                                    match memory.read(offset, &mut buffer) {
-                                        Ok(()) => {
-                                            let value = u32::from_le_bytes(buffer) as i64; // Zero extend
-                                            #[cfg(feature = "tracing")]
-                                            trace!("I64Load32U: read value {} from address {}", value, offset);
-                                            operand_stack.push(Value::I64(value));
-                                        }
-                                        Err(_) => {
-                                            return Err(wrt_error::Error::runtime_trap("out of bounds memory access"));
-                                        }
+                        let (addr, is_mem64) = pop_memory_address(&mut operand_stack, &instance, mem_arg.memory_index as u32)?;
+                        let offset = effective_address_for_memory(addr, mem_arg.offset, 4, is_mem64)? as u32;
+                        match instance.memory(mem_arg.memory_index as u32) {
+                            Ok(memory_wrapper) => {
+                                let memory = &memory_wrapper.0;
+                                let mut buffer = [0u8; 4];
+                                match memory.read(offset, &mut buffer) {
+                                    Ok(()) => {
+                                        let value = u32::from_le_bytes(buffer) as i64; // Zero extend
+                                        operand_stack.push(Value::I64(value));
+                                    }
+                                    Err(_) => {
+                                        return Err(wrt_error::Error::runtime_trap("out of bounds memory access"));
                                     }
                                 }
-                                Err(_) => {
-                                    return Err(wrt_error::Error::runtime_trap("out of bounds memory access"));
-                                }
+                            }
+                            Err(_) => {
+                                return Err(wrt_error::Error::runtime_trap("out of bounds memory access"));
                             }
                         }
                     }
@@ -4580,94 +4556,57 @@ impl StacklessEngine {
                     // I64 Partial Store Instructions (store lower bits of i64)
                     // ========================================
                     Instruction::I64Store8(mem_arg) => {
-                        if let (Some(Value::I64(value)), Some(Value::I32(addr))) = (operand_stack.pop(), operand_stack.pop()) {
-                            let offset = calculate_effective_address(addr, mem_arg.offset, 1)? as u32;
-                            #[cfg(feature = "tracing")]
-                            trace!(
-                                instance_id = instance_id,
-                                addr = addr,
-                                offset = format_args!("{:#x}", offset),
-                                value = value & 0xFF,
-                                "[I64Store8] Store low 8 bits of i64"
-                            );
+                        if let Some(Value::I64(value)) = operand_stack.pop() {
+                            let (addr, is_mem64) = pop_memory_address(&mut operand_stack, &instance, mem_arg.memory_index as u32)?;
+                            let offset = effective_address_for_memory(addr, mem_arg.offset, 1, is_mem64)? as u32;
                             match instance.memory(mem_arg.memory_index as u32) {
                                 Ok(memory_wrapper) => {
                                     let memory = &memory_wrapper.0;
                                     let bytes = [(value & 0xFF) as u8];
-                                    // ASIL-B COMPLIANT: Use write_shared for thread-safe writes
                                     match memory.write_shared(offset, &bytes) {
-                                        Ok(()) => {
-                                            #[cfg(feature = "tracing")]
-                                            trace!("I64Store8: successfully wrote value {} to address {}", value & 0xFF, offset);
-                                        }
+                                        Ok(()) => {}
                                         Err(_e) => {
                                             return Err(wrt_error::Error::runtime_trap("out of bounds memory access"));
                                         }
                                     }
                                 }
                                 Err(_e) => {
-                                    #[cfg(feature = "tracing")]
-                                    trace!("I64Store8: failed to get memory at index {}", mem_arg.memory_index);
                                     return Err(wrt_error::Error::runtime_trap("out of bounds memory access"));
                                 }
                             }
                         }
                     }
                     Instruction::I64Store16(mem_arg) => {
-                        if let (Some(Value::I64(value)), Some(Value::I32(addr))) = (operand_stack.pop(), operand_stack.pop()) {
-                            let offset = calculate_effective_address(addr, mem_arg.offset, 2)? as u32;
-                            #[cfg(feature = "tracing")]
-                            trace!(
-                                instance_id = instance_id,
-                                addr = addr,
-                                offset = format_args!("{:#x}", offset),
-                                value = value & 0xFFFF,
-                                "[I64Store16] Store low 16 bits of i64"
-                            );
+                        if let Some(Value::I64(value)) = operand_stack.pop() {
+                            let (addr, is_mem64) = pop_memory_address(&mut operand_stack, &instance, mem_arg.memory_index as u32)?;
+                            let offset = effective_address_for_memory(addr, mem_arg.offset, 2, is_mem64)? as u32;
                             match instance.memory(mem_arg.memory_index as u32) {
                                 Ok(memory_wrapper) => {
                                     let memory = &memory_wrapper.0;
                                     let bytes = (value as u16).to_le_bytes();
-                                    // ASIL-B COMPLIANT: Use write_shared for thread-safe writes
                                     match memory.write_shared(offset, &bytes) {
-                                        Ok(()) => {
-                                            #[cfg(feature = "tracing")]
-                                            trace!("I64Store16: successfully wrote value {} to address {}", value & 0xFFFF, offset);
-                                        }
+                                        Ok(()) => {}
                                         Err(_e) => {
                                             return Err(wrt_error::Error::runtime_trap("out of bounds memory access"));
                                         }
                                     }
                                 }
                                 Err(_e) => {
-                                    #[cfg(feature = "tracing")]
-                                    trace!("I64Store16: failed to get memory at index {}", mem_arg.memory_index);
                                     return Err(wrt_error::Error::runtime_trap("out of bounds memory access"));
                                 }
                             }
                         }
                     }
                     Instruction::I64Store32(mem_arg) => {
-                        if let (Some(Value::I64(value)), Some(Value::I32(addr))) = (operand_stack.pop(), operand_stack.pop()) {
-                            let offset = calculate_effective_address(addr, mem_arg.offset, 4)? as u32;
-                            #[cfg(feature = "tracing")]
-                            trace!(
-                                instance_id = instance_id,
-                                addr = addr,
-                                offset = format_args!("{:#x}", offset),
-                                value = value & 0xFFFFFFFF,
-                                "[I64Store32] Store low 32 bits of i64"
-                            );
+                        if let Some(Value::I64(value)) = operand_stack.pop() {
+                            let (addr, is_mem64) = pop_memory_address(&mut operand_stack, &instance, mem_arg.memory_index as u32)?;
+                            let offset = effective_address_for_memory(addr, mem_arg.offset, 4, is_mem64)? as u32;
                             match instance.memory(mem_arg.memory_index as u32) {
                                 Ok(memory_wrapper) => {
                                     let memory = &memory_wrapper.0;
                                     let bytes = (value as u32).to_le_bytes();
-                                    // ASIL-B COMPLIANT: Use write_shared for thread-safe writes
                                     match memory.write_shared(offset, &bytes) {
-                                        Ok(()) => {
-                                            #[cfg(feature = "tracing")]
-                                            trace!("I64Store32: successfully wrote value {} to address {}", value & 0xFFFFFFFF, offset);
-                                        }
+                                        Ok(()) => {}
                                         Err(_e) => {
                                             return Err(wrt_error::Error::runtime_trap("out of bounds memory access"));
                                         }
@@ -4690,46 +4629,31 @@ impl StacklessEngine {
                         operand_stack.push(Value::F64(FloatBits64(bits)));
                     }
                     Instruction::F32Load(mem_arg) => {
-                        #[cfg(feature = "tracing")]
-                        trace!("F32Load: stack before pop has {} elements", operand_stack.len());
-                        if let Some(Value::I32(addr)) = operand_stack.pop() {
-                            let offset = calculate_effective_address(addr, mem_arg.offset, 4)? as u32;
-                            #[cfg(feature = "tracing")]
-                            trace!("F32Load: addr={}, offset={}, mem_idx={}", addr, offset, mem_arg.memory_index);
-                            match instance.memory(mem_arg.memory_index as u32) {
-                                Ok(memory_wrapper) => {
-                                    let memory = &memory_wrapper.0;
-                                    let mut buffer = [0u8; 4];
-                                    match memory.read(offset, &mut buffer) {
-                                        Ok(()) => {
-                                            let bits = u32::from_le_bytes(buffer);
-                                            #[cfg(feature = "tracing")]
-                                            trace!("F32Load: read bytes {:?}, bits={:#x}, pushing F32", buffer, bits);
-                                            operand_stack.push(Value::F32(FloatBits32(bits)));
-                                            #[cfg(feature = "tracing")]
-                                            trace!("F32Load: stack after push has {} elements", operand_stack.len());
-                                        }
-                                        Err(e) => {
-                                            #[cfg(feature = "tracing")]
-                                            error!("F32Load: memory read error: {:?}", e);
-                                            return Err(wrt_error::Error::runtime_trap("out of bounds memory access"));
-                                        }
+                        let (addr, is_mem64) = pop_memory_address(&mut operand_stack, &instance, mem_arg.memory_index as u32)?;
+                        let offset = effective_address_for_memory(addr, mem_arg.offset, 4, is_mem64)? as u32;
+                        match instance.memory(mem_arg.memory_index as u32) {
+                            Ok(memory_wrapper) => {
+                                let memory = &memory_wrapper.0;
+                                let mut buffer = [0u8; 4];
+                                match memory.read(offset, &mut buffer) {
+                                    Ok(()) => {
+                                        let bits = u32::from_le_bytes(buffer);
+                                        operand_stack.push(Value::F32(FloatBits32(bits)));
+                                    }
+                                    Err(_e) => {
+                                        return Err(wrt_error::Error::runtime_trap("out of bounds memory access"));
                                     }
                                 }
-                                Err(e) => {
-                                    #[cfg(feature = "tracing")]
-                                    error!("F32Load: memory access error: {:?}", e);
-                                    return Err(wrt_error::Error::runtime_trap("out of bounds memory access"));
-                                }
                             }
-                        } else {
-                            #[cfg(feature = "tracing")]
-                            error!("F32Load: stack was empty or top was not I32!");
+                            Err(_e) => {
+                                return Err(wrt_error::Error::runtime_trap("out of bounds memory access"));
+                            }
                         }
                     }
                     Instruction::F32Store(mem_arg) => {
-                        if let (Some(Value::F32(bits)), Some(Value::I32(addr))) = (operand_stack.pop(), operand_stack.pop()) {
-                            let offset = calculate_effective_address(addr, mem_arg.offset, 4)? as u32;
+                        if let Some(Value::F32(bits)) = operand_stack.pop() {
+                            let (addr, is_mem64) = pop_memory_address(&mut operand_stack, &instance, mem_arg.memory_index as u32)?;
+                            let offset = effective_address_for_memory(addr, mem_arg.offset, 4, is_mem64)? as u32;
                             match instance.memory(mem_arg.memory_index as u32) {
                                 Ok(memory_wrapper) => {
                                     let memory = &memory_wrapper.0;
@@ -4745,31 +4669,31 @@ impl StacklessEngine {
                         }
                     }
                     Instruction::F64Load(mem_arg) => {
-                        if let Some(Value::I32(addr)) = operand_stack.pop() {
-                            let offset = calculate_effective_address(addr, mem_arg.offset, 8)? as u32;
-                            match instance.memory(mem_arg.memory_index as u32) {
-                                Ok(memory_wrapper) => {
-                                    let memory = &memory_wrapper.0;
-                                    let mut buffer = [0u8; 8];
-                                    match memory.read(offset, &mut buffer) {
-                                        Ok(()) => {
-                                            let bits = u64::from_le_bytes(buffer);
-                                            operand_stack.push(Value::F64(FloatBits64(bits)));
-                                        }
-                                        Err(_) => {
-                                            return Err(wrt_error::Error::runtime_trap("out of bounds memory access"));
-                                        }
+                        let (addr, is_mem64) = pop_memory_address(&mut operand_stack, &instance, mem_arg.memory_index as u32)?;
+                        let offset = effective_address_for_memory(addr, mem_arg.offset, 8, is_mem64)? as u32;
+                        match instance.memory(mem_arg.memory_index as u32) {
+                            Ok(memory_wrapper) => {
+                                let memory = &memory_wrapper.0;
+                                let mut buffer = [0u8; 8];
+                                match memory.read(offset, &mut buffer) {
+                                    Ok(()) => {
+                                        let bits = u64::from_le_bytes(buffer);
+                                        operand_stack.push(Value::F64(FloatBits64(bits)));
+                                    }
+                                    Err(_) => {
+                                        return Err(wrt_error::Error::runtime_trap("out of bounds memory access"));
                                     }
                                 }
-                                Err(_) => {
-                                    return Err(wrt_error::Error::runtime_trap("out of bounds memory access"));
-                                }
+                            }
+                            Err(_) => {
+                                return Err(wrt_error::Error::runtime_trap("out of bounds memory access"));
                             }
                         }
                     }
                     Instruction::F64Store(mem_arg) => {
-                        if let (Some(Value::F64(bits)), Some(Value::I32(addr))) = (operand_stack.pop(), operand_stack.pop()) {
-                            let offset = calculate_effective_address(addr, mem_arg.offset, 8)? as u32;
+                        if let Some(Value::F64(bits)) = operand_stack.pop() {
+                            let (addr, is_mem64) = pop_memory_address(&mut operand_stack, &instance, mem_arg.memory_index as u32)?;
+                            let offset = effective_address_for_memory(addr, mem_arg.offset, 8, is_mem64)? as u32;
                             match instance.memory(mem_arg.memory_index as u32) {
                                 Ok(memory_wrapper) => {
                                     let memory = &memory_wrapper.0;
@@ -5659,13 +5583,20 @@ impl StacklessEngine {
                             Ok(memory_wrapper) => {
                                 let memory = &memory_wrapper.0;
                                 let size_in_pages = memory.size();
+                                let is_memory64 = memory.ty.memory64;
                                 #[cfg(feature = "tracing")]
                                 trace!(
                                     memory_idx = memory_idx,
                                     size_in_pages = size_in_pages,
+                                    is_memory64 = is_memory64,
                                     "[MemorySize] Retrieved memory size"
                                 );
-                                operand_stack.push(Value::I32(size_in_pages as i32));
+                                // memory64 returns i64, memory32 returns i32
+                                if is_memory64 {
+                                    operand_stack.push(Value::I64(size_in_pages as i64));
+                                } else {
+                                    operand_stack.push(Value::I32(size_in_pages as i32));
+                                }
                             }
                             Err(e) => {
                                 #[cfg(feature = "tracing")]
@@ -5676,50 +5607,88 @@ impl StacklessEngine {
                     }
                     Instruction::MemoryGrow(memory_idx) => {
                         // Pop the number of pages to grow
-                        if let Some(Value::I32(delta)) = operand_stack.pop() {
-                            if delta < 0 {
-                                // Negative delta is invalid, return -1 (failure)
-                                #[cfg(feature = "tracing")]
-                                trace!("MemoryGrow: negative delta {}, pushing -1", delta);
-                                operand_stack.push(Value::I32(-1));
+                        // For memory64, delta is i64; for memory32, delta is i32
+                        // First, check if this is a memory64 memory
+                        let is_memory64 = instance.memory(memory_idx as u32)
+                            .map(|mw| mw.0.ty.memory64)
+                            .unwrap_or(false);
+
+                        let delta_pages: i64 = if is_memory64 {
+                            match operand_stack.pop() {
+                                Some(Value::I64(d)) => d,
+                                _ => {
+                                    operand_stack.push(Value::I64(-1));
+                                    continue;
+                                }
+                            }
+                        } else {
+                            match operand_stack.pop() {
+                                Some(Value::I32(d)) => d as i64,
+                                _ => {
+                                    operand_stack.push(Value::I32(-1));
+                                    continue;
+                                }
+                            }
+                        };
+
+                        if delta_pages < 0 {
+                            // Negative delta is invalid, return -1 (failure)
+                            #[cfg(feature = "tracing")]
+                            trace!("MemoryGrow: negative delta {}, pushing -1", delta_pages);
+                            if is_memory64 {
+                                operand_stack.push(Value::I64(-1));
                             } else {
-                                // Use instance memory for grow (has initialized data segments)
-                                match instance.memory(memory_idx as u32) {
-                                    Ok(memory_wrapper) => {
-                                        let memory = &memory_wrapper.0;
-                                        let current_size = memory.size();
-                                        #[cfg(feature = "tracing")]
-                                        trace!(
-                                            memory_idx = memory_idx,
-                                            delta = delta,
-                                            current_size = current_size,
-                                            "[MemoryGrow] Attempting to grow memory"
-                                        );
-                                        match memory.grow_shared(delta as u32) {
-                                            Ok(prev_pages) => {
-                                                #[cfg(feature = "tracing")]
-                                                trace!(
-                                                    memory_idx = memory_idx,
-                                                    prev_pages = prev_pages,
-                                                    new_pages = prev_pages + delta as u32,
-                                                    "[MemoryGrow] Success"
-                                                );
+                                operand_stack.push(Value::I32(-1));
+                            }
+                        } else {
+                            // Use instance memory for grow (has initialized data segments)
+                            match instance.memory(memory_idx as u32) {
+                                Ok(memory_wrapper) => {
+                                    let memory = &memory_wrapper.0;
+                                    let current_size = memory.size();
+                                    #[cfg(feature = "tracing")]
+                                    trace!(
+                                        memory_idx = memory_idx,
+                                        delta = delta_pages,
+                                        current_size = current_size,
+                                        "[MemoryGrow] Attempting to grow memory"
+                                    );
+                                    match memory.grow_shared(delta_pages as u32) {
+                                        Ok(prev_pages) => {
+                                            #[cfg(feature = "tracing")]
+                                            trace!(
+                                                memory_idx = memory_idx,
+                                                prev_pages = prev_pages,
+                                                new_pages = prev_pages + delta_pages as u32,
+                                                "[MemoryGrow] Success"
+                                            );
+                                            if is_memory64 {
+                                                operand_stack.push(Value::I64(prev_pages as i64));
+                                            } else {
                                                 operand_stack.push(Value::I32(prev_pages as i32));
                                             }
-                                            Err(e) => {
-                                                #[cfg(feature = "tracing")]
-                                                warn!(
-                                                    memory_idx = memory_idx,
-                                                    error = ?e,
-                                                    "[MemoryGrow] Failed"
-                                                );
+                                        }
+                                        Err(e) => {
+                                            #[cfg(feature = "tracing")]
+                                            warn!(
+                                                memory_idx = memory_idx,
+                                                error = ?e,
+                                                "[MemoryGrow] Failed"
+                                            );
+                                            if is_memory64 {
+                                                operand_stack.push(Value::I64(-1));
+                                            } else {
                                                 operand_stack.push(Value::I32(-1));
                                             }
                                         }
                                     }
-                                    Err(e) => {
-                                        #[cfg(feature = "tracing")]
-                                        trace!("MemoryGrow: memory[{}] not found: {:?}", memory_idx, e);
+                                }
+                                Err(e) => {
+                                    #[cfg(feature = "tracing")]
+                                    trace!("MemoryGrow: memory[{}] not found: {:?}", memory_idx, e);
+                                    if is_memory64 {
+                                        operand_stack.push(Value::I64(-1));
+                                    } else {
                                         operand_stack.push(Value::I32(-1));
                                     }
                                 }
@@ -6405,27 +6374,81 @@ impl StacklessEngine {
                         }
                     }
 
+                    Instruction::BrOnNonNull(br_label_idx) => {
+                        // Pop reference, branch if non-null (keep ref), fall through if null (drop ref)
+                        if let Some(ref_val) = operand_stack.pop() {
+                            let is_null = matches!(&ref_val,
+                                Value::FuncRef(None) | Value::ExternRef(None) |
+                                Value::ExnRef(None) | Value::I31Ref(None) |
+                                Value::StructRef(None) | Value::ArrayRef(None)
+                            );
+                            #[cfg(feature = "tracing")]
+                            trace!("BrOnNonNull: label={}, is_null={}", br_label_idx, is_null);
+                            if !is_null {
+                                // Non-null: push reference back and branch
+                                operand_stack.push(ref_val);
+                                if br_label_idx as usize >= block_stack.len() {
+                                    #[cfg(feature = "tracing")]
+                                    trace!("BrOnNonNull: branching out of function");
+                                    break;
+                                }
+                                let target_depth = block_stack.len() - 1 - br_label_idx as usize;
+                                if let Some((block_type, start_pc, _block_type_idx, _entry_stack_height)) = block_stack.get(target_depth).copied() {
+                                    if block_type == "loop" {
+                                        pc = start_pc;
+                                    } else {
+                                        let mut depth = 1;
+                                        let mut search_pc = pc + 1;
+                                        while depth > 0 && search_pc < instructions.len() {
+                                            #[cfg(feature = "std")]
+                                            if let Some(search_instr) = instructions.get(search_pc) {
+                                                match search_instr {
+                                                    Instruction::Block { .. } | Instruction::Loop { .. } | Instruction::If { .. } | Instruction::Try { .. } | Instruction::TryTable { .. } => depth += 1,
+                                                    Instruction::End => depth -= 1,
+                                                    _ => {}
+                                                }
+                                            }
+                                            #[cfg(not(feature = "std"))]
+                                            if let Ok(search_instr) = instructions.get(search_pc) {
+                                                match search_instr {
+                                                    Instruction::Block { .. } | Instruction::Loop { .. } | Instruction::If { .. } | Instruction::Try { .. } | Instruction::TryTable { .. } => depth += 1,
+                                                    Instruction::End => depth -= 1,
+                                                    _ => {}
+                                                }
+                                            }
+                                            if depth > 0 { search_pc += 1; }
+                                        }
+                                        pc = search_pc;
+                                    }
+                                }
+                                continue;
+                            }
+                            // Null: fall through, reference is already consumed (dropped)
+                        }
+                    }
+
                     // ==================== TABLE OPERATIONS ====================
                     Instruction::TableGet(table_idx) => {
                         // table.get: [i32] -> [ref]
                         // Pop index from stack, get element from table at that index
                         if let Some(Value::I32(elem_idx)) = operand_stack.pop() {
+                            // Treat the i32 as u32 per the WebAssembly spec
+                            let idx = elem_idx as u32;
                             #[cfg(feature = "tracing")]
                             trace!(
                                 table_idx = table_idx,
-                                elem_idx = elem_idx,
+                                elem_idx = idx,
                                 "[TableGet] Getting element from table"
                             );
 
-                            if elem_idx < 0 {
-                                return Err(wrt_error::Error::runtime_trap(
-                                    "table.get: index cannot be negative",
-                                ));
-                            }
-
                             // Get the table from the instance
                             let table = instance.table(table_idx)?;
-                            let elem = table.get(elem_idx as u32)?;
+                            if idx >= table.size() {
+                                return Err(wrt_error::Error::runtime_trap(
+                                    "out of bounds table access",
+                                ));
+                            }
+                            let elem = table.get(idx)?;
 
                             // Push the element (or null ref) onto the stack
                             let value = match elem {
@@ -6464,19 +6487,15 @@ impl StacklessEngine {
                         })?;
 
                         if let Value::I32(elem_idx) = idx {
+                            // Treat the i32 as u32 per the WebAssembly spec
+                            let idx_u32 = elem_idx as u32;
                             #[cfg(feature = "tracing")]
                             trace!(
                                 table_idx = table_idx,
-                                elem_idx = elem_idx,
+                                elem_idx = idx_u32,
                                 value = ?value,
                                 "[TableSet] Setting element in table"
                             );
-
-                            if elem_idx < 0 {
-                                return Err(wrt_error::Error::runtime_trap(
-                                    "table.set: index cannot be negative",
-                                ));
-                            }
 
                             // Validate value is a reference type
                             let table_value = match &value {
@@ -6491,7 +6510,12 @@ impl StacklessEngine {
 
                             // Get the table and set the element
                             let table = instance.table(table_idx)?;
-                            table.set(elem_idx as u32, table_value)?;
+                            if idx_u32 >= table.size() {
+                                return Err(wrt_error::Error::runtime_trap(
+                                    "out of bounds table access",
+                                ));
+                            }
+                            table.set(idx_u32, table_value)?;
 
                             #[cfg(feature = "tracing")]
                             trace!(
@@ -10100,6 +10124,8 @@ impl StacklessEngine {
                     wrt_foundation::ValueType::I64 => Value::I64(0),
                     wrt_foundation::ValueType::F32 => Value::F32(FloatBits32(0)),
                     wrt_foundation::ValueType::F64 => Value::F64(FloatBits64(0)),
+                    wrt_foundation::ValueType::FuncRef => Value::FuncRef(None),
+                    wrt_foundation::ValueType::ExternRef => Value::ExternRef(None),
                     _ => Value::I32(0),
                 };
                 results.push(default_value)?;
@@ -10188,8 +10214,9 @@ impl StacklessEngine {
                 wrt_foundation::ValueType::I64 => Value::I64(0),
                 wrt_foundation::ValueType::F32 => Value::F32(FloatBits32(0.0f32.to_bits())),
                 wrt_foundation::ValueType::F64 => Value::F64(FloatBits64(0.0f64.to_bits())),
-                // Add other types as needed
-                _ => Value::I32(0), // Default fallback
+                wrt_foundation::ValueType::FuncRef => Value::FuncRef(None),
+                wrt_foundation::ValueType::ExternRef => Value::ExternRef(None),
+                _ => Value::I32(0),
             };
             results
                 .push(default_value)
@@ -10261,6 +10288,8 @@ impl StacklessEngine {
                 wrt_foundation::ValueType::I64 => Value::I64(0),
                 wrt_foundation::ValueType::F32 => Value::F32(FloatBits32(0.0f32.to_bits())),
                 wrt_foundation::ValueType::F64 => Value::F64(FloatBits64(0.0f64.to_bits())),
+                wrt_foundation::ValueType::FuncRef => Value::FuncRef(None),
+                wrt_foundation::ValueType::ExternRef => Value::ExternRef(None),
                 _ => Value::I32(0),
             };
             results

--- a/wrt-runtime/src/stackless/engine.rs
+++ b/wrt-runtime/src/stackless/engine.rs
@@ -146,10 +146,12 @@ use wrt_foundation::{
     values::{
         FloatBits32,
         FloatBits64,
+        V128,
         Value,
     },
 };
 
+use super::simd_ops;
 use crate::module_instance::ModuleInstance;
 
 /// Strip the version suffix from a WASI interface name.
@@ -6458,6 +6460,7 @@ impl StacklessEngine {
                                     match table.element_type() {
                                         wrt_foundation::types::RefType::Funcref => Value::FuncRef(None),
                                         wrt_foundation::types::RefType::Externref => Value::ExternRef(None),
+                                        wrt_foundation::types::RefType::Gc(_) => Value::FuncRef(None), // GC ref types default to null funcref
                                     }
                                 }
                             };
@@ -10051,6 +10054,2384 @@ impl StacklessEngine {
                         return Err(wrt_error::Error::runtime_error(
                             "GC instruction not yet fully implemented",
                         ));
+                    }
+
+                    // ========================================
+                    // SIMD Instructions (v128 operations)
+                    // ========================================
+                    Instruction::V128Const { bytes } => {
+                        operand_stack.push(Value::V128(V128::new(bytes)));
+                    }
+
+                    Instruction::SimdOp { opcode } => {
+                        match opcode {
+                            // ========================================
+                            // i8x16 comparison operations (0x23-0x2C)
+                            // ========================================
+                            0x23 => {
+                                // i8x16.eq
+                                if let (Some(Value::V128(b)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    let mut result = [0u8; 16];
+                                    for i in 0..16 {
+                                        result[i] = if a.bytes[i] == b.bytes[i] { 0xFF } else { 0x00 };
+                                    }
+                                    operand_stack.push(Value::V128(V128::new(result)));
+                                }
+                            }
+                            0x24 => {
+                                // i8x16.ne
+                                if let (Some(Value::V128(b)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    let mut result = [0u8; 16];
+                                    for i in 0..16 {
+                                        result[i] = if a.bytes[i] != b.bytes[i] { 0xFF } else { 0x00 };
+                                    }
+                                    operand_stack.push(Value::V128(V128::new(result)));
+                                }
+                            }
+                            0x25 => {
+                                // i8x16.lt_s
+                                if let (Some(Value::V128(b)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    let mut result = [0u8; 16];
+                                    for i in 0..16 {
+                                        result[i] = if (a.bytes[i] as i8) < (b.bytes[i] as i8) { 0xFF } else { 0x00 };
+                                    }
+                                    operand_stack.push(Value::V128(V128::new(result)));
+                                }
+                            }
+                            0x26 => {
+                                // i8x16.lt_u
+                                if let (Some(Value::V128(b)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    let mut result = [0u8; 16];
+                                    for i in 0..16 {
+                                        result[i] = if a.bytes[i] < b.bytes[i] { 0xFF } else { 0x00 };
+                                    }
+                                    operand_stack.push(Value::V128(V128::new(result)));
+                                }
+                            }
+                            0x27 => {
+                                // i8x16.gt_s
+                                if let (Some(Value::V128(b)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    let mut result = [0u8; 16];
+                                    for i in 0..16 {
+                                        result[i] = if (a.bytes[i] as i8) > (b.bytes[i] as i8) { 0xFF } else { 0x00 };
+                                    }
+                                    operand_stack.push(Value::V128(V128::new(result)));
+                                }
+                            }
+                            0x28 => {
+                                // i8x16.gt_u
+                                if let (Some(Value::V128(b)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    let mut result = [0u8; 16];
+                                    for i in 0..16 {
+                                        result[i] = if a.bytes[i] > b.bytes[i] { 0xFF } else { 0x00 };
+                                    }
+                                    operand_stack.push(Value::V128(V128::new(result)));
+                                }
+                            }
+                            0x29 => {
+                                // i8x16.le_s
+                                if let (Some(Value::V128(b)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    let mut result = [0u8; 16];
+                                    for i in 0..16 {
+                                        result[i] = if (a.bytes[i] as i8) <= (b.bytes[i] as i8) { 0xFF } else { 0x00 };
+                                    }
+                                    operand_stack.push(Value::V128(V128::new(result)));
+                                }
+                            }
+                            0x2A => {
+                                // i8x16.le_u
+                                if let (Some(Value::V128(b)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    let mut result = [0u8; 16];
+                                    for i in 0..16 {
+                                        result[i] = if a.bytes[i] <= b.bytes[i] { 0xFF } else { 0x00 };
+                                    }
+                                    operand_stack.push(Value::V128(V128::new(result)));
+                                }
+                            }
+                            0x2B => {
+                                // i8x16.ge_s
+                                if let (Some(Value::V128(b)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    let mut result = [0u8; 16];
+                                    for i in 0..16 {
+                                        result[i] = if (a.bytes[i] as i8) >= (b.bytes[i] as i8) { 0xFF } else { 0x00 };
+                                    }
+                                    operand_stack.push(Value::V128(V128::new(result)));
+                                }
+                            }
+                            0x2C => {
+                                // i8x16.ge_u
+                                if let (Some(Value::V128(b)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    let mut result = [0u8; 16];
+                                    for i in 0..16 {
+                                        result[i] = if a.bytes[i] >= b.bytes[i] { 0xFF } else { 0x00 };
+                                    }
+                                    operand_stack.push(Value::V128(V128::new(result)));
+                                }
+                            }
+
+                            // ========================================
+                            // i16x8 comparison operations (0x2D-0x36)
+                            // ========================================
+                            0x2D => {
+                                // i16x8.eq
+                                if let (Some(Value::V128(b)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    let mut result = [0u8; 16];
+                                    for i in 0..8 {
+                                        let la = u16::from_le_bytes([a.bytes[i*2], a.bytes[i*2+1]]);
+                                        let lb = u16::from_le_bytes([b.bytes[i*2], b.bytes[i*2+1]]);
+                                        let r: u16 = if la == lb { 0xFFFF } else { 0x0000 };
+                                        let rb = r.to_le_bytes();
+                                        result[i*2] = rb[0];
+                                        result[i*2+1] = rb[1];
+                                    }
+                                    operand_stack.push(Value::V128(V128::new(result)));
+                                }
+                            }
+                            0x2E => {
+                                // i16x8.ne
+                                if let (Some(Value::V128(b)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    let mut result = [0u8; 16];
+                                    for i in 0..8 {
+                                        let la = u16::from_le_bytes([a.bytes[i*2], a.bytes[i*2+1]]);
+                                        let lb = u16::from_le_bytes([b.bytes[i*2], b.bytes[i*2+1]]);
+                                        let r: u16 = if la != lb { 0xFFFF } else { 0x0000 };
+                                        let rb = r.to_le_bytes();
+                                        result[i*2] = rb[0];
+                                        result[i*2+1] = rb[1];
+                                    }
+                                    operand_stack.push(Value::V128(V128::new(result)));
+                                }
+                            }
+                            0x2F => {
+                                // i16x8.lt_s
+                                if let (Some(Value::V128(b)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    let mut result = [0u8; 16];
+                                    for i in 0..8 {
+                                        let la = i16::from_le_bytes([a.bytes[i*2], a.bytes[i*2+1]]);
+                                        let lb = i16::from_le_bytes([b.bytes[i*2], b.bytes[i*2+1]]);
+                                        let r: u16 = if la < lb { 0xFFFF } else { 0x0000 };
+                                        let rb = r.to_le_bytes();
+                                        result[i*2] = rb[0];
+                                        result[i*2+1] = rb[1];
+                                    }
+                                    operand_stack.push(Value::V128(V128::new(result)));
+                                }
+                            }
+                            0x30 => {
+                                // i16x8.lt_u
+                                if let (Some(Value::V128(b)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    let mut result = [0u8; 16];
+                                    for i in 0..8 {
+                                        let la = u16::from_le_bytes([a.bytes[i*2], a.bytes[i*2+1]]);
+                                        let lb = u16::from_le_bytes([b.bytes[i*2], b.bytes[i*2+1]]);
+                                        let r: u16 = if la < lb { 0xFFFF } else { 0x0000 };
+                                        let rb = r.to_le_bytes();
+                                        result[i*2] = rb[0];
+                                        result[i*2+1] = rb[1];
+                                    }
+                                    operand_stack.push(Value::V128(V128::new(result)));
+                                }
+                            }
+                            0x31 => {
+                                // i16x8.gt_s
+                                if let (Some(Value::V128(b)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    let mut result = [0u8; 16];
+                                    for i in 0..8 {
+                                        let la = i16::from_le_bytes([a.bytes[i*2], a.bytes[i*2+1]]);
+                                        let lb = i16::from_le_bytes([b.bytes[i*2], b.bytes[i*2+1]]);
+                                        let r: u16 = if la > lb { 0xFFFF } else { 0x0000 };
+                                        let rb = r.to_le_bytes();
+                                        result[i*2] = rb[0];
+                                        result[i*2+1] = rb[1];
+                                    }
+                                    operand_stack.push(Value::V128(V128::new(result)));
+                                }
+                            }
+                            0x32 => {
+                                // i16x8.gt_u
+                                if let (Some(Value::V128(b)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    let mut result = [0u8; 16];
+                                    for i in 0..8 {
+                                        let la = u16::from_le_bytes([a.bytes[i*2], a.bytes[i*2+1]]);
+                                        let lb = u16::from_le_bytes([b.bytes[i*2], b.bytes[i*2+1]]);
+                                        let r: u16 = if la > lb { 0xFFFF } else { 0x0000 };
+                                        let rb = r.to_le_bytes();
+                                        result[i*2] = rb[0];
+                                        result[i*2+1] = rb[1];
+                                    }
+                                    operand_stack.push(Value::V128(V128::new(result)));
+                                }
+                            }
+                            0x33 => {
+                                // i16x8.le_s
+                                if let (Some(Value::V128(b)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    let mut result = [0u8; 16];
+                                    for i in 0..8 {
+                                        let la = i16::from_le_bytes([a.bytes[i*2], a.bytes[i*2+1]]);
+                                        let lb = i16::from_le_bytes([b.bytes[i*2], b.bytes[i*2+1]]);
+                                        let r: u16 = if la <= lb { 0xFFFF } else { 0x0000 };
+                                        let rb = r.to_le_bytes();
+                                        result[i*2] = rb[0];
+                                        result[i*2+1] = rb[1];
+                                    }
+                                    operand_stack.push(Value::V128(V128::new(result)));
+                                }
+                            }
+                            0x34 => {
+                                // i16x8.le_u
+                                if let (Some(Value::V128(b)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    let mut result = [0u8; 16];
+                                    for i in 0..8 {
+                                        let la = u16::from_le_bytes([a.bytes[i*2], a.bytes[i*2+1]]);
+                                        let lb = u16::from_le_bytes([b.bytes[i*2], b.bytes[i*2+1]]);
+                                        let r: u16 = if la <= lb { 0xFFFF } else { 0x0000 };
+                                        let rb = r.to_le_bytes();
+                                        result[i*2] = rb[0];
+                                        result[i*2+1] = rb[1];
+                                    }
+                                    operand_stack.push(Value::V128(V128::new(result)));
+                                }
+                            }
+                            0x35 => {
+                                // i16x8.ge_s
+                                if let (Some(Value::V128(b)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    let mut result = [0u8; 16];
+                                    for i in 0..8 {
+                                        let la = i16::from_le_bytes([a.bytes[i*2], a.bytes[i*2+1]]);
+                                        let lb = i16::from_le_bytes([b.bytes[i*2], b.bytes[i*2+1]]);
+                                        let r: u16 = if la >= lb { 0xFFFF } else { 0x0000 };
+                                        let rb = r.to_le_bytes();
+                                        result[i*2] = rb[0];
+                                        result[i*2+1] = rb[1];
+                                    }
+                                    operand_stack.push(Value::V128(V128::new(result)));
+                                }
+                            }
+                            0x36 => {
+                                // i16x8.ge_u
+                                if let (Some(Value::V128(b)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    let mut result = [0u8; 16];
+                                    for i in 0..8 {
+                                        let la = u16::from_le_bytes([a.bytes[i*2], a.bytes[i*2+1]]);
+                                        let lb = u16::from_le_bytes([b.bytes[i*2], b.bytes[i*2+1]]);
+                                        let r: u16 = if la >= lb { 0xFFFF } else { 0x0000 };
+                                        let rb = r.to_le_bytes();
+                                        result[i*2] = rb[0];
+                                        result[i*2+1] = rb[1];
+                                    }
+                                    operand_stack.push(Value::V128(V128::new(result)));
+                                }
+                            }
+
+                            // ========================================
+                            // i32x4 comparison operations (0x37-0x40)
+                            // ========================================
+                            0x37 => {
+                                // i32x4.eq
+                                if let (Some(Value::V128(b)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    let mut result = [0u8; 16];
+                                    for i in 0..4 {
+                                        let la = u32::from_le_bytes([a.bytes[i*4], a.bytes[i*4+1], a.bytes[i*4+2], a.bytes[i*4+3]]);
+                                        let lb = u32::from_le_bytes([b.bytes[i*4], b.bytes[i*4+1], b.bytes[i*4+2], b.bytes[i*4+3]]);
+                                        let r: u32 = if la == lb { 0xFFFF_FFFF } else { 0x0000_0000 };
+                                        let rb = r.to_le_bytes();
+                                        result[i*4] = rb[0]; result[i*4+1] = rb[1]; result[i*4+2] = rb[2]; result[i*4+3] = rb[3];
+                                    }
+                                    operand_stack.push(Value::V128(V128::new(result)));
+                                }
+                            }
+                            0x38 => {
+                                // i32x4.ne
+                                if let (Some(Value::V128(b)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    let mut result = [0u8; 16];
+                                    for i in 0..4 {
+                                        let la = u32::from_le_bytes([a.bytes[i*4], a.bytes[i*4+1], a.bytes[i*4+2], a.bytes[i*4+3]]);
+                                        let lb = u32::from_le_bytes([b.bytes[i*4], b.bytes[i*4+1], b.bytes[i*4+2], b.bytes[i*4+3]]);
+                                        let r: u32 = if la != lb { 0xFFFF_FFFF } else { 0x0000_0000 };
+                                        let rb = r.to_le_bytes();
+                                        result[i*4] = rb[0]; result[i*4+1] = rb[1]; result[i*4+2] = rb[2]; result[i*4+3] = rb[3];
+                                    }
+                                    operand_stack.push(Value::V128(V128::new(result)));
+                                }
+                            }
+                            0x39 => {
+                                // i32x4.lt_s
+                                if let (Some(Value::V128(b)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    let mut result = [0u8; 16];
+                                    for i in 0..4 {
+                                        let la = i32::from_le_bytes([a.bytes[i*4], a.bytes[i*4+1], a.bytes[i*4+2], a.bytes[i*4+3]]);
+                                        let lb = i32::from_le_bytes([b.bytes[i*4], b.bytes[i*4+1], b.bytes[i*4+2], b.bytes[i*4+3]]);
+                                        let r: u32 = if la < lb { 0xFFFF_FFFF } else { 0x0000_0000 };
+                                        let rb = r.to_le_bytes();
+                                        result[i*4] = rb[0]; result[i*4+1] = rb[1]; result[i*4+2] = rb[2]; result[i*4+3] = rb[3];
+                                    }
+                                    operand_stack.push(Value::V128(V128::new(result)));
+                                }
+                            }
+                            0x3A => {
+                                // i32x4.lt_u
+                                if let (Some(Value::V128(b)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    let mut result = [0u8; 16];
+                                    for i in 0..4 {
+                                        let la = u32::from_le_bytes([a.bytes[i*4], a.bytes[i*4+1], a.bytes[i*4+2], a.bytes[i*4+3]]);
+                                        let lb = u32::from_le_bytes([b.bytes[i*4], b.bytes[i*4+1], b.bytes[i*4+2], b.bytes[i*4+3]]);
+                                        let r: u32 = if la < lb { 0xFFFF_FFFF } else { 0x0000_0000 };
+                                        let rb = r.to_le_bytes();
+                                        result[i*4] = rb[0]; result[i*4+1] = rb[1]; result[i*4+2] = rb[2]; result[i*4+3] = rb[3];
+                                    }
+                                    operand_stack.push(Value::V128(V128::new(result)));
+                                }
+                            }
+                            0x3B => {
+                                // i32x4.gt_s
+                                if let (Some(Value::V128(b)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    let mut result = [0u8; 16];
+                                    for i in 0..4 {
+                                        let la = i32::from_le_bytes([a.bytes[i*4], a.bytes[i*4+1], a.bytes[i*4+2], a.bytes[i*4+3]]);
+                                        let lb = i32::from_le_bytes([b.bytes[i*4], b.bytes[i*4+1], b.bytes[i*4+2], b.bytes[i*4+3]]);
+                                        let r: u32 = if la > lb { 0xFFFF_FFFF } else { 0x0000_0000 };
+                                        let rb = r.to_le_bytes();
+                                        result[i*4] = rb[0]; result[i*4+1] = rb[1]; result[i*4+2] = rb[2]; result[i*4+3] = rb[3];
+                                    }
+                                    operand_stack.push(Value::V128(V128::new(result)));
+                                }
+                            }
+                            0x3C => {
+                                // i32x4.gt_u
+                                if let (Some(Value::V128(b)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    let mut result = [0u8; 16];
+                                    for i in 0..4 {
+                                        let la = u32::from_le_bytes([a.bytes[i*4], a.bytes[i*4+1], a.bytes[i*4+2], a.bytes[i*4+3]]);
+                                        let lb = u32::from_le_bytes([b.bytes[i*4], b.bytes[i*4+1], b.bytes[i*4+2], b.bytes[i*4+3]]);
+                                        let r: u32 = if la > lb { 0xFFFF_FFFF } else { 0x0000_0000 };
+                                        let rb = r.to_le_bytes();
+                                        result[i*4] = rb[0]; result[i*4+1] = rb[1]; result[i*4+2] = rb[2]; result[i*4+3] = rb[3];
+                                    }
+                                    operand_stack.push(Value::V128(V128::new(result)));
+                                }
+                            }
+                            0x3D => {
+                                // i32x4.le_s
+                                if let (Some(Value::V128(b)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    let mut result = [0u8; 16];
+                                    for i in 0..4 {
+                                        let la = i32::from_le_bytes([a.bytes[i*4], a.bytes[i*4+1], a.bytes[i*4+2], a.bytes[i*4+3]]);
+                                        let lb = i32::from_le_bytes([b.bytes[i*4], b.bytes[i*4+1], b.bytes[i*4+2], b.bytes[i*4+3]]);
+                                        let r: u32 = if la <= lb { 0xFFFF_FFFF } else { 0x0000_0000 };
+                                        let rb = r.to_le_bytes();
+                                        result[i*4] = rb[0]; result[i*4+1] = rb[1]; result[i*4+2] = rb[2]; result[i*4+3] = rb[3];
+                                    }
+                                    operand_stack.push(Value::V128(V128::new(result)));
+                                }
+                            }
+                            0x3E => {
+                                // i32x4.le_u
+                                if let (Some(Value::V128(b)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    let mut result = [0u8; 16];
+                                    for i in 0..4 {
+                                        let la = u32::from_le_bytes([a.bytes[i*4], a.bytes[i*4+1], a.bytes[i*4+2], a.bytes[i*4+3]]);
+                                        let lb = u32::from_le_bytes([b.bytes[i*4], b.bytes[i*4+1], b.bytes[i*4+2], b.bytes[i*4+3]]);
+                                        let r: u32 = if la <= lb { 0xFFFF_FFFF } else { 0x0000_0000 };
+                                        let rb = r.to_le_bytes();
+                                        result[i*4] = rb[0]; result[i*4+1] = rb[1]; result[i*4+2] = rb[2]; result[i*4+3] = rb[3];
+                                    }
+                                    operand_stack.push(Value::V128(V128::new(result)));
+                                }
+                            }
+                            0x3F => {
+                                // i32x4.ge_s
+                                if let (Some(Value::V128(b)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    let mut result = [0u8; 16];
+                                    for i in 0..4 {
+                                        let la = i32::from_le_bytes([a.bytes[i*4], a.bytes[i*4+1], a.bytes[i*4+2], a.bytes[i*4+3]]);
+                                        let lb = i32::from_le_bytes([b.bytes[i*4], b.bytes[i*4+1], b.bytes[i*4+2], b.bytes[i*4+3]]);
+                                        let r: u32 = if la >= lb { 0xFFFF_FFFF } else { 0x0000_0000 };
+                                        let rb = r.to_le_bytes();
+                                        result[i*4] = rb[0]; result[i*4+1] = rb[1]; result[i*4+2] = rb[2]; result[i*4+3] = rb[3];
+                                    }
+                                    operand_stack.push(Value::V128(V128::new(result)));
+                                }
+                            }
+                            0x40 => {
+                                // i32x4.ge_u
+                                if let (Some(Value::V128(b)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    let mut result = [0u8; 16];
+                                    for i in 0..4 {
+                                        let la = u32::from_le_bytes([a.bytes[i*4], a.bytes[i*4+1], a.bytes[i*4+2], a.bytes[i*4+3]]);
+                                        let lb = u32::from_le_bytes([b.bytes[i*4], b.bytes[i*4+1], b.bytes[i*4+2], b.bytes[i*4+3]]);
+                                        let r: u32 = if la >= lb { 0xFFFF_FFFF } else { 0x0000_0000 };
+                                        let rb = r.to_le_bytes();
+                                        result[i*4] = rb[0]; result[i*4+1] = rb[1]; result[i*4+2] = rb[2]; result[i*4+3] = rb[3];
+                                    }
+                                    operand_stack.push(Value::V128(V128::new(result)));
+                                }
+                            }
+
+                            // ========================================
+                            // f32x4 comparison operations (0x41-0x46)
+                            // ========================================
+                            0x41 => {
+                                // f32x4.eq
+                                if let (Some(Value::V128(b)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    let mut result = [0u8; 16];
+                                    for i in 0..4 {
+                                        let fa = f32::from_le_bytes([a.bytes[i*4], a.bytes[i*4+1], a.bytes[i*4+2], a.bytes[i*4+3]]);
+                                        let fb = f32::from_le_bytes([b.bytes[i*4], b.bytes[i*4+1], b.bytes[i*4+2], b.bytes[i*4+3]]);
+                                        let r: u32 = if fa == fb { 0xFFFF_FFFF } else { 0x0000_0000 };
+                                        let rb = r.to_le_bytes();
+                                        result[i*4] = rb[0]; result[i*4+1] = rb[1]; result[i*4+2] = rb[2]; result[i*4+3] = rb[3];
+                                    }
+                                    operand_stack.push(Value::V128(V128::new(result)));
+                                }
+                            }
+                            0x42 => {
+                                // f32x4.ne
+                                if let (Some(Value::V128(b)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    let mut result = [0u8; 16];
+                                    for i in 0..4 {
+                                        let fa = f32::from_le_bytes([a.bytes[i*4], a.bytes[i*4+1], a.bytes[i*4+2], a.bytes[i*4+3]]);
+                                        let fb = f32::from_le_bytes([b.bytes[i*4], b.bytes[i*4+1], b.bytes[i*4+2], b.bytes[i*4+3]]);
+                                        let r: u32 = if fa != fb { 0xFFFF_FFFF } else { 0x0000_0000 };
+                                        let rb = r.to_le_bytes();
+                                        result[i*4] = rb[0]; result[i*4+1] = rb[1]; result[i*4+2] = rb[2]; result[i*4+3] = rb[3];
+                                    }
+                                    operand_stack.push(Value::V128(V128::new(result)));
+                                }
+                            }
+                            0x43 => {
+                                // f32x4.lt
+                                if let (Some(Value::V128(b)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    let mut result = [0u8; 16];
+                                    for i in 0..4 {
+                                        let fa = f32::from_le_bytes([a.bytes[i*4], a.bytes[i*4+1], a.bytes[i*4+2], a.bytes[i*4+3]]);
+                                        let fb = f32::from_le_bytes([b.bytes[i*4], b.bytes[i*4+1], b.bytes[i*4+2], b.bytes[i*4+3]]);
+                                        let r: u32 = if fa < fb { 0xFFFF_FFFF } else { 0x0000_0000 };
+                                        let rb = r.to_le_bytes();
+                                        result[i*4] = rb[0]; result[i*4+1] = rb[1]; result[i*4+2] = rb[2]; result[i*4+3] = rb[3];
+                                    }
+                                    operand_stack.push(Value::V128(V128::new(result)));
+                                }
+                            }
+                            0x44 => {
+                                // f32x4.gt
+                                if let (Some(Value::V128(b)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    let mut result = [0u8; 16];
+                                    for i in 0..4 {
+                                        let fa = f32::from_le_bytes([a.bytes[i*4], a.bytes[i*4+1], a.bytes[i*4+2], a.bytes[i*4+3]]);
+                                        let fb = f32::from_le_bytes([b.bytes[i*4], b.bytes[i*4+1], b.bytes[i*4+2], b.bytes[i*4+3]]);
+                                        let r: u32 = if fa > fb { 0xFFFF_FFFF } else { 0x0000_0000 };
+                                        let rb = r.to_le_bytes();
+                                        result[i*4] = rb[0]; result[i*4+1] = rb[1]; result[i*4+2] = rb[2]; result[i*4+3] = rb[3];
+                                    }
+                                    operand_stack.push(Value::V128(V128::new(result)));
+                                }
+                            }
+                            0x45 => {
+                                // f32x4.le
+                                if let (Some(Value::V128(b)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    let mut result = [0u8; 16];
+                                    for i in 0..4 {
+                                        let fa = f32::from_le_bytes([a.bytes[i*4], a.bytes[i*4+1], a.bytes[i*4+2], a.bytes[i*4+3]]);
+                                        let fb = f32::from_le_bytes([b.bytes[i*4], b.bytes[i*4+1], b.bytes[i*4+2], b.bytes[i*4+3]]);
+                                        let r: u32 = if fa <= fb { 0xFFFF_FFFF } else { 0x0000_0000 };
+                                        let rb = r.to_le_bytes();
+                                        result[i*4] = rb[0]; result[i*4+1] = rb[1]; result[i*4+2] = rb[2]; result[i*4+3] = rb[3];
+                                    }
+                                    operand_stack.push(Value::V128(V128::new(result)));
+                                }
+                            }
+                            0x46 => {
+                                // f32x4.ge
+                                if let (Some(Value::V128(b)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    let mut result = [0u8; 16];
+                                    for i in 0..4 {
+                                        let fa = f32::from_le_bytes([a.bytes[i*4], a.bytes[i*4+1], a.bytes[i*4+2], a.bytes[i*4+3]]);
+                                        let fb = f32::from_le_bytes([b.bytes[i*4], b.bytes[i*4+1], b.bytes[i*4+2], b.bytes[i*4+3]]);
+                                        let r: u32 = if fa >= fb { 0xFFFF_FFFF } else { 0x0000_0000 };
+                                        let rb = r.to_le_bytes();
+                                        result[i*4] = rb[0]; result[i*4+1] = rb[1]; result[i*4+2] = rb[2]; result[i*4+3] = rb[3];
+                                    }
+                                    operand_stack.push(Value::V128(V128::new(result)));
+                                }
+                            }
+
+                            // ========================================
+                            // f64x2 comparison operations (0x47-0x4C)
+                            // ========================================
+                            0x47 => {
+                                // f64x2.eq
+                                if let (Some(Value::V128(b)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    let mut result = [0u8; 16];
+                                    for i in 0..2 {
+                                        let mut ab = [0u8; 8];
+                                        let mut bb = [0u8; 8];
+                                        ab.copy_from_slice(&a.bytes[i*8..i*8+8]);
+                                        bb.copy_from_slice(&b.bytes[i*8..i*8+8]);
+                                        let fa = f64::from_le_bytes(ab);
+                                        let fb = f64::from_le_bytes(bb);
+                                        let r: u64 = if fa == fb { 0xFFFF_FFFF_FFFF_FFFF } else { 0x0000_0000_0000_0000 };
+                                        let rb = r.to_le_bytes();
+                                        result[i*8..i*8+8].copy_from_slice(&rb);
+                                    }
+                                    operand_stack.push(Value::V128(V128::new(result)));
+                                }
+                            }
+                            0x48 => {
+                                // f64x2.ne
+                                if let (Some(Value::V128(b)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    let mut result = [0u8; 16];
+                                    for i in 0..2 {
+                                        let mut ab = [0u8; 8];
+                                        let mut bb = [0u8; 8];
+                                        ab.copy_from_slice(&a.bytes[i*8..i*8+8]);
+                                        bb.copy_from_slice(&b.bytes[i*8..i*8+8]);
+                                        let fa = f64::from_le_bytes(ab);
+                                        let fb = f64::from_le_bytes(bb);
+                                        let r: u64 = if fa != fb { 0xFFFF_FFFF_FFFF_FFFF } else { 0x0000_0000_0000_0000 };
+                                        let rb = r.to_le_bytes();
+                                        result[i*8..i*8+8].copy_from_slice(&rb);
+                                    }
+                                    operand_stack.push(Value::V128(V128::new(result)));
+                                }
+                            }
+                            0x49 => {
+                                // f64x2.lt
+                                if let (Some(Value::V128(b)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    let mut result = [0u8; 16];
+                                    for i in 0..2 {
+                                        let mut ab = [0u8; 8];
+                                        let mut bb = [0u8; 8];
+                                        ab.copy_from_slice(&a.bytes[i*8..i*8+8]);
+                                        bb.copy_from_slice(&b.bytes[i*8..i*8+8]);
+                                        let fa = f64::from_le_bytes(ab);
+                                        let fb = f64::from_le_bytes(bb);
+                                        let r: u64 = if fa < fb { 0xFFFF_FFFF_FFFF_FFFF } else { 0x0000_0000_0000_0000 };
+                                        let rb = r.to_le_bytes();
+                                        result[i*8..i*8+8].copy_from_slice(&rb);
+                                    }
+                                    operand_stack.push(Value::V128(V128::new(result)));
+                                }
+                            }
+                            0x4A => {
+                                // f64x2.gt
+                                if let (Some(Value::V128(b)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    let mut result = [0u8; 16];
+                                    for i in 0..2 {
+                                        let mut ab = [0u8; 8];
+                                        let mut bb = [0u8; 8];
+                                        ab.copy_from_slice(&a.bytes[i*8..i*8+8]);
+                                        bb.copy_from_slice(&b.bytes[i*8..i*8+8]);
+                                        let fa = f64::from_le_bytes(ab);
+                                        let fb = f64::from_le_bytes(bb);
+                                        let r: u64 = if fa > fb { 0xFFFF_FFFF_FFFF_FFFF } else { 0x0000_0000_0000_0000 };
+                                        let rb = r.to_le_bytes();
+                                        result[i*8..i*8+8].copy_from_slice(&rb);
+                                    }
+                                    operand_stack.push(Value::V128(V128::new(result)));
+                                }
+                            }
+                            0x4B => {
+                                // f64x2.le
+                                if let (Some(Value::V128(b)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    let mut result = [0u8; 16];
+                                    for i in 0..2 {
+                                        let mut ab = [0u8; 8];
+                                        let mut bb = [0u8; 8];
+                                        ab.copy_from_slice(&a.bytes[i*8..i*8+8]);
+                                        bb.copy_from_slice(&b.bytes[i*8..i*8+8]);
+                                        let fa = f64::from_le_bytes(ab);
+                                        let fb = f64::from_le_bytes(bb);
+                                        let r: u64 = if fa <= fb { 0xFFFF_FFFF_FFFF_FFFF } else { 0x0000_0000_0000_0000 };
+                                        let rb = r.to_le_bytes();
+                                        result[i*8..i*8+8].copy_from_slice(&rb);
+                                    }
+                                    operand_stack.push(Value::V128(V128::new(result)));
+                                }
+                            }
+                            0x4C => {
+                                // f64x2.ge
+                                if let (Some(Value::V128(b)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    let mut result = [0u8; 16];
+                                    for i in 0..2 {
+                                        let mut ab = [0u8; 8];
+                                        let mut bb = [0u8; 8];
+                                        ab.copy_from_slice(&a.bytes[i*8..i*8+8]);
+                                        bb.copy_from_slice(&b.bytes[i*8..i*8+8]);
+                                        let fa = f64::from_le_bytes(ab);
+                                        let fb = f64::from_le_bytes(bb);
+                                        let r: u64 = if fa >= fb { 0xFFFF_FFFF_FFFF_FFFF } else { 0x0000_0000_0000_0000 };
+                                        let rb = r.to_le_bytes();
+                                        result[i*8..i*8+8].copy_from_slice(&rb);
+                                    }
+                                    operand_stack.push(Value::V128(V128::new(result)));
+                                }
+                            }
+
+                            // ========================================
+                            // i64x2 comparison operations (0xD6-0xDB)
+                            // ========================================
+                            0xD6 => {
+                                // i64x2.eq
+                                if let (Some(Value::V128(b)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    let mut result = [0u8; 16];
+                                    for i in 0..2 {
+                                        let mut ab = [0u8; 8];
+                                        let mut bb = [0u8; 8];
+                                        ab.copy_from_slice(&a.bytes[i*8..i*8+8]);
+                                        bb.copy_from_slice(&b.bytes[i*8..i*8+8]);
+                                        let la = u64::from_le_bytes(ab);
+                                        let lb = u64::from_le_bytes(bb);
+                                        let r: u64 = if la == lb { 0xFFFF_FFFF_FFFF_FFFF } else { 0x0000_0000_0000_0000 };
+                                        result[i*8..i*8+8].copy_from_slice(&r.to_le_bytes());
+                                    }
+                                    operand_stack.push(Value::V128(V128::new(result)));
+                                }
+                            }
+                            0xD7 => {
+                                // i64x2.ne
+                                if let (Some(Value::V128(b)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    let mut result = [0u8; 16];
+                                    for i in 0..2 {
+                                        let mut ab = [0u8; 8];
+                                        let mut bb = [0u8; 8];
+                                        ab.copy_from_slice(&a.bytes[i*8..i*8+8]);
+                                        bb.copy_from_slice(&b.bytes[i*8..i*8+8]);
+                                        let la = u64::from_le_bytes(ab);
+                                        let lb = u64::from_le_bytes(bb);
+                                        let r: u64 = if la != lb { 0xFFFF_FFFF_FFFF_FFFF } else { 0x0000_0000_0000_0000 };
+                                        result[i*8..i*8+8].copy_from_slice(&r.to_le_bytes());
+                                    }
+                                    operand_stack.push(Value::V128(V128::new(result)));
+                                }
+                            }
+                            0xD8 => {
+                                // i64x2.lt_s
+                                if let (Some(Value::V128(b)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    let mut result = [0u8; 16];
+                                    for i in 0..2 {
+                                        let mut ab = [0u8; 8];
+                                        let mut bb = [0u8; 8];
+                                        ab.copy_from_slice(&a.bytes[i*8..i*8+8]);
+                                        bb.copy_from_slice(&b.bytes[i*8..i*8+8]);
+                                        let la = i64::from_le_bytes(ab);
+                                        let lb = i64::from_le_bytes(bb);
+                                        let r: u64 = if la < lb { 0xFFFF_FFFF_FFFF_FFFF } else { 0x0000_0000_0000_0000 };
+                                        result[i*8..i*8+8].copy_from_slice(&r.to_le_bytes());
+                                    }
+                                    operand_stack.push(Value::V128(V128::new(result)));
+                                }
+                            }
+                            0xD9 => {
+                                // i64x2.gt_s
+                                if let (Some(Value::V128(b)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    let mut result = [0u8; 16];
+                                    for i in 0..2 {
+                                        let mut ab = [0u8; 8];
+                                        let mut bb = [0u8; 8];
+                                        ab.copy_from_slice(&a.bytes[i*8..i*8+8]);
+                                        bb.copy_from_slice(&b.bytes[i*8..i*8+8]);
+                                        let la = i64::from_le_bytes(ab);
+                                        let lb = i64::from_le_bytes(bb);
+                                        let r: u64 = if la > lb { 0xFFFF_FFFF_FFFF_FFFF } else { 0x0000_0000_0000_0000 };
+                                        result[i*8..i*8+8].copy_from_slice(&r.to_le_bytes());
+                                    }
+                                    operand_stack.push(Value::V128(V128::new(result)));
+                                }
+                            }
+                            0xDA => {
+                                // i64x2.le_s
+                                if let (Some(Value::V128(b)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    let mut result = [0u8; 16];
+                                    for i in 0..2 {
+                                        let mut ab = [0u8; 8];
+                                        let mut bb = [0u8; 8];
+                                        ab.copy_from_slice(&a.bytes[i*8..i*8+8]);
+                                        bb.copy_from_slice(&b.bytes[i*8..i*8+8]);
+                                        let la = i64::from_le_bytes(ab);
+                                        let lb = i64::from_le_bytes(bb);
+                                        let r: u64 = if la <= lb { 0xFFFF_FFFF_FFFF_FFFF } else { 0x0000_0000_0000_0000 };
+                                        result[i*8..i*8+8].copy_from_slice(&r.to_le_bytes());
+                                    }
+                                    operand_stack.push(Value::V128(V128::new(result)));
+                                }
+                            }
+                            0xDB => {
+                                // i64x2.ge_s
+                                if let (Some(Value::V128(b)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    let mut result = [0u8; 16];
+                                    for i in 0..2 {
+                                        let mut ab = [0u8; 8];
+                                        let mut bb = [0u8; 8];
+                                        ab.copy_from_slice(&a.bytes[i*8..i*8+8]);
+                                        bb.copy_from_slice(&b.bytes[i*8..i*8+8]);
+                                        let la = i64::from_le_bytes(ab);
+                                        let lb = i64::from_le_bytes(bb);
+                                        let r: u64 = if la >= lb { 0xFFFF_FFFF_FFFF_FFFF } else { 0x0000_0000_0000_0000 };
+                                        result[i*8..i*8+8].copy_from_slice(&r.to_le_bytes());
+                                    }
+                                    operand_stack.push(Value::V128(V128::new(result)));
+                                }
+                            }
+
+                            // ========================================
+                            // f32x4 unary float operations
+                            // ========================================
+                            0xE0 => {
+                                // f32x4.abs
+                                if let Some(Value::V128(a)) = operand_stack.pop() {
+                                    let mut result = [0u8; 16];
+                                    for i in 0..4 {
+                                        let f = f32::from_le_bytes([a.bytes[i*4], a.bytes[i*4+1], a.bytes[i*4+2], a.bytes[i*4+3]]);
+                                        let r = f.abs();
+                                        let rb = r.to_le_bytes();
+                                        result[i*4] = rb[0]; result[i*4+1] = rb[1]; result[i*4+2] = rb[2]; result[i*4+3] = rb[3];
+                                    }
+                                    operand_stack.push(Value::V128(V128::new(result)));
+                                }
+                            }
+                            0xE1 => {
+                                // f32x4.neg
+                                if let Some(Value::V128(a)) = operand_stack.pop() {
+                                    let mut result = [0u8; 16];
+                                    for i in 0..4 {
+                                        let f = f32::from_le_bytes([a.bytes[i*4], a.bytes[i*4+1], a.bytes[i*4+2], a.bytes[i*4+3]]);
+                                        let r = -f;
+                                        let rb = r.to_le_bytes();
+                                        result[i*4] = rb[0]; result[i*4+1] = rb[1]; result[i*4+2] = rb[2]; result[i*4+3] = rb[3];
+                                    }
+                                    operand_stack.push(Value::V128(V128::new(result)));
+                                }
+                            }
+                            0xE3 => {
+                                // f32x4.sqrt
+                                if let Some(Value::V128(a)) = operand_stack.pop() {
+                                    let mut result = [0u8; 16];
+                                    for i in 0..4 {
+                                        let f = f32::from_le_bytes([a.bytes[i*4], a.bytes[i*4+1], a.bytes[i*4+2], a.bytes[i*4+3]]);
+                                        let r = f.sqrt();
+                                        let rb = r.to_le_bytes();
+                                        result[i*4] = rb[0]; result[i*4+1] = rb[1]; result[i*4+2] = rb[2]; result[i*4+3] = rb[3];
+                                    }
+                                    operand_stack.push(Value::V128(V128::new(result)));
+                                }
+                            }
+
+                            // ========================================
+                            // f32x4 binary arithmetic (0xE4-0xE7)
+                            // ========================================
+                            0xE4 => {
+                                // f32x4.add
+                                if let (Some(Value::V128(b)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    let mut result = [0u8; 16];
+                                    for i in 0..4 {
+                                        let fa = f32::from_le_bytes([a.bytes[i*4], a.bytes[i*4+1], a.bytes[i*4+2], a.bytes[i*4+3]]);
+                                        let fb = f32::from_le_bytes([b.bytes[i*4], b.bytes[i*4+1], b.bytes[i*4+2], b.bytes[i*4+3]]);
+                                        let r = (fa + fb).to_le_bytes();
+                                        result[i*4] = r[0]; result[i*4+1] = r[1]; result[i*4+2] = r[2]; result[i*4+3] = r[3];
+                                    }
+                                    operand_stack.push(Value::V128(V128::new(result)));
+                                }
+                            }
+                            0xE5 => {
+                                // f32x4.sub
+                                if let (Some(Value::V128(b)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    let mut result = [0u8; 16];
+                                    for i in 0..4 {
+                                        let fa = f32::from_le_bytes([a.bytes[i*4], a.bytes[i*4+1], a.bytes[i*4+2], a.bytes[i*4+3]]);
+                                        let fb = f32::from_le_bytes([b.bytes[i*4], b.bytes[i*4+1], b.bytes[i*4+2], b.bytes[i*4+3]]);
+                                        let r = (fa - fb).to_le_bytes();
+                                        result[i*4] = r[0]; result[i*4+1] = r[1]; result[i*4+2] = r[2]; result[i*4+3] = r[3];
+                                    }
+                                    operand_stack.push(Value::V128(V128::new(result)));
+                                }
+                            }
+                            0xE6 => {
+                                // f32x4.mul
+                                if let (Some(Value::V128(b)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    let mut result = [0u8; 16];
+                                    for i in 0..4 {
+                                        let fa = f32::from_le_bytes([a.bytes[i*4], a.bytes[i*4+1], a.bytes[i*4+2], a.bytes[i*4+3]]);
+                                        let fb = f32::from_le_bytes([b.bytes[i*4], b.bytes[i*4+1], b.bytes[i*4+2], b.bytes[i*4+3]]);
+                                        let r = (fa * fb).to_le_bytes();
+                                        result[i*4] = r[0]; result[i*4+1] = r[1]; result[i*4+2] = r[2]; result[i*4+3] = r[3];
+                                    }
+                                    operand_stack.push(Value::V128(V128::new(result)));
+                                }
+                            }
+                            0xE7 => {
+                                // f32x4.div
+                                if let (Some(Value::V128(b)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    let mut result = [0u8; 16];
+                                    for i in 0..4 {
+                                        let fa = f32::from_le_bytes([a.bytes[i*4], a.bytes[i*4+1], a.bytes[i*4+2], a.bytes[i*4+3]]);
+                                        let fb = f32::from_le_bytes([b.bytes[i*4], b.bytes[i*4+1], b.bytes[i*4+2], b.bytes[i*4+3]]);
+                                        let r = (fa / fb).to_le_bytes();
+                                        result[i*4] = r[0]; result[i*4+1] = r[1]; result[i*4+2] = r[2]; result[i*4+3] = r[3];
+                                    }
+                                    operand_stack.push(Value::V128(V128::new(result)));
+                                }
+                            }
+
+                            // ========================================
+                            // f32x4 min/max/pmin/pmax (0xE8-0xEB)
+                            // ========================================
+                            0xE8 => {
+                                // f32x4.min (IEEE min: NaN propagates, -0 < +0)
+                                if let (Some(Value::V128(b)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    let mut result = [0u8; 16];
+                                    for i in 0..4 {
+                                        let fa = f32::from_le_bytes([a.bytes[i*4], a.bytes[i*4+1], a.bytes[i*4+2], a.bytes[i*4+3]]);
+                                        let fb = f32::from_le_bytes([b.bytes[i*4], b.bytes[i*4+1], b.bytes[i*4+2], b.bytes[i*4+3]]);
+                                        let r = if fa.is_nan() || fb.is_nan() {
+                                            // Produce a canonical NaN
+                                            f32::NAN
+                                        } else if fa == 0.0 && fb == 0.0 {
+                                            // -0 is less than +0
+                                            if fa.is_sign_negative() || fb.is_sign_negative() { -0.0_f32 } else { 0.0_f32 }
+                                        } else {
+                                            fa.min(fb)
+                                        };
+                                        let rb = r.to_le_bytes();
+                                        result[i*4] = rb[0]; result[i*4+1] = rb[1]; result[i*4+2] = rb[2]; result[i*4+3] = rb[3];
+                                    }
+                                    operand_stack.push(Value::V128(V128::new(result)));
+                                }
+                            }
+                            0xE9 => {
+                                // f32x4.max (IEEE max: NaN propagates, +0 > -0)
+                                if let (Some(Value::V128(b)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    let mut result = [0u8; 16];
+                                    for i in 0..4 {
+                                        let fa = f32::from_le_bytes([a.bytes[i*4], a.bytes[i*4+1], a.bytes[i*4+2], a.bytes[i*4+3]]);
+                                        let fb = f32::from_le_bytes([b.bytes[i*4], b.bytes[i*4+1], b.bytes[i*4+2], b.bytes[i*4+3]]);
+                                        let r = if fa.is_nan() || fb.is_nan() {
+                                            f32::NAN
+                                        } else if fa == 0.0 && fb == 0.0 {
+                                            if fa.is_sign_positive() || fb.is_sign_positive() { 0.0_f32 } else { -0.0_f32 }
+                                        } else {
+                                            fa.max(fb)
+                                        };
+                                        let rb = r.to_le_bytes();
+                                        result[i*4] = rb[0]; result[i*4+1] = rb[1]; result[i*4+2] = rb[2]; result[i*4+3] = rb[3];
+                                    }
+                                    operand_stack.push(Value::V128(V128::new(result)));
+                                }
+                            }
+                            0xEA => {
+                                // f32x4.pmin: b < a ? b : a
+                                if let (Some(Value::V128(b)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    let mut result = [0u8; 16];
+                                    for i in 0..4 {
+                                        let fa = f32::from_le_bytes([a.bytes[i*4], a.bytes[i*4+1], a.bytes[i*4+2], a.bytes[i*4+3]]);
+                                        let fb = f32::from_le_bytes([b.bytes[i*4], b.bytes[i*4+1], b.bytes[i*4+2], b.bytes[i*4+3]]);
+                                        // pmin(a, b) = b < a ? b : a
+                                        let r = if fb < fa { fb } else { fa };
+                                        let rb = r.to_le_bytes();
+                                        result[i*4] = rb[0]; result[i*4+1] = rb[1]; result[i*4+2] = rb[2]; result[i*4+3] = rb[3];
+                                    }
+                                    operand_stack.push(Value::V128(V128::new(result)));
+                                }
+                            }
+                            0xEB => {
+                                // f32x4.pmax: a < b ? b : a
+                                if let (Some(Value::V128(b)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    let mut result = [0u8; 16];
+                                    for i in 0..4 {
+                                        let fa = f32::from_le_bytes([a.bytes[i*4], a.bytes[i*4+1], a.bytes[i*4+2], a.bytes[i*4+3]]);
+                                        let fb = f32::from_le_bytes([b.bytes[i*4], b.bytes[i*4+1], b.bytes[i*4+2], b.bytes[i*4+3]]);
+                                        // pmax(a, b) = a < b ? b : a
+                                        let r = if fa < fb { fb } else { fa };
+                                        let rb = r.to_le_bytes();
+                                        result[i*4] = rb[0]; result[i*4+1] = rb[1]; result[i*4+2] = rb[2]; result[i*4+3] = rb[3];
+                                    }
+                                    operand_stack.push(Value::V128(V128::new(result)));
+                                }
+                            }
+
+                            // ========================================
+                            // f64x2 unary float operations
+                            // ========================================
+                            0xEC => {
+                                // f64x2.abs
+                                if let Some(Value::V128(a)) = operand_stack.pop() {
+                                    let mut result = [0u8; 16];
+                                    for i in 0..2 {
+                                        let mut ab = [0u8; 8];
+                                        ab.copy_from_slice(&a.bytes[i*8..i*8+8]);
+                                        let f = f64::from_le_bytes(ab);
+                                        let r = f.abs();
+                                        result[i*8..i*8+8].copy_from_slice(&r.to_le_bytes());
+                                    }
+                                    operand_stack.push(Value::V128(V128::new(result)));
+                                }
+                            }
+                            0xED => {
+                                // f64x2.neg
+                                if let Some(Value::V128(a)) = operand_stack.pop() {
+                                    let mut result = [0u8; 16];
+                                    for i in 0..2 {
+                                        let mut ab = [0u8; 8];
+                                        ab.copy_from_slice(&a.bytes[i*8..i*8+8]);
+                                        let f = f64::from_le_bytes(ab);
+                                        let r = -f;
+                                        result[i*8..i*8+8].copy_from_slice(&r.to_le_bytes());
+                                    }
+                                    operand_stack.push(Value::V128(V128::new(result)));
+                                }
+                            }
+                            0xEF => {
+                                // f64x2.sqrt
+                                if let Some(Value::V128(a)) = operand_stack.pop() {
+                                    let mut result = [0u8; 16];
+                                    for i in 0..2 {
+                                        let mut ab = [0u8; 8];
+                                        ab.copy_from_slice(&a.bytes[i*8..i*8+8]);
+                                        let f = f64::from_le_bytes(ab);
+                                        let r = f.sqrt();
+                                        result[i*8..i*8+8].copy_from_slice(&r.to_le_bytes());
+                                    }
+                                    operand_stack.push(Value::V128(V128::new(result)));
+                                }
+                            }
+
+                            // ========================================
+                            // f64x2 binary arithmetic (0xF0-0xF3)
+                            // ========================================
+                            0xF0 => {
+                                // f64x2.add
+                                if let (Some(Value::V128(b)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    let mut result = [0u8; 16];
+                                    for i in 0..2 {
+                                        let mut ab = [0u8; 8];
+                                        let mut bb = [0u8; 8];
+                                        ab.copy_from_slice(&a.bytes[i*8..i*8+8]);
+                                        bb.copy_from_slice(&b.bytes[i*8..i*8+8]);
+                                        let fa = f64::from_le_bytes(ab);
+                                        let fb = f64::from_le_bytes(bb);
+                                        result[i*8..i*8+8].copy_from_slice(&(fa + fb).to_le_bytes());
+                                    }
+                                    operand_stack.push(Value::V128(V128::new(result)));
+                                }
+                            }
+                            0xF1 => {
+                                // f64x2.sub
+                                if let (Some(Value::V128(b)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    let mut result = [0u8; 16];
+                                    for i in 0..2 {
+                                        let mut ab = [0u8; 8];
+                                        let mut bb = [0u8; 8];
+                                        ab.copy_from_slice(&a.bytes[i*8..i*8+8]);
+                                        bb.copy_from_slice(&b.bytes[i*8..i*8+8]);
+                                        let fa = f64::from_le_bytes(ab);
+                                        let fb = f64::from_le_bytes(bb);
+                                        result[i*8..i*8+8].copy_from_slice(&(fa - fb).to_le_bytes());
+                                    }
+                                    operand_stack.push(Value::V128(V128::new(result)));
+                                }
+                            }
+                            0xF2 => {
+                                // f64x2.mul
+                                if let (Some(Value::V128(b)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    let mut result = [0u8; 16];
+                                    for i in 0..2 {
+                                        let mut ab = [0u8; 8];
+                                        let mut bb = [0u8; 8];
+                                        ab.copy_from_slice(&a.bytes[i*8..i*8+8]);
+                                        bb.copy_from_slice(&b.bytes[i*8..i*8+8]);
+                                        let fa = f64::from_le_bytes(ab);
+                                        let fb = f64::from_le_bytes(bb);
+                                        result[i*8..i*8+8].copy_from_slice(&(fa * fb).to_le_bytes());
+                                    }
+                                    operand_stack.push(Value::V128(V128::new(result)));
+                                }
+                            }
+                            0xF3 => {
+                                // f64x2.div
+                                if let (Some(Value::V128(b)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    let mut result = [0u8; 16];
+                                    for i in 0..2 {
+                                        let mut ab = [0u8; 8];
+                                        let mut bb = [0u8; 8];
+                                        ab.copy_from_slice(&a.bytes[i*8..i*8+8]);
+                                        bb.copy_from_slice(&b.bytes[i*8..i*8+8]);
+                                        let fa = f64::from_le_bytes(ab);
+                                        let fb = f64::from_le_bytes(bb);
+                                        result[i*8..i*8+8].copy_from_slice(&(fa / fb).to_le_bytes());
+                                    }
+                                    operand_stack.push(Value::V128(V128::new(result)));
+                                }
+                            }
+
+                            // ========================================
+                            // f64x2 min/max/pmin/pmax (0xF4-0xF7)
+                            // ========================================
+                            0xF4 => {
+                                // f64x2.min (IEEE min: NaN propagates, -0 < +0)
+                                if let (Some(Value::V128(b)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    let mut result = [0u8; 16];
+                                    for i in 0..2 {
+                                        let mut ab = [0u8; 8];
+                                        let mut bb = [0u8; 8];
+                                        ab.copy_from_slice(&a.bytes[i*8..i*8+8]);
+                                        bb.copy_from_slice(&b.bytes[i*8..i*8+8]);
+                                        let fa = f64::from_le_bytes(ab);
+                                        let fb = f64::from_le_bytes(bb);
+                                        let r = if fa.is_nan() || fb.is_nan() {
+                                            f64::NAN
+                                        } else if fa == 0.0 && fb == 0.0 {
+                                            if fa.is_sign_negative() || fb.is_sign_negative() { -0.0_f64 } else { 0.0_f64 }
+                                        } else {
+                                            fa.min(fb)
+                                        };
+                                        result[i*8..i*8+8].copy_from_slice(&r.to_le_bytes());
+                                    }
+                                    operand_stack.push(Value::V128(V128::new(result)));
+                                }
+                            }
+                            0xF5 => {
+                                // f64x2.max (IEEE max: NaN propagates, +0 > -0)
+                                if let (Some(Value::V128(b)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    let mut result = [0u8; 16];
+                                    for i in 0..2 {
+                                        let mut ab = [0u8; 8];
+                                        let mut bb = [0u8; 8];
+                                        ab.copy_from_slice(&a.bytes[i*8..i*8+8]);
+                                        bb.copy_from_slice(&b.bytes[i*8..i*8+8]);
+                                        let fa = f64::from_le_bytes(ab);
+                                        let fb = f64::from_le_bytes(bb);
+                                        let r = if fa.is_nan() || fb.is_nan() {
+                                            f64::NAN
+                                        } else if fa == 0.0 && fb == 0.0 {
+                                            if fa.is_sign_positive() || fb.is_sign_positive() { 0.0_f64 } else { -0.0_f64 }
+                                        } else {
+                                            fa.max(fb)
+                                        };
+                                        result[i*8..i*8+8].copy_from_slice(&r.to_le_bytes());
+                                    }
+                                    operand_stack.push(Value::V128(V128::new(result)));
+                                }
+                            }
+                            0xF6 => {
+                                // f64x2.pmin: b < a ? b : a
+                                if let (Some(Value::V128(b)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    let mut result = [0u8; 16];
+                                    for i in 0..2 {
+                                        let mut ab = [0u8; 8];
+                                        let mut bb = [0u8; 8];
+                                        ab.copy_from_slice(&a.bytes[i*8..i*8+8]);
+                                        bb.copy_from_slice(&b.bytes[i*8..i*8+8]);
+                                        let fa = f64::from_le_bytes(ab);
+                                        let fb = f64::from_le_bytes(bb);
+                                        // pmin(a, b) = b < a ? b : a
+                                        let r = if fb < fa { fb } else { fa };
+                                        result[i*8..i*8+8].copy_from_slice(&r.to_le_bytes());
+                                    }
+                                    operand_stack.push(Value::V128(V128::new(result)));
+                                }
+                            }
+                            0xF7 => {
+                                // f64x2.pmax: a < b ? b : a
+                                if let (Some(Value::V128(b)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    let mut result = [0u8; 16];
+                                    for i in 0..2 {
+                                        let mut ab = [0u8; 8];
+                                        let mut bb = [0u8; 8];
+                                        ab.copy_from_slice(&a.bytes[i*8..i*8+8]);
+                                        bb.copy_from_slice(&b.bytes[i*8..i*8+8]);
+                                        let fa = f64::from_le_bytes(ab);
+                                        let fb = f64::from_le_bytes(bb);
+                                        // pmax(a, b) = a < b ? b : a
+                                        let r = if fa < fb { fb } else { fa };
+                                        result[i*8..i*8+8].copy_from_slice(&r.to_le_bytes());
+                                    }
+                                    operand_stack.push(Value::V128(V128::new(result)));
+                                }
+                            }
+
+                            // ========================================
+                            // i8x16.swizzle (0x0E)
+                            // ========================================
+                            0x0E => {
+                                if let (Some(Value::V128(s)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::i8x16_swizzle(&a.bytes, &s.bytes))));
+                                }
+                            }
+
+                            // ========================================
+                            // Splat operations (0x0F-0x14)
+                            // ========================================
+                            0x0F => {
+                                // i8x16.splat
+                                if let Some(val) = operand_stack.pop() {
+                                    let v = match val { Value::I32(n) => n as u8, _ => 0u8 };
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::splat_i8x16(v))));
+                                }
+                            }
+                            0x10 => {
+                                // i16x8.splat
+                                if let Some(val) = operand_stack.pop() {
+                                    let v = match val { Value::I32(n) => n as u16, _ => 0u16 };
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::splat_i16x8(v))));
+                                }
+                            }
+                            0x11 => {
+                                // i32x4.splat
+                                if let Some(val) = operand_stack.pop() {
+                                    let v = match val { Value::I32(n) => n as u32, _ => 0u32 };
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::splat_i32x4(v))));
+                                }
+                            }
+                            0x12 => {
+                                // i64x2.splat
+                                if let Some(val) = operand_stack.pop() {
+                                    let v = match val { Value::I64(n) => n as u64, _ => 0u64 };
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::splat_i64x2(v))));
+                                }
+                            }
+                            0x13 => {
+                                // f32x4.splat
+                                if let Some(val) = operand_stack.pop() {
+                                    let v = match val { Value::F32(n) => n.value(), _ => 0.0f32 };
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::splat_f32x4(v))));
+                                }
+                            }
+                            0x14 => {
+                                // f64x2.splat
+                                if let Some(val) = operand_stack.pop() {
+                                    let v = match val { Value::F64(n) => n.value(), _ => 0.0f64 };
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::splat_f64x2(v))));
+                                }
+                            }
+
+                            // ========================================
+                            // v128 bitwise operations (0x4D-0x53)
+                            // ========================================
+                            0x4D => {
+                                // v128.not
+                                if let Some(Value::V128(a)) = operand_stack.pop() {
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::v128_not(&a.bytes))));
+                                }
+                            }
+                            0x4E => {
+                                // v128.and
+                                if let (Some(Value::V128(b)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::v128_and(&a.bytes, &b.bytes))));
+                                }
+                            }
+                            0x4F => {
+                                // v128.andnot
+                                if let (Some(Value::V128(b)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::v128_andnot(&a.bytes, &b.bytes))));
+                                }
+                            }
+                            0x50 => {
+                                // v128.or
+                                if let (Some(Value::V128(b)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::v128_or(&a.bytes, &b.bytes))));
+                                }
+                            }
+                            0x51 => {
+                                // v128.xor
+                                if let (Some(Value::V128(b)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::v128_xor(&a.bytes, &b.bytes))));
+                                }
+                            }
+                            0x52 => {
+                                // v128.bitselect: (v1, v2, c) -> (v1 & c) | (v2 & ~c)
+                                if let (Some(Value::V128(c)), Some(Value::V128(v2)), Some(Value::V128(v1))) =
+                                    (operand_stack.pop(), operand_stack.pop(), operand_stack.pop()) {
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::v128_bitselect(&v1.bytes, &v2.bytes, &c.bytes))));
+                                }
+                            }
+                            0x53 => {
+                                // v128.any_true
+                                if let Some(Value::V128(a)) = operand_stack.pop() {
+                                    operand_stack.push(Value::I32(if simd_ops::v128_any_true(&a.bytes) { 1 } else { 0 }));
+                                }
+                            }
+
+                            // ========================================
+                            // Conversion: f32x4.demote/f64x2.promote (0x5E-0x5F)
+                            // ========================================
+                            0x5E => {
+                                if let Some(Value::V128(a)) = operand_stack.pop() {
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::f32x4_demote_f64x2_zero(&a.bytes))));
+                                }
+                            }
+                            0x5F => {
+                                if let Some(Value::V128(a)) = operand_stack.pop() {
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::f64x2_promote_low_f32x4(&a.bytes))));
+                                }
+                            }
+
+                            // ========================================
+                            // i8x16 unary (0x60-0x64)
+                            // ========================================
+                            0x60 => {
+                                if let Some(Value::V128(a)) = operand_stack.pop() {
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::i8x16_abs(&a.bytes))));
+                                }
+                            }
+                            0x61 => {
+                                if let Some(Value::V128(a)) = operand_stack.pop() {
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::i8x16_neg(&a.bytes))));
+                                }
+                            }
+                            0x62 => {
+                                if let Some(Value::V128(a)) = operand_stack.pop() {
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::i8x16_popcnt(&a.bytes))));
+                                }
+                            }
+                            0x63 => {
+                                if let Some(Value::V128(a)) = operand_stack.pop() {
+                                    operand_stack.push(Value::I32(if simd_ops::i8x16_all_true(&a.bytes) { 1 } else { 0 }));
+                                }
+                            }
+                            0x64 => {
+                                if let Some(Value::V128(a)) = operand_stack.pop() {
+                                    operand_stack.push(Value::I32(simd_ops::i8x16_bitmask(&a.bytes) as i32));
+                                }
+                            }
+
+                            // i8x16 narrow (0x65-0x66)
+                            0x65 => {
+                                if let (Some(Value::V128(b)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::i8x16_narrow_i16x8_s(&a.bytes, &b.bytes))));
+                                }
+                            }
+                            0x66 => {
+                                if let (Some(Value::V128(b)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::i8x16_narrow_i16x8_u(&a.bytes, &b.bytes))));
+                                }
+                            }
+
+                            // f32x4 ceil/floor/trunc/nearest (0x67-0x6A)
+                            0x67 => {
+                                if let Some(Value::V128(a)) = operand_stack.pop() {
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::f32x4_ceil(&a.bytes))));
+                                }
+                            }
+                            0x68 => {
+                                if let Some(Value::V128(a)) = operand_stack.pop() {
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::f32x4_floor(&a.bytes))));
+                                }
+                            }
+                            0x69 => {
+                                if let Some(Value::V128(a)) = operand_stack.pop() {
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::f32x4_trunc(&a.bytes))));
+                                }
+                            }
+                            0x6A => {
+                                if let Some(Value::V128(a)) = operand_stack.pop() {
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::f32x4_nearest(&a.bytes))));
+                                }
+                            }
+
+                            // i8x16 shift/arith (0x6B-0x73)
+                            0x6B => {
+                                if let (Some(Value::I32(s)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::i8x16_shl(&a.bytes, s as u32))));
+                                }
+                            }
+                            0x6C => {
+                                if let (Some(Value::I32(s)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::i8x16_shr_s(&a.bytes, s as u32))));
+                                }
+                            }
+                            0x6D => {
+                                if let (Some(Value::I32(s)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::i8x16_shr_u(&a.bytes, s as u32))));
+                                }
+                            }
+                            0x6E => {
+                                if let (Some(Value::V128(b)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::i8x16_add(&a.bytes, &b.bytes))));
+                                }
+                            }
+                            0x6F => {
+                                if let (Some(Value::V128(b)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::i8x16_add_sat_s(&a.bytes, &b.bytes))));
+                                }
+                            }
+                            0x70 => {
+                                if let (Some(Value::V128(b)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::i8x16_add_sat_u(&a.bytes, &b.bytes))));
+                                }
+                            }
+                            0x71 => {
+                                if let (Some(Value::V128(b)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::i8x16_sub(&a.bytes, &b.bytes))));
+                                }
+                            }
+                            0x72 => {
+                                if let (Some(Value::V128(b)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::i8x16_sub_sat_s(&a.bytes, &b.bytes))));
+                                }
+                            }
+                            0x73 => {
+                                if let (Some(Value::V128(b)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::i8x16_sub_sat_u(&a.bytes, &b.bytes))));
+                                }
+                            }
+
+                            // f64x2 ceil/floor (0x74-0x75)
+                            0x74 => {
+                                if let Some(Value::V128(a)) = operand_stack.pop() {
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::f64x2_ceil(&a.bytes))));
+                                }
+                            }
+                            0x75 => {
+                                if let Some(Value::V128(a)) = operand_stack.pop() {
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::f64x2_floor(&a.bytes))));
+                                }
+                            }
+
+                            // i8x16 min/max/avgr (0x76-0x7B)
+                            0x76 => {
+                                if let (Some(Value::V128(b)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::i8x16_min_s(&a.bytes, &b.bytes))));
+                                }
+                            }
+                            0x77 => {
+                                if let (Some(Value::V128(b)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::i8x16_min_u(&a.bytes, &b.bytes))));
+                                }
+                            }
+                            0x78 => {
+                                if let (Some(Value::V128(b)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::i8x16_max_s(&a.bytes, &b.bytes))));
+                                }
+                            }
+                            0x79 => {
+                                if let (Some(Value::V128(b)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::i8x16_max_u(&a.bytes, &b.bytes))));
+                                }
+                            }
+                            // f64x2.trunc (0x7A)
+                            0x7A => {
+                                if let Some(Value::V128(a)) = operand_stack.pop() {
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::f64x2_trunc(&a.bytes))));
+                                }
+                            }
+                            0x7B => {
+                                if let (Some(Value::V128(b)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::i8x16_avgr_u(&a.bytes, &b.bytes))));
+                                }
+                            }
+
+                            // Extended add pairwise (0x7C-0x7F)
+                            0x7C => {
+                                if let Some(Value::V128(a)) = operand_stack.pop() {
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::i16x8_extadd_pairwise_i8x16_s(&a.bytes))));
+                                }
+                            }
+                            0x7D => {
+                                if let Some(Value::V128(a)) = operand_stack.pop() {
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::i16x8_extadd_pairwise_i8x16_u(&a.bytes))));
+                                }
+                            }
+                            0x7E => {
+                                if let Some(Value::V128(a)) = operand_stack.pop() {
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::i32x4_extadd_pairwise_i16x8_s(&a.bytes))));
+                                }
+                            }
+                            0x7F => {
+                                if let Some(Value::V128(a)) = operand_stack.pop() {
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::i32x4_extadd_pairwise_i16x8_u(&a.bytes))));
+                                }
+                            }
+
+                            // i16x8 unary/test (0x80-0x84)
+                            0x80 => {
+                                if let Some(Value::V128(a)) = operand_stack.pop() {
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::i16x8_abs(&a.bytes))));
+                                }
+                            }
+                            0x81 => {
+                                if let Some(Value::V128(a)) = operand_stack.pop() {
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::i16x8_neg(&a.bytes))));
+                                }
+                            }
+                            0x82 => {
+                                if let (Some(Value::V128(b)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::i16x8_q15mulr_sat_s(&a.bytes, &b.bytes))));
+                                }
+                            }
+                            0x83 => {
+                                if let Some(Value::V128(a)) = operand_stack.pop() {
+                                    operand_stack.push(Value::I32(if simd_ops::i16x8_all_true(&a.bytes) { 1 } else { 0 }));
+                                }
+                            }
+                            0x84 => {
+                                if let Some(Value::V128(a)) = operand_stack.pop() {
+                                    operand_stack.push(Value::I32(simd_ops::i16x8_bitmask(&a.bytes) as i32));
+                                }
+                            }
+
+                            // i16x8 narrow (0x85-0x86)
+                            0x85 => {
+                                if let (Some(Value::V128(b)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::i16x8_narrow_i32x4_s(&a.bytes, &b.bytes))));
+                                }
+                            }
+                            0x86 => {
+                                if let (Some(Value::V128(b)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::i16x8_narrow_i32x4_u(&a.bytes, &b.bytes))));
+                                }
+                            }
+
+                            // i16x8 extend (0x87-0x8A)
+                            0x87 => {
+                                if let Some(Value::V128(a)) = operand_stack.pop() {
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::i16x8_extend_low_i8x16_s(&a.bytes))));
+                                }
+                            }
+                            0x88 => {
+                                if let Some(Value::V128(a)) = operand_stack.pop() {
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::i16x8_extend_low_i8x16_u(&a.bytes))));
+                                }
+                            }
+                            0x89 => {
+                                if let Some(Value::V128(a)) = operand_stack.pop() {
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::i16x8_extend_high_i8x16_s(&a.bytes))));
+                                }
+                            }
+                            0x8A => {
+                                if let Some(Value::V128(a)) = operand_stack.pop() {
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::i16x8_extend_high_i8x16_u(&a.bytes))));
+                                }
+                            }
+
+                            // i16x8 shift/arith (0x8B-0x95)
+                            0x8B => {
+                                if let (Some(Value::I32(s)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::i16x8_shl(&a.bytes, s as u32))));
+                                }
+                            }
+                            0x8C => {
+                                if let (Some(Value::I32(s)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::i16x8_shr_s(&a.bytes, s as u32))));
+                                }
+                            }
+                            0x8D => {
+                                if let (Some(Value::I32(s)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::i16x8_shr_u(&a.bytes, s as u32))));
+                                }
+                            }
+                            0x8E => {
+                                if let (Some(Value::V128(b)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::i16x8_add(&a.bytes, &b.bytes))));
+                                }
+                            }
+                            0x8F => {
+                                if let (Some(Value::V128(b)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::i16x8_add_sat_s(&a.bytes, &b.bytes))));
+                                }
+                            }
+                            0x90 => {
+                                if let (Some(Value::V128(b)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::i16x8_add_sat_u(&a.bytes, &b.bytes))));
+                                }
+                            }
+                            0x91 => {
+                                if let (Some(Value::V128(b)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::i16x8_sub(&a.bytes, &b.bytes))));
+                                }
+                            }
+                            0x92 => {
+                                if let (Some(Value::V128(b)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::i16x8_sub_sat_s(&a.bytes, &b.bytes))));
+                                }
+                            }
+                            0x93 => {
+                                if let (Some(Value::V128(b)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::i16x8_sub_sat_u(&a.bytes, &b.bytes))));
+                                }
+                            }
+                            // f64x2.nearest (0x94)
+                            0x94 => {
+                                if let Some(Value::V128(a)) = operand_stack.pop() {
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::f64x2_nearest(&a.bytes))));
+                                }
+                            }
+                            0x95 => {
+                                if let (Some(Value::V128(b)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::i16x8_mul(&a.bytes, &b.bytes))));
+                                }
+                            }
+
+                            // i16x8 min/max/avgr (0x96-0x9B)
+                            0x96 => {
+                                if let (Some(Value::V128(b)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::i16x8_min_s(&a.bytes, &b.bytes))));
+                                }
+                            }
+                            0x97 => {
+                                if let (Some(Value::V128(b)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::i16x8_min_u(&a.bytes, &b.bytes))));
+                                }
+                            }
+                            0x98 => {
+                                if let (Some(Value::V128(b)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::i16x8_max_s(&a.bytes, &b.bytes))));
+                                }
+                            }
+                            0x99 => {
+                                if let (Some(Value::V128(b)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::i16x8_max_u(&a.bytes, &b.bytes))));
+                                }
+                            }
+                            0x9B => {
+                                if let (Some(Value::V128(b)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::i16x8_avgr_u(&a.bytes, &b.bytes))));
+                                }
+                            }
+
+                            // i16x8 extended multiply (0x9C-0x9F)
+                            0x9C => {
+                                if let (Some(Value::V128(b)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::i16x8_extmul_low_i8x16_s(&a.bytes, &b.bytes))));
+                                }
+                            }
+                            0x9D => {
+                                if let (Some(Value::V128(b)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::i16x8_extmul_high_i8x16_s(&a.bytes, &b.bytes))));
+                                }
+                            }
+                            0x9E => {
+                                if let (Some(Value::V128(b)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::i16x8_extmul_low_i8x16_u(&a.bytes, &b.bytes))));
+                                }
+                            }
+                            0x9F => {
+                                if let (Some(Value::V128(b)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::i16x8_extmul_high_i8x16_u(&a.bytes, &b.bytes))));
+                                }
+                            }
+
+                            // i32x4 unary/test (0xA0-0xA4)
+                            0xA0 => {
+                                if let Some(Value::V128(a)) = operand_stack.pop() {
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::i32x4_abs(&a.bytes))));
+                                }
+                            }
+                            0xA1 => {
+                                if let Some(Value::V128(a)) = operand_stack.pop() {
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::i32x4_neg(&a.bytes))));
+                                }
+                            }
+                            0xA3 => {
+                                if let Some(Value::V128(a)) = operand_stack.pop() {
+                                    operand_stack.push(Value::I32(if simd_ops::i32x4_all_true(&a.bytes) { 1 } else { 0 }));
+                                }
+                            }
+                            0xA4 => {
+                                if let Some(Value::V128(a)) = operand_stack.pop() {
+                                    operand_stack.push(Value::I32(simd_ops::i32x4_bitmask(&a.bytes) as i32));
+                                }
+                            }
+
+                            // i32x4 extend (0xA7-0xAA)
+                            0xA7 => {
+                                if let Some(Value::V128(a)) = operand_stack.pop() {
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::i32x4_extend_low_i16x8_s(&a.bytes))));
+                                }
+                            }
+                            0xA8 => {
+                                if let Some(Value::V128(a)) = operand_stack.pop() {
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::i32x4_extend_low_i16x8_u(&a.bytes))));
+                                }
+                            }
+                            0xA9 => {
+                                if let Some(Value::V128(a)) = operand_stack.pop() {
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::i32x4_extend_high_i16x8_s(&a.bytes))));
+                                }
+                            }
+                            0xAA => {
+                                if let Some(Value::V128(a)) = operand_stack.pop() {
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::i32x4_extend_high_i16x8_u(&a.bytes))));
+                                }
+                            }
+
+                            // i32x4 shift/arith (0xAB-0xB5)
+                            0xAB => {
+                                if let (Some(Value::I32(s)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::i32x4_shl(&a.bytes, s as u32))));
+                                }
+                            }
+                            0xAC => {
+                                if let (Some(Value::I32(s)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::i32x4_shr_s(&a.bytes, s as u32))));
+                                }
+                            }
+                            0xAD => {
+                                if let (Some(Value::I32(s)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::i32x4_shr_u(&a.bytes, s as u32))));
+                                }
+                            }
+                            0xAE => {
+                                if let (Some(Value::V128(b)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::i32x4_add(&a.bytes, &b.bytes))));
+                                }
+                            }
+                            0xB1 => {
+                                if let (Some(Value::V128(b)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::i32x4_sub(&a.bytes, &b.bytes))));
+                                }
+                            }
+                            0xB5 => {
+                                if let (Some(Value::V128(b)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::i32x4_mul(&a.bytes, &b.bytes))));
+                                }
+                            }
+
+                            // i32x4 min/max/dot (0xB6-0xBA)
+                            0xB6 => {
+                                if let (Some(Value::V128(b)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::i32x4_min_s(&a.bytes, &b.bytes))));
+                                }
+                            }
+                            0xB7 => {
+                                if let (Some(Value::V128(b)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::i32x4_min_u(&a.bytes, &b.bytes))));
+                                }
+                            }
+                            0xB8 => {
+                                if let (Some(Value::V128(b)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::i32x4_max_s(&a.bytes, &b.bytes))));
+                                }
+                            }
+                            0xB9 => {
+                                if let (Some(Value::V128(b)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::i32x4_max_u(&a.bytes, &b.bytes))));
+                                }
+                            }
+                            0xBA => {
+                                if let (Some(Value::V128(b)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::i32x4_dot_i16x8_s(&a.bytes, &b.bytes))));
+                                }
+                            }
+
+                            // i32x4 extended multiply (0xBC-0xBF)
+                            0xBC => {
+                                if let (Some(Value::V128(b)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::i32x4_extmul_low_i16x8_s(&a.bytes, &b.bytes))));
+                                }
+                            }
+                            0xBD => {
+                                if let (Some(Value::V128(b)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::i32x4_extmul_high_i16x8_s(&a.bytes, &b.bytes))));
+                                }
+                            }
+                            0xBE => {
+                                if let (Some(Value::V128(b)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::i32x4_extmul_low_i16x8_u(&a.bytes, &b.bytes))));
+                                }
+                            }
+                            0xBF => {
+                                if let (Some(Value::V128(b)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::i32x4_extmul_high_i16x8_u(&a.bytes, &b.bytes))));
+                                }
+                            }
+
+                            // i64x2 unary/test (0xC0-0xC4)
+                            0xC0 => {
+                                if let Some(Value::V128(a)) = operand_stack.pop() {
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::i64x2_abs(&a.bytes))));
+                                }
+                            }
+                            0xC1 => {
+                                if let Some(Value::V128(a)) = operand_stack.pop() {
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::i64x2_neg(&a.bytes))));
+                                }
+                            }
+                            0xC3 => {
+                                if let Some(Value::V128(a)) = operand_stack.pop() {
+                                    operand_stack.push(Value::I32(if simd_ops::i64x2_all_true(&a.bytes) { 1 } else { 0 }));
+                                }
+                            }
+                            0xC4 => {
+                                if let Some(Value::V128(a)) = operand_stack.pop() {
+                                    operand_stack.push(Value::I32(simd_ops::i64x2_bitmask(&a.bytes) as i32));
+                                }
+                            }
+
+                            // i64x2 extend (0xC7-0xCA)
+                            0xC7 => {
+                                if let Some(Value::V128(a)) = operand_stack.pop() {
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::i64x2_extend_low_i32x4_s(&a.bytes))));
+                                }
+                            }
+                            0xC8 => {
+                                if let Some(Value::V128(a)) = operand_stack.pop() {
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::i64x2_extend_low_i32x4_u(&a.bytes))));
+                                }
+                            }
+                            0xC9 => {
+                                if let Some(Value::V128(a)) = operand_stack.pop() {
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::i64x2_extend_high_i32x4_s(&a.bytes))));
+                                }
+                            }
+                            0xCA => {
+                                if let Some(Value::V128(a)) = operand_stack.pop() {
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::i64x2_extend_high_i32x4_u(&a.bytes))));
+                                }
+                            }
+
+                            // i64x2 shift/arith (0xCB-0xD5)
+                            0xCB => {
+                                if let (Some(Value::I32(s)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::i64x2_shl(&a.bytes, s as u32))));
+                                }
+                            }
+                            0xCC => {
+                                if let (Some(Value::I32(s)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::i64x2_shr_s(&a.bytes, s as u32))));
+                                }
+                            }
+                            0xCD => {
+                                if let (Some(Value::I32(s)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::i64x2_shr_u(&a.bytes, s as u32))));
+                                }
+                            }
+                            0xCE => {
+                                if let (Some(Value::V128(b)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::i64x2_add(&a.bytes, &b.bytes))));
+                                }
+                            }
+                            0xD1 => {
+                                if let (Some(Value::V128(b)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::i64x2_sub(&a.bytes, &b.bytes))));
+                                }
+                            }
+                            0xD5 => {
+                                if let (Some(Value::V128(b)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::i64x2_mul(&a.bytes, &b.bytes))));
+                                }
+                            }
+
+                            // i64x2 extended multiply (0xDC-0xDF)
+                            0xDC => {
+                                if let (Some(Value::V128(b)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::i64x2_extmul_low_i32x4_s(&a.bytes, &b.bytes))));
+                                }
+                            }
+                            0xDD => {
+                                if let (Some(Value::V128(b)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::i64x2_extmul_high_i32x4_s(&a.bytes, &b.bytes))));
+                                }
+                            }
+                            0xDE => {
+                                if let (Some(Value::V128(b)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::i64x2_extmul_low_i32x4_u(&a.bytes, &b.bytes))));
+                                }
+                            }
+                            0xDF => {
+                                if let (Some(Value::V128(b)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::i64x2_extmul_high_i32x4_u(&a.bytes, &b.bytes))));
+                                }
+                            }
+
+                            // Conversion operations (0xF8-0xFF)
+                            0xF8 => {
+                                if let Some(Value::V128(a)) = operand_stack.pop() {
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::i32x4_trunc_sat_f32x4_s(&a.bytes))));
+                                }
+                            }
+                            0xF9 => {
+                                if let Some(Value::V128(a)) = operand_stack.pop() {
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::i32x4_trunc_sat_f32x4_u(&a.bytes))));
+                                }
+                            }
+                            0xFA => {
+                                if let Some(Value::V128(a)) = operand_stack.pop() {
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::f32x4_convert_i32x4_s(&a.bytes))));
+                                }
+                            }
+                            0xFB => {
+                                if let Some(Value::V128(a)) = operand_stack.pop() {
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::f32x4_convert_i32x4_u(&a.bytes))));
+                                }
+                            }
+                            0xFC => {
+                                if let Some(Value::V128(a)) = operand_stack.pop() {
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::i32x4_trunc_sat_f64x2_s_zero(&a.bytes))));
+                                }
+                            }
+                            0xFD => {
+                                if let Some(Value::V128(a)) = operand_stack.pop() {
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::i32x4_trunc_sat_f64x2_u_zero(&a.bytes))));
+                                }
+                            }
+                            0xFE => {
+                                if let Some(Value::V128(a)) = operand_stack.pop() {
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::f64x2_convert_low_i32x4_s(&a.bytes))));
+                                }
+                            }
+                            0xFF => {
+                                if let Some(Value::V128(a)) = operand_stack.pop() {
+                                    operand_stack.push(Value::V128(V128::new(simd_ops::f64x2_convert_low_i32x4_u(&a.bytes))));
+                                }
+                            }
+
+                            _ => {
+                                #[cfg(feature = "tracing")]
+                                error!("Unimplemented SIMD opcode at pc={}: 0x{:X}", pc, opcode);
+                                return Err(wrt_error::Error::runtime_error(
+                                    "Unimplemented SIMD instruction",
+                                ));
+                            }
+                        }
+                    }
+
+                    // ========================================
+                    // SIMD Memory Operations (v128.load, v128.store, etc.)
+                    // ========================================
+                    Instruction::SimdMemOp { opcode, memarg } => {
+                        match opcode {
+                            0x00 => {
+                                // v128.load
+                                let (addr, is_mem64) = pop_memory_address(&mut operand_stack, &instance, memarg.memory_index as u32)?;
+                                let offset = effective_address_for_memory(addr, memarg.offset, 16, is_mem64)? as u32;
+                                match instance.memory(memarg.memory_index as u32) {
+                                    Ok(mw) => {
+                                        let mut buf = [0u8; 16];
+                                        match mw.0.read(offset, &mut buf) {
+                                            Ok(()) => operand_stack.push(Value::V128(V128::new(buf))),
+                                            Err(_) => return Err(wrt_error::Error::runtime_trap("out of bounds memory access")),
+                                        }
+                                    }
+                                    Err(_) => return Err(wrt_error::Error::runtime_trap("out of bounds memory access")),
+                                }
+                            }
+                            0x0B => {
+                                // v128.store
+                                if let Some(Value::V128(v)) = operand_stack.pop() {
+                                    let (addr, is_mem64) = pop_memory_address(&mut operand_stack, &instance, memarg.memory_index as u32)?;
+                                    let offset = effective_address_for_memory(addr, memarg.offset, 16, is_mem64)? as u32;
+                                    match instance.memory(memarg.memory_index as u32) {
+                                        Ok(mw) => {
+                                            match mw.0.write_shared(offset, &v.bytes) {
+                                                Ok(()) => {}
+                                                Err(_) => return Err(wrt_error::Error::runtime_trap("out of bounds memory access")),
+                                            }
+                                        }
+                                        Err(_) => return Err(wrt_error::Error::runtime_trap("out of bounds memory access")),
+                                    }
+                                }
+                            }
+                            0x01 => {
+                                // v128.load8x8_s
+                                let (addr, is_mem64) = pop_memory_address(&mut operand_stack, &instance, memarg.memory_index as u32)?;
+                                let offset = effective_address_for_memory(addr, memarg.offset, 8, is_mem64)? as u32;
+                                match instance.memory(memarg.memory_index as u32) {
+                                    Ok(mw) => {
+                                        let mut buf = [0u8; 8];
+                                        match mw.0.read(offset, &mut buf) {
+                                            Ok(()) => {
+                                                let mut r = [0u8; 16];
+                                                for i in 0..8 { simd_ops::set_i16(&mut r, i, buf[i] as i8 as i16); }
+                                                operand_stack.push(Value::V128(V128::new(r)));
+                                            }
+                                            Err(_) => return Err(wrt_error::Error::runtime_trap("out of bounds memory access")),
+                                        }
+                                    }
+                                    Err(_) => return Err(wrt_error::Error::runtime_trap("out of bounds memory access")),
+                                }
+                            }
+                            0x02 => {
+                                // v128.load8x8_u
+                                let (addr, is_mem64) = pop_memory_address(&mut operand_stack, &instance, memarg.memory_index as u32)?;
+                                let offset = effective_address_for_memory(addr, memarg.offset, 8, is_mem64)? as u32;
+                                match instance.memory(memarg.memory_index as u32) {
+                                    Ok(mw) => {
+                                        let mut buf = [0u8; 8];
+                                        match mw.0.read(offset, &mut buf) {
+                                            Ok(()) => {
+                                                let mut r = [0u8; 16];
+                                                for i in 0..8 { simd_ops::set_u16(&mut r, i, buf[i] as u16); }
+                                                operand_stack.push(Value::V128(V128::new(r)));
+                                            }
+                                            Err(_) => return Err(wrt_error::Error::runtime_trap("out of bounds memory access")),
+                                        }
+                                    }
+                                    Err(_) => return Err(wrt_error::Error::runtime_trap("out of bounds memory access")),
+                                }
+                            }
+                            0x03 => {
+                                // v128.load16x4_s
+                                let (addr, is_mem64) = pop_memory_address(&mut operand_stack, &instance, memarg.memory_index as u32)?;
+                                let offset = effective_address_for_memory(addr, memarg.offset, 8, is_mem64)? as u32;
+                                match instance.memory(memarg.memory_index as u32) {
+                                    Ok(mw) => {
+                                        let mut buf = [0u8; 8];
+                                        match mw.0.read(offset, &mut buf) {
+                                            Ok(()) => {
+                                                let mut r = [0u8; 16];
+                                                for i in 0..4 {
+                                                    let v = i16::from_le_bytes([buf[i*2], buf[i*2+1]]);
+                                                    simd_ops::set_i32(&mut r, i, v as i32);
+                                                }
+                                                operand_stack.push(Value::V128(V128::new(r)));
+                                            }
+                                            Err(_) => return Err(wrt_error::Error::runtime_trap("out of bounds memory access")),
+                                        }
+                                    }
+                                    Err(_) => return Err(wrt_error::Error::runtime_trap("out of bounds memory access")),
+                                }
+                            }
+                            0x04 => {
+                                // v128.load16x4_u
+                                let (addr, is_mem64) = pop_memory_address(&mut operand_stack, &instance, memarg.memory_index as u32)?;
+                                let offset = effective_address_for_memory(addr, memarg.offset, 8, is_mem64)? as u32;
+                                match instance.memory(memarg.memory_index as u32) {
+                                    Ok(mw) => {
+                                        let mut buf = [0u8; 8];
+                                        match mw.0.read(offset, &mut buf) {
+                                            Ok(()) => {
+                                                let mut r = [0u8; 16];
+                                                for i in 0..4 {
+                                                    let v = u16::from_le_bytes([buf[i*2], buf[i*2+1]]);
+                                                    simd_ops::set_u32(&mut r, i, v as u32);
+                                                }
+                                                operand_stack.push(Value::V128(V128::new(r)));
+                                            }
+                                            Err(_) => return Err(wrt_error::Error::runtime_trap("out of bounds memory access")),
+                                        }
+                                    }
+                                    Err(_) => return Err(wrt_error::Error::runtime_trap("out of bounds memory access")),
+                                }
+                            }
+                            0x05 => {
+                                // v128.load32x2_s
+                                let (addr, is_mem64) = pop_memory_address(&mut operand_stack, &instance, memarg.memory_index as u32)?;
+                                let offset = effective_address_for_memory(addr, memarg.offset, 8, is_mem64)? as u32;
+                                match instance.memory(memarg.memory_index as u32) {
+                                    Ok(mw) => {
+                                        let mut buf = [0u8; 8];
+                                        match mw.0.read(offset, &mut buf) {
+                                            Ok(()) => {
+                                                let mut r = [0u8; 16];
+                                                for i in 0..2 {
+                                                    let v = i32::from_le_bytes([buf[i*4], buf[i*4+1], buf[i*4+2], buf[i*4+3]]);
+                                                    simd_ops::set_i64(&mut r, i, v as i64);
+                                                }
+                                                operand_stack.push(Value::V128(V128::new(r)));
+                                            }
+                                            Err(_) => return Err(wrt_error::Error::runtime_trap("out of bounds memory access")),
+                                        }
+                                    }
+                                    Err(_) => return Err(wrt_error::Error::runtime_trap("out of bounds memory access")),
+                                }
+                            }
+                            0x06 => {
+                                // v128.load32x2_u
+                                let (addr, is_mem64) = pop_memory_address(&mut operand_stack, &instance, memarg.memory_index as u32)?;
+                                let offset = effective_address_for_memory(addr, memarg.offset, 8, is_mem64)? as u32;
+                                match instance.memory(memarg.memory_index as u32) {
+                                    Ok(mw) => {
+                                        let mut buf = [0u8; 8];
+                                        match mw.0.read(offset, &mut buf) {
+                                            Ok(()) => {
+                                                let mut r = [0u8; 16];
+                                                for i in 0..2 {
+                                                    let v = u32::from_le_bytes([buf[i*4], buf[i*4+1], buf[i*4+2], buf[i*4+3]]);
+                                                    simd_ops::set_u64(&mut r, i, v as u64);
+                                                }
+                                                operand_stack.push(Value::V128(V128::new(r)));
+                                            }
+                                            Err(_) => return Err(wrt_error::Error::runtime_trap("out of bounds memory access")),
+                                        }
+                                    }
+                                    Err(_) => return Err(wrt_error::Error::runtime_trap("out of bounds memory access")),
+                                }
+                            }
+                            0x07 => {
+                                // v128.load8_splat
+                                let (addr, is_mem64) = pop_memory_address(&mut operand_stack, &instance, memarg.memory_index as u32)?;
+                                let offset = effective_address_for_memory(addr, memarg.offset, 1, is_mem64)? as u32;
+                                match instance.memory(memarg.memory_index as u32) {
+                                    Ok(mw) => {
+                                        let mut buf = [0u8; 1];
+                                        match mw.0.read(offset, &mut buf) {
+                                            Ok(()) => operand_stack.push(Value::V128(V128::new([buf[0]; 16]))),
+                                            Err(_) => return Err(wrt_error::Error::runtime_trap("out of bounds memory access")),
+                                        }
+                                    }
+                                    Err(_) => return Err(wrt_error::Error::runtime_trap("out of bounds memory access")),
+                                }
+                            }
+                            0x08 => {
+                                // v128.load16_splat
+                                let (addr, is_mem64) = pop_memory_address(&mut operand_stack, &instance, memarg.memory_index as u32)?;
+                                let offset = effective_address_for_memory(addr, memarg.offset, 2, is_mem64)? as u32;
+                                match instance.memory(memarg.memory_index as u32) {
+                                    Ok(mw) => {
+                                        let mut buf = [0u8; 2];
+                                        match mw.0.read(offset, &mut buf) {
+                                            Ok(()) => {
+                                                let val = u16::from_le_bytes(buf);
+                                                operand_stack.push(Value::V128(V128::new(simd_ops::splat_i16x8(val))));
+                                            }
+                                            Err(_) => return Err(wrt_error::Error::runtime_trap("out of bounds memory access")),
+                                        }
+                                    }
+                                    Err(_) => return Err(wrt_error::Error::runtime_trap("out of bounds memory access")),
+                                }
+                            }
+                            0x09 => {
+                                // v128.load32_splat
+                                let (addr, is_mem64) = pop_memory_address(&mut operand_stack, &instance, memarg.memory_index as u32)?;
+                                let offset = effective_address_for_memory(addr, memarg.offset, 4, is_mem64)? as u32;
+                                match instance.memory(memarg.memory_index as u32) {
+                                    Ok(mw) => {
+                                        let mut buf = [0u8; 4];
+                                        match mw.0.read(offset, &mut buf) {
+                                            Ok(()) => {
+                                                let val = u32::from_le_bytes(buf);
+                                                operand_stack.push(Value::V128(V128::new(simd_ops::splat_i32x4(val))));
+                                            }
+                                            Err(_) => return Err(wrt_error::Error::runtime_trap("out of bounds memory access")),
+                                        }
+                                    }
+                                    Err(_) => return Err(wrt_error::Error::runtime_trap("out of bounds memory access")),
+                                }
+                            }
+                            0x0A => {
+                                // v128.load64_splat
+                                let (addr, is_mem64) = pop_memory_address(&mut operand_stack, &instance, memarg.memory_index as u32)?;
+                                let offset = effective_address_for_memory(addr, memarg.offset, 8, is_mem64)? as u32;
+                                match instance.memory(memarg.memory_index as u32) {
+                                    Ok(mw) => {
+                                        let mut buf = [0u8; 8];
+                                        match mw.0.read(offset, &mut buf) {
+                                            Ok(()) => {
+                                                let mut b8 = [0u8; 8];
+                                                b8.copy_from_slice(&buf);
+                                                let val = u64::from_le_bytes(b8);
+                                                operand_stack.push(Value::V128(V128::new(simd_ops::splat_i64x2(val))));
+                                            }
+                                            Err(_) => return Err(wrt_error::Error::runtime_trap("out of bounds memory access")),
+                                        }
+                                    }
+                                    Err(_) => return Err(wrt_error::Error::runtime_trap("out of bounds memory access")),
+                                }
+                            }
+                            0x5C => {
+                                // v128.load32_zero
+                                let (addr, is_mem64) = pop_memory_address(&mut operand_stack, &instance, memarg.memory_index as u32)?;
+                                let offset = effective_address_for_memory(addr, memarg.offset, 4, is_mem64)? as u32;
+                                match instance.memory(memarg.memory_index as u32) {
+                                    Ok(mw) => {
+                                        let mut buf = [0u8; 4];
+                                        match mw.0.read(offset, &mut buf) {
+                                            Ok(()) => {
+                                                let mut r = [0u8; 16];
+                                                r[0..4].copy_from_slice(&buf);
+                                                operand_stack.push(Value::V128(V128::new(r)));
+                                            }
+                                            Err(_) => return Err(wrt_error::Error::runtime_trap("out of bounds memory access")),
+                                        }
+                                    }
+                                    Err(_) => return Err(wrt_error::Error::runtime_trap("out of bounds memory access")),
+                                }
+                            }
+                            0x5D => {
+                                // v128.load64_zero
+                                let (addr, is_mem64) = pop_memory_address(&mut operand_stack, &instance, memarg.memory_index as u32)?;
+                                let offset = effective_address_for_memory(addr, memarg.offset, 8, is_mem64)? as u32;
+                                match instance.memory(memarg.memory_index as u32) {
+                                    Ok(mw) => {
+                                        let mut buf = [0u8; 8];
+                                        match mw.0.read(offset, &mut buf) {
+                                            Ok(()) => {
+                                                let mut r = [0u8; 16];
+                                                r[0..8].copy_from_slice(&buf);
+                                                operand_stack.push(Value::V128(V128::new(r)));
+                                            }
+                                            Err(_) => return Err(wrt_error::Error::runtime_trap("out of bounds memory access")),
+                                        }
+                                    }
+                                    Err(_) => return Err(wrt_error::Error::runtime_trap("out of bounds memory access")),
+                                }
+                            }
+                            _ => {
+                                #[cfg(feature = "tracing")]
+                                error!("Unimplemented SIMD memory opcode at pc={}: 0x{:X}", pc, opcode);
+                                return Err(wrt_error::Error::runtime_error("Unimplemented SIMD memory instruction"));
+                            }
+                        }
+                    }
+
+                    // ========================================
+                    // SIMD Shuffle (i8x16.shuffle)
+                    // ========================================
+                    Instruction::SimdShuffle { lanes } => {
+                        if let (Some(Value::V128(b)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                            operand_stack.push(Value::V128(V128::new(simd_ops::i8x16_shuffle(&a.bytes, &b.bytes, &lanes))));
+                        }
+                    }
+
+                    // ========================================
+                    // SIMD Lane Operations (extract/replace)
+                    // ========================================
+                    Instruction::SimdLaneOp { opcode, lane } => {
+                        match opcode {
+                            0x15 => {
+                                if let Some(Value::V128(a)) = operand_stack.pop() {
+                                    operand_stack.push(Value::I32(simd_ops::get_i8(&a.bytes, lane as usize) as i32));
+                                }
+                            }
+                            0x16 => {
+                                if let Some(Value::V128(a)) = operand_stack.pop() {
+                                    operand_stack.push(Value::I32(simd_ops::get_u8(&a.bytes, lane as usize) as i32));
+                                }
+                            }
+                            0x17 => {
+                                if let (Some(Value::I32(val)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    let mut r = a.bytes;
+                                    simd_ops::set_u8(&mut r, lane as usize, val as u8);
+                                    operand_stack.push(Value::V128(V128::new(r)));
+                                }
+                            }
+                            0x18 => {
+                                if let Some(Value::V128(a)) = operand_stack.pop() {
+                                    operand_stack.push(Value::I32(simd_ops::get_i16(&a.bytes, lane as usize) as i32));
+                                }
+                            }
+                            0x19 => {
+                                if let Some(Value::V128(a)) = operand_stack.pop() {
+                                    operand_stack.push(Value::I32(simd_ops::get_u16(&a.bytes, lane as usize) as i32));
+                                }
+                            }
+                            0x1A => {
+                                if let (Some(Value::I32(val)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    let mut r = a.bytes;
+                                    simd_ops::set_u16(&mut r, lane as usize, val as u16);
+                                    operand_stack.push(Value::V128(V128::new(r)));
+                                }
+                            }
+                            0x1B => {
+                                if let Some(Value::V128(a)) = operand_stack.pop() {
+                                    operand_stack.push(Value::I32(simd_ops::get_i32(&a.bytes, lane as usize)));
+                                }
+                            }
+                            0x1C => {
+                                if let (Some(Value::I32(val)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    let mut r = a.bytes;
+                                    simd_ops::set_i32(&mut r, lane as usize, val);
+                                    operand_stack.push(Value::V128(V128::new(r)));
+                                }
+                            }
+                            0x1D => {
+                                if let Some(Value::V128(a)) = operand_stack.pop() {
+                                    operand_stack.push(Value::I64(simd_ops::get_i64(&a.bytes, lane as usize)));
+                                }
+                            }
+                            0x1E => {
+                                if let (Some(Value::I64(val)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    let mut r = a.bytes;
+                                    simd_ops::set_i64(&mut r, lane as usize, val);
+                                    operand_stack.push(Value::V128(V128::new(r)));
+                                }
+                            }
+                            0x1F => {
+                                if let Some(Value::V128(a)) = operand_stack.pop() {
+                                    operand_stack.push(Value::F32(FloatBits32::from_float(simd_ops::get_f32(&a.bytes, lane as usize))));
+                                }
+                            }
+                            0x20 => {
+                                if let (Some(Value::F32(val)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    let mut r = a.bytes;
+                                    simd_ops::set_f32(&mut r, lane as usize, val.value());
+                                    operand_stack.push(Value::V128(V128::new(r)));
+                                }
+                            }
+                            0x21 => {
+                                if let Some(Value::V128(a)) = operand_stack.pop() {
+                                    operand_stack.push(Value::F64(FloatBits64::from_float(simd_ops::get_f64(&a.bytes, lane as usize))));
+                                }
+                            }
+                            0x22 => {
+                                if let (Some(Value::F64(val)), Some(Value::V128(a))) = (operand_stack.pop(), operand_stack.pop()) {
+                                    let mut r = a.bytes;
+                                    simd_ops::set_f64(&mut r, lane as usize, val.value());
+                                    operand_stack.push(Value::V128(V128::new(r)));
+                                }
+                            }
+                            _ => {
+                                #[cfg(feature = "tracing")]
+                                error!("Unimplemented SIMD lane opcode at pc={}: 0x{:X}", pc, opcode);
+                                return Err(wrt_error::Error::runtime_error("Unimplemented SIMD lane instruction"));
+                            }
+                        }
+                    }
+
+                    // ========================================
+                    // SIMD Memory Lane Operations (load/store lane)
+                    // ========================================
+                    Instruction::SimdMemLaneOp { opcode, memarg, lane } => {
+                        match opcode {
+                            0x54 => {
+                                // v128.load8_lane
+                                if let Some(Value::V128(v)) = operand_stack.pop() {
+                                    let (addr, is_mem64) = pop_memory_address(&mut operand_stack, &instance, memarg.memory_index as u32)?;
+                                    let offset = effective_address_for_memory(addr, memarg.offset, 1, is_mem64)? as u32;
+                                    match instance.memory(memarg.memory_index as u32) {
+                                        Ok(mw) => {
+                                            let mut buf = [0u8; 1];
+                                            match mw.0.read(offset, &mut buf) {
+                                                Ok(()) => {
+                                                    let mut r = v.bytes;
+                                                    r[lane as usize] = buf[0];
+                                                    operand_stack.push(Value::V128(V128::new(r)));
+                                                }
+                                                Err(_) => return Err(wrt_error::Error::runtime_trap("out of bounds memory access")),
+                                            }
+                                        }
+                                        Err(_) => return Err(wrt_error::Error::runtime_trap("out of bounds memory access")),
+                                    }
+                                }
+                            }
+                            0x55 => {
+                                // v128.load16_lane
+                                if let Some(Value::V128(v)) = operand_stack.pop() {
+                                    let (addr, is_mem64) = pop_memory_address(&mut operand_stack, &instance, memarg.memory_index as u32)?;
+                                    let offset = effective_address_for_memory(addr, memarg.offset, 2, is_mem64)? as u32;
+                                    match instance.memory(memarg.memory_index as u32) {
+                                        Ok(mw) => {
+                                            let mut buf = [0u8; 2];
+                                            match mw.0.read(offset, &mut buf) {
+                                                Ok(()) => {
+                                                    let mut r = v.bytes;
+                                                    let o = lane as usize * 2;
+                                                    r[o] = buf[0]; r[o+1] = buf[1];
+                                                    operand_stack.push(Value::V128(V128::new(r)));
+                                                }
+                                                Err(_) => return Err(wrt_error::Error::runtime_trap("out of bounds memory access")),
+                                            }
+                                        }
+                                        Err(_) => return Err(wrt_error::Error::runtime_trap("out of bounds memory access")),
+                                    }
+                                }
+                            }
+                            0x56 => {
+                                // v128.load32_lane
+                                if let Some(Value::V128(v)) = operand_stack.pop() {
+                                    let (addr, is_mem64) = pop_memory_address(&mut operand_stack, &instance, memarg.memory_index as u32)?;
+                                    let offset = effective_address_for_memory(addr, memarg.offset, 4, is_mem64)? as u32;
+                                    match instance.memory(memarg.memory_index as u32) {
+                                        Ok(mw) => {
+                                            let mut buf = [0u8; 4];
+                                            match mw.0.read(offset, &mut buf) {
+                                                Ok(()) => {
+                                                    let mut r = v.bytes;
+                                                    let o = lane as usize * 4;
+                                                    r[o..o+4].copy_from_slice(&buf);
+                                                    operand_stack.push(Value::V128(V128::new(r)));
+                                                }
+                                                Err(_) => return Err(wrt_error::Error::runtime_trap("out of bounds memory access")),
+                                            }
+                                        }
+                                        Err(_) => return Err(wrt_error::Error::runtime_trap("out of bounds memory access")),
+                                    }
+                                }
+                            }
+                            0x57 => {
+                                // v128.load64_lane
+                                if let Some(Value::V128(v)) = operand_stack.pop() {
+                                    let (addr, is_mem64) = pop_memory_address(&mut operand_stack, &instance, memarg.memory_index as u32)?;
+                                    let offset = effective_address_for_memory(addr, memarg.offset, 8, is_mem64)? as u32;
+                                    match instance.memory(memarg.memory_index as u32) {
+                                        Ok(mw) => {
+                                            let mut buf = [0u8; 8];
+                                            match mw.0.read(offset, &mut buf) {
+                                                Ok(()) => {
+                                                    let mut r = v.bytes;
+                                                    let o = lane as usize * 8;
+                                                    r[o..o+8].copy_from_slice(&buf);
+                                                    operand_stack.push(Value::V128(V128::new(r)));
+                                                }
+                                                Err(_) => return Err(wrt_error::Error::runtime_trap("out of bounds memory access")),
+                                            }
+                                        }
+                                        Err(_) => return Err(wrt_error::Error::runtime_trap("out of bounds memory access")),
+                                    }
+                                }
+                            }
+                            0x58 => {
+                                // v128.store8_lane
+                                if let Some(Value::V128(v)) = operand_stack.pop() {
+                                    let (addr, is_mem64) = pop_memory_address(&mut operand_stack, &instance, memarg.memory_index as u32)?;
+                                    let offset = effective_address_for_memory(addr, memarg.offset, 1, is_mem64)? as u32;
+                                    match instance.memory(memarg.memory_index as u32) {
+                                        Ok(mw) => {
+                                            match mw.0.write_shared(offset, &[v.bytes[lane as usize]]) {
+                                                Ok(()) => {}
+                                                Err(_) => return Err(wrt_error::Error::runtime_trap("out of bounds memory access")),
+                                            }
+                                        }
+                                        Err(_) => return Err(wrt_error::Error::runtime_trap("out of bounds memory access")),
+                                    }
+                                }
+                            }
+                            0x59 => {
+                                // v128.store16_lane
+                                if let Some(Value::V128(v)) = operand_stack.pop() {
+                                    let (addr, is_mem64) = pop_memory_address(&mut operand_stack, &instance, memarg.memory_index as u32)?;
+                                    let offset = effective_address_for_memory(addr, memarg.offset, 2, is_mem64)? as u32;
+                                    let o = lane as usize * 2;
+                                    match instance.memory(memarg.memory_index as u32) {
+                                        Ok(mw) => {
+                                            match mw.0.write_shared(offset, &v.bytes[o..o+2]) {
+                                                Ok(()) => {}
+                                                Err(_) => return Err(wrt_error::Error::runtime_trap("out of bounds memory access")),
+                                            }
+                                        }
+                                        Err(_) => return Err(wrt_error::Error::runtime_trap("out of bounds memory access")),
+                                    }
+                                }
+                            }
+                            0x5A => {
+                                // v128.store32_lane
+                                if let Some(Value::V128(v)) = operand_stack.pop() {
+                                    let (addr, is_mem64) = pop_memory_address(&mut operand_stack, &instance, memarg.memory_index as u32)?;
+                                    let offset = effective_address_for_memory(addr, memarg.offset, 4, is_mem64)? as u32;
+                                    let o = lane as usize * 4;
+                                    match instance.memory(memarg.memory_index as u32) {
+                                        Ok(mw) => {
+                                            match mw.0.write_shared(offset, &v.bytes[o..o+4]) {
+                                                Ok(()) => {}
+                                                Err(_) => return Err(wrt_error::Error::runtime_trap("out of bounds memory access")),
+                                            }
+                                        }
+                                        Err(_) => return Err(wrt_error::Error::runtime_trap("out of bounds memory access")),
+                                    }
+                                }
+                            }
+                            0x5B => {
+                                // v128.store64_lane
+                                if let Some(Value::V128(v)) = operand_stack.pop() {
+                                    let (addr, is_mem64) = pop_memory_address(&mut operand_stack, &instance, memarg.memory_index as u32)?;
+                                    let offset = effective_address_for_memory(addr, memarg.offset, 8, is_mem64)? as u32;
+                                    let o = lane as usize * 8;
+                                    match instance.memory(memarg.memory_index as u32) {
+                                        Ok(mw) => {
+                                            match mw.0.write_shared(offset, &v.bytes[o..o+8]) {
+                                                Ok(()) => {}
+                                                Err(_) => return Err(wrt_error::Error::runtime_trap("out of bounds memory access")),
+                                            }
+                                        }
+                                        Err(_) => return Err(wrt_error::Error::runtime_trap("out of bounds memory access")),
+                                    }
+                                }
+                            }
+                            _ => {
+                                #[cfg(feature = "tracing")]
+                                error!("Unimplemented SIMD memory lane opcode at pc={}: 0x{:X}", pc, opcode);
+                                return Err(wrt_error::Error::runtime_error("Unimplemented SIMD memory lane instruction"));
+                            }
+                        }
                     }
 
                     _ => {

--- a/wrt-runtime/src/stackless/mod.rs
+++ b/wrt-runtime/src/stackless/mod.rs
@@ -18,6 +18,7 @@ type String =
 pub mod engine;
 pub mod extensions;
 pub mod frame;
+pub mod simd_ops;
 
 #[cfg(feature = "std")]
 pub mod tail_call;

--- a/wrt-runtime/src/stackless/simd_ops.rs
+++ b/wrt-runtime/src/stackless/simd_ops.rs
@@ -1,0 +1,1486 @@
+//! SIMD (V128) operation helper functions
+//!
+//! Pure computation helpers for SIMD operations. These functions operate on
+//! `[u8; 16]` byte arrays in little-endian format, matching the WebAssembly
+//! V128 value representation.
+
+// ============================================================
+// Lane accessor helpers
+// ============================================================
+
+#[inline]
+pub fn get_i8(v: &[u8; 16], lane: usize) -> i8 {
+    v[lane] as i8
+}
+
+#[inline]
+pub fn set_i8(v: &mut [u8; 16], lane: usize, val: i8) {
+    v[lane] = val as u8;
+}
+
+#[inline]
+pub fn get_u8(v: &[u8; 16], lane: usize) -> u8 {
+    v[lane]
+}
+
+#[inline]
+pub fn set_u8(v: &mut [u8; 16], lane: usize, val: u8) {
+    v[lane] = val;
+}
+
+#[inline]
+pub fn get_i16(v: &[u8; 16], lane: usize) -> i16 {
+    i16::from_le_bytes([v[lane * 2], v[lane * 2 + 1]])
+}
+
+#[inline]
+pub fn set_i16(v: &mut [u8; 16], lane: usize, val: i16) {
+    let b = val.to_le_bytes();
+    v[lane * 2] = b[0];
+    v[lane * 2 + 1] = b[1];
+}
+
+#[inline]
+pub fn get_u16(v: &[u8; 16], lane: usize) -> u16 {
+    u16::from_le_bytes([v[lane * 2], v[lane * 2 + 1]])
+}
+
+#[inline]
+pub fn set_u16(v: &mut [u8; 16], lane: usize, val: u16) {
+    let b = val.to_le_bytes();
+    v[lane * 2] = b[0];
+    v[lane * 2 + 1] = b[1];
+}
+
+#[inline]
+pub fn get_i32(v: &[u8; 16], lane: usize) -> i32 {
+    let o = lane * 4;
+    i32::from_le_bytes([v[o], v[o + 1], v[o + 2], v[o + 3]])
+}
+
+#[inline]
+pub fn set_i32(v: &mut [u8; 16], lane: usize, val: i32) {
+    let o = lane * 4;
+    let b = val.to_le_bytes();
+    v[o] = b[0];
+    v[o + 1] = b[1];
+    v[o + 2] = b[2];
+    v[o + 3] = b[3];
+}
+
+#[inline]
+pub fn get_u32(v: &[u8; 16], lane: usize) -> u32 {
+    let o = lane * 4;
+    u32::from_le_bytes([v[o], v[o + 1], v[o + 2], v[o + 3]])
+}
+
+#[inline]
+pub fn set_u32(v: &mut [u8; 16], lane: usize, val: u32) {
+    let o = lane * 4;
+    let b = val.to_le_bytes();
+    v[o] = b[0];
+    v[o + 1] = b[1];
+    v[o + 2] = b[2];
+    v[o + 3] = b[3];
+}
+
+#[inline]
+pub fn get_i64(v: &[u8; 16], lane: usize) -> i64 {
+    let o = lane * 8;
+    let mut b = [0u8; 8];
+    b.copy_from_slice(&v[o..o + 8]);
+    i64::from_le_bytes(b)
+}
+
+#[inline]
+pub fn set_i64(v: &mut [u8; 16], lane: usize, val: i64) {
+    let o = lane * 8;
+    v[o..o + 8].copy_from_slice(&val.to_le_bytes());
+}
+
+#[inline]
+pub fn get_u64(v: &[u8; 16], lane: usize) -> u64 {
+    let o = lane * 8;
+    let mut b = [0u8; 8];
+    b.copy_from_slice(&v[o..o + 8]);
+    u64::from_le_bytes(b)
+}
+
+#[inline]
+pub fn set_u64(v: &mut [u8; 16], lane: usize, val: u64) {
+    let o = lane * 8;
+    v[o..o + 8].copy_from_slice(&val.to_le_bytes());
+}
+
+#[inline]
+pub fn get_f32(v: &[u8; 16], lane: usize) -> f32 {
+    let o = lane * 4;
+    f32::from_le_bytes([v[o], v[o + 1], v[o + 2], v[o + 3]])
+}
+
+#[inline]
+pub fn set_f32(v: &mut [u8; 16], lane: usize, val: f32) {
+    let o = lane * 4;
+    let b = val.to_le_bytes();
+    v[o] = b[0];
+    v[o + 1] = b[1];
+    v[o + 2] = b[2];
+    v[o + 3] = b[3];
+}
+
+#[inline]
+pub fn get_f64(v: &[u8; 16], lane: usize) -> f64 {
+    let o = lane * 8;
+    let mut b = [0u8; 8];
+    b.copy_from_slice(&v[o..o + 8]);
+    f64::from_le_bytes(b)
+}
+
+#[inline]
+pub fn set_f64(v: &mut [u8; 16], lane: usize, val: f64) {
+    let o = lane * 8;
+    v[o..o + 8].copy_from_slice(&val.to_le_bytes());
+}
+
+// ============================================================
+// Splat operations
+// ============================================================
+
+#[inline]
+pub fn splat_i8x16(val: u8) -> [u8; 16] {
+    [val; 16]
+}
+
+#[inline]
+pub fn splat_i16x8(val: u16) -> [u8; 16] {
+    let mut r = [0u8; 16];
+    for i in 0..8 {
+        set_u16(&mut r, i, val);
+    }
+    r
+}
+
+#[inline]
+pub fn splat_i32x4(val: u32) -> [u8; 16] {
+    let mut r = [0u8; 16];
+    for i in 0..4 {
+        set_u32(&mut r, i, val);
+    }
+    r
+}
+
+#[inline]
+pub fn splat_i64x2(val: u64) -> [u8; 16] {
+    let mut r = [0u8; 16];
+    set_u64(&mut r, 0, val);
+    set_u64(&mut r, 1, val);
+    r
+}
+
+#[inline]
+pub fn splat_f32x4(val: f32) -> [u8; 16] {
+    let mut r = [0u8; 16];
+    for i in 0..4 {
+        set_f32(&mut r, i, val);
+    }
+    r
+}
+
+#[inline]
+pub fn splat_f64x2(val: f64) -> [u8; 16] {
+    let mut r = [0u8; 16];
+    set_f64(&mut r, 0, val);
+    set_f64(&mut r, 1, val);
+    r
+}
+
+// ============================================================
+// Bitwise operations
+// ============================================================
+
+#[inline]
+pub fn v128_not(v: &[u8; 16]) -> [u8; 16] {
+    let mut r = [0u8; 16];
+    for i in 0..16 {
+        r[i] = !v[i];
+    }
+    r
+}
+
+#[inline]
+pub fn v128_and(a: &[u8; 16], b: &[u8; 16]) -> [u8; 16] {
+    let mut r = [0u8; 16];
+    for i in 0..16 {
+        r[i] = a[i] & b[i];
+    }
+    r
+}
+
+#[inline]
+pub fn v128_andnot(a: &[u8; 16], b: &[u8; 16]) -> [u8; 16] {
+    let mut r = [0u8; 16];
+    for i in 0..16 {
+        r[i] = a[i] & !b[i];
+    }
+    r
+}
+
+#[inline]
+pub fn v128_or(a: &[u8; 16], b: &[u8; 16]) -> [u8; 16] {
+    let mut r = [0u8; 16];
+    for i in 0..16 {
+        r[i] = a[i] | b[i];
+    }
+    r
+}
+
+#[inline]
+pub fn v128_xor(a: &[u8; 16], b: &[u8; 16]) -> [u8; 16] {
+    let mut r = [0u8; 16];
+    for i in 0..16 {
+        r[i] = a[i] ^ b[i];
+    }
+    r
+}
+
+#[inline]
+pub fn v128_bitselect(v1: &[u8; 16], v2: &[u8; 16], c: &[u8; 16]) -> [u8; 16] {
+    // result = (v1 & c) | (v2 & ~c)
+    let mut r = [0u8; 16];
+    for i in 0..16 {
+        r[i] = (v1[i] & c[i]) | (v2[i] & !c[i]);
+    }
+    r
+}
+
+#[inline]
+pub fn v128_any_true(v: &[u8; 16]) -> bool {
+    v.iter().any(|&b| b != 0)
+}
+
+// ============================================================
+// i8x16 operations
+// ============================================================
+
+#[inline]
+pub fn i8x16_swizzle(a: &[u8; 16], s: &[u8; 16]) -> [u8; 16] {
+    let mut r = [0u8; 16];
+    for i in 0..16 {
+        let idx = s[i] as usize;
+        r[i] = if idx < 16 { a[idx] } else { 0 };
+    }
+    r
+}
+
+#[inline]
+pub fn i8x16_shuffle(a: &[u8; 16], b: &[u8; 16], lanes: &[u8; 16]) -> [u8; 16] {
+    let mut r = [0u8; 16];
+    let combined: [u8; 32] = {
+        let mut c = [0u8; 32];
+        c[..16].copy_from_slice(a);
+        c[16..].copy_from_slice(b);
+        c
+    };
+    for i in 0..16 {
+        let idx = lanes[i] as usize;
+        r[i] = if idx < 32 { combined[idx] } else { 0 };
+    }
+    r
+}
+
+#[inline]
+pub fn i8x16_abs(v: &[u8; 16]) -> [u8; 16] {
+    let mut r = [0u8; 16];
+    for i in 0..16 {
+        r[i] = (v[i] as i8).wrapping_abs() as u8;
+    }
+    r
+}
+
+#[inline]
+pub fn i8x16_neg(v: &[u8; 16]) -> [u8; 16] {
+    let mut r = [0u8; 16];
+    for i in 0..16 {
+        r[i] = (v[i] as i8).wrapping_neg() as u8;
+    }
+    r
+}
+
+#[inline]
+pub fn i8x16_popcnt(v: &[u8; 16]) -> [u8; 16] {
+    let mut r = [0u8; 16];
+    for i in 0..16 {
+        r[i] = v[i].count_ones() as u8;
+    }
+    r
+}
+
+#[inline]
+pub fn i8x16_all_true(v: &[u8; 16]) -> bool {
+    v.iter().all(|&b| b != 0)
+}
+
+#[inline]
+pub fn i8x16_bitmask(v: &[u8; 16]) -> u32 {
+    let mut mask = 0u32;
+    for i in 0..16 {
+        if (v[i] as i8) < 0 {
+            mask |= 1 << i;
+        }
+    }
+    mask
+}
+
+#[inline]
+pub fn i8x16_add(a: &[u8; 16], b: &[u8; 16]) -> [u8; 16] {
+    let mut r = [0u8; 16];
+    for i in 0..16 {
+        r[i] = a[i].wrapping_add(b[i]);
+    }
+    r
+}
+
+#[inline]
+pub fn i8x16_sub(a: &[u8; 16], b: &[u8; 16]) -> [u8; 16] {
+    let mut r = [0u8; 16];
+    for i in 0..16 {
+        r[i] = a[i].wrapping_sub(b[i]);
+    }
+    r
+}
+
+#[inline]
+pub fn i8x16_add_sat_s(a: &[u8; 16], b: &[u8; 16]) -> [u8; 16] {
+    let mut r = [0u8; 16];
+    for i in 0..16 {
+        r[i] = (a[i] as i8).saturating_add(b[i] as i8) as u8;
+    }
+    r
+}
+
+#[inline]
+pub fn i8x16_add_sat_u(a: &[u8; 16], b: &[u8; 16]) -> [u8; 16] {
+    let mut r = [0u8; 16];
+    for i in 0..16 {
+        r[i] = a[i].saturating_add(b[i]);
+    }
+    r
+}
+
+#[inline]
+pub fn i8x16_sub_sat_s(a: &[u8; 16], b: &[u8; 16]) -> [u8; 16] {
+    let mut r = [0u8; 16];
+    for i in 0..16 {
+        r[i] = (a[i] as i8).saturating_sub(b[i] as i8) as u8;
+    }
+    r
+}
+
+#[inline]
+pub fn i8x16_sub_sat_u(a: &[u8; 16], b: &[u8; 16]) -> [u8; 16] {
+    let mut r = [0u8; 16];
+    for i in 0..16 {
+        r[i] = a[i].saturating_sub(b[i]);
+    }
+    r
+}
+
+#[inline]
+pub fn i8x16_min_s(a: &[u8; 16], b: &[u8; 16]) -> [u8; 16] {
+    let mut r = [0u8; 16];
+    for i in 0..16 {
+        let va = a[i] as i8;
+        let vb = b[i] as i8;
+        r[i] = if va < vb { va } else { vb } as u8;
+    }
+    r
+}
+
+#[inline]
+pub fn i8x16_min_u(a: &[u8; 16], b: &[u8; 16]) -> [u8; 16] {
+    let mut r = [0u8; 16];
+    for i in 0..16 {
+        r[i] = a[i].min(b[i]);
+    }
+    r
+}
+
+#[inline]
+pub fn i8x16_max_s(a: &[u8; 16], b: &[u8; 16]) -> [u8; 16] {
+    let mut r = [0u8; 16];
+    for i in 0..16 {
+        let va = a[i] as i8;
+        let vb = b[i] as i8;
+        r[i] = if va > vb { va } else { vb } as u8;
+    }
+    r
+}
+
+#[inline]
+pub fn i8x16_max_u(a: &[u8; 16], b: &[u8; 16]) -> [u8; 16] {
+    let mut r = [0u8; 16];
+    for i in 0..16 {
+        r[i] = a[i].max(b[i]);
+    }
+    r
+}
+
+#[inline]
+pub fn i8x16_avgr_u(a: &[u8; 16], b: &[u8; 16]) -> [u8; 16] {
+    let mut r = [0u8; 16];
+    for i in 0..16 {
+        r[i] = ((a[i] as u16 + b[i] as u16 + 1) / 2) as u8;
+    }
+    r
+}
+
+#[inline]
+pub fn i8x16_shl(v: &[u8; 16], shift: u32) -> [u8; 16] {
+    let s = (shift % 8) as u8;
+    let mut r = [0u8; 16];
+    for i in 0..16 {
+        r[i] = v[i] << s;
+    }
+    r
+}
+
+#[inline]
+pub fn i8x16_shr_s(v: &[u8; 16], shift: u32) -> [u8; 16] {
+    let s = (shift % 8) as u8;
+    let mut r = [0u8; 16];
+    for i in 0..16 {
+        r[i] = ((v[i] as i8) >> s) as u8;
+    }
+    r
+}
+
+#[inline]
+pub fn i8x16_shr_u(v: &[u8; 16], shift: u32) -> [u8; 16] {
+    let s = (shift % 8) as u8;
+    let mut r = [0u8; 16];
+    for i in 0..16 {
+        r[i] = v[i] >> s;
+    }
+    r
+}
+
+#[inline]
+pub fn i8x16_narrow_i16x8_s(a: &[u8; 16], b: &[u8; 16]) -> [u8; 16] {
+    let mut r = [0u8; 16];
+    for i in 0..8 {
+        let va = get_i16(a, i) as i32;
+        r[i] = va.max(-128).min(127) as i8 as u8;
+    }
+    for i in 0..8 {
+        let vb = get_i16(b, i) as i32;
+        r[i + 8] = vb.max(-128).min(127) as i8 as u8;
+    }
+    r
+}
+
+#[inline]
+pub fn i8x16_narrow_i16x8_u(a: &[u8; 16], b: &[u8; 16]) -> [u8; 16] {
+    let mut r = [0u8; 16];
+    for i in 0..8 {
+        let va = get_i16(a, i) as i32;
+        r[i] = va.max(0).min(255) as u8;
+    }
+    for i in 0..8 {
+        let vb = get_i16(b, i) as i32;
+        r[i + 8] = vb.max(0).min(255) as u8;
+    }
+    r
+}
+
+// ============================================================
+// i16x8 operations
+// ============================================================
+
+#[inline]
+pub fn i16x8_abs(v: &[u8; 16]) -> [u8; 16] {
+    let mut r = [0u8; 16];
+    for i in 0..8 {
+        set_i16(&mut r, i, get_i16(v, i).wrapping_abs());
+    }
+    r
+}
+
+#[inline]
+pub fn i16x8_neg(v: &[u8; 16]) -> [u8; 16] {
+    let mut r = [0u8; 16];
+    for i in 0..8 {
+        set_i16(&mut r, i, get_i16(v, i).wrapping_neg());
+    }
+    r
+}
+
+#[inline]
+pub fn i16x8_all_true(v: &[u8; 16]) -> bool {
+    for i in 0..8 {
+        if get_u16(v, i) == 0 {
+            return false;
+        }
+    }
+    true
+}
+
+#[inline]
+pub fn i16x8_bitmask(v: &[u8; 16]) -> u32 {
+    let mut mask = 0u32;
+    for i in 0..8 {
+        if get_i16(v, i) < 0 {
+            mask |= 1 << i;
+        }
+    }
+    mask
+}
+
+#[inline]
+pub fn i16x8_add(a: &[u8; 16], b: &[u8; 16]) -> [u8; 16] {
+    let mut r = [0u8; 16];
+    for i in 0..8 {
+        set_u16(&mut r, i, get_u16(a, i).wrapping_add(get_u16(b, i)));
+    }
+    r
+}
+
+#[inline]
+pub fn i16x8_sub(a: &[u8; 16], b: &[u8; 16]) -> [u8; 16] {
+    let mut r = [0u8; 16];
+    for i in 0..8 {
+        set_u16(&mut r, i, get_u16(a, i).wrapping_sub(get_u16(b, i)));
+    }
+    r
+}
+
+#[inline]
+pub fn i16x8_mul(a: &[u8; 16], b: &[u8; 16]) -> [u8; 16] {
+    let mut r = [0u8; 16];
+    for i in 0..8 {
+        set_u16(&mut r, i, get_u16(a, i).wrapping_mul(get_u16(b, i)));
+    }
+    r
+}
+
+#[inline]
+pub fn i16x8_add_sat_s(a: &[u8; 16], b: &[u8; 16]) -> [u8; 16] {
+    let mut r = [0u8; 16];
+    for i in 0..8 {
+        set_i16(&mut r, i, get_i16(a, i).saturating_add(get_i16(b, i)));
+    }
+    r
+}
+
+#[inline]
+pub fn i16x8_add_sat_u(a: &[u8; 16], b: &[u8; 16]) -> [u8; 16] {
+    let mut r = [0u8; 16];
+    for i in 0..8 {
+        set_u16(&mut r, i, get_u16(a, i).saturating_add(get_u16(b, i)));
+    }
+    r
+}
+
+#[inline]
+pub fn i16x8_sub_sat_s(a: &[u8; 16], b: &[u8; 16]) -> [u8; 16] {
+    let mut r = [0u8; 16];
+    for i in 0..8 {
+        set_i16(&mut r, i, get_i16(a, i).saturating_sub(get_i16(b, i)));
+    }
+    r
+}
+
+#[inline]
+pub fn i16x8_sub_sat_u(a: &[u8; 16], b: &[u8; 16]) -> [u8; 16] {
+    let mut r = [0u8; 16];
+    for i in 0..8 {
+        set_u16(&mut r, i, get_u16(a, i).saturating_sub(get_u16(b, i)));
+    }
+    r
+}
+
+#[inline]
+pub fn i16x8_shl(v: &[u8; 16], shift: u32) -> [u8; 16] {
+    let s = (shift % 16) as u16;
+    let mut r = [0u8; 16];
+    for i in 0..8 {
+        set_u16(&mut r, i, get_u16(v, i) << s);
+    }
+    r
+}
+
+#[inline]
+pub fn i16x8_shr_s(v: &[u8; 16], shift: u32) -> [u8; 16] {
+    let s = (shift % 16) as u16;
+    let mut r = [0u8; 16];
+    for i in 0..8 {
+        set_i16(&mut r, i, get_i16(v, i) >> s);
+    }
+    r
+}
+
+#[inline]
+pub fn i16x8_shr_u(v: &[u8; 16], shift: u32) -> [u8; 16] {
+    let s = (shift % 16) as u16;
+    let mut r = [0u8; 16];
+    for i in 0..8 {
+        set_u16(&mut r, i, get_u16(v, i) >> s);
+    }
+    r
+}
+
+#[inline]
+pub fn i16x8_min_s(a: &[u8; 16], b: &[u8; 16]) -> [u8; 16] {
+    let mut r = [0u8; 16];
+    for i in 0..8 {
+        let va = get_i16(a, i);
+        let vb = get_i16(b, i);
+        set_i16(&mut r, i, if va < vb { va } else { vb });
+    }
+    r
+}
+
+#[inline]
+pub fn i16x8_min_u(a: &[u8; 16], b: &[u8; 16]) -> [u8; 16] {
+    let mut r = [0u8; 16];
+    for i in 0..8 {
+        set_u16(&mut r, i, get_u16(a, i).min(get_u16(b, i)));
+    }
+    r
+}
+
+#[inline]
+pub fn i16x8_max_s(a: &[u8; 16], b: &[u8; 16]) -> [u8; 16] {
+    let mut r = [0u8; 16];
+    for i in 0..8 {
+        let va = get_i16(a, i);
+        let vb = get_i16(b, i);
+        set_i16(&mut r, i, if va > vb { va } else { vb });
+    }
+    r
+}
+
+#[inline]
+pub fn i16x8_max_u(a: &[u8; 16], b: &[u8; 16]) -> [u8; 16] {
+    let mut r = [0u8; 16];
+    for i in 0..8 {
+        set_u16(&mut r, i, get_u16(a, i).max(get_u16(b, i)));
+    }
+    r
+}
+
+#[inline]
+pub fn i16x8_avgr_u(a: &[u8; 16], b: &[u8; 16]) -> [u8; 16] {
+    let mut r = [0u8; 16];
+    for i in 0..8 {
+        let sum = get_u16(a, i) as u32 + get_u16(b, i) as u32 + 1;
+        set_u16(&mut r, i, (sum / 2) as u16);
+    }
+    r
+}
+
+#[inline]
+pub fn i16x8_narrow_i32x4_s(a: &[u8; 16], b: &[u8; 16]) -> [u8; 16] {
+    let mut r = [0u8; 16];
+    for i in 0..4 {
+        let va = get_i32(a, i) as i64;
+        set_i16(&mut r, i, va.max(-32768).min(32767) as i16);
+    }
+    for i in 0..4 {
+        let vb = get_i32(b, i) as i64;
+        set_i16(&mut r, i + 4, vb.max(-32768).min(32767) as i16);
+    }
+    r
+}
+
+#[inline]
+pub fn i16x8_narrow_i32x4_u(a: &[u8; 16], b: &[u8; 16]) -> [u8; 16] {
+    let mut r = [0u8; 16];
+    for i in 0..4 {
+        let va = get_i32(a, i) as i64;
+        set_u16(&mut r, i, va.max(0).min(65535) as u16);
+    }
+    for i in 0..4 {
+        let vb = get_i32(b, i) as i64;
+        set_u16(&mut r, i + 4, vb.max(0).min(65535) as u16);
+    }
+    r
+}
+
+#[inline]
+pub fn i16x8_extend_low_i8x16_s(v: &[u8; 16]) -> [u8; 16] {
+    let mut r = [0u8; 16];
+    for i in 0..8 {
+        set_i16(&mut r, i, v[i] as i8 as i16);
+    }
+    r
+}
+
+#[inline]
+pub fn i16x8_extend_low_i8x16_u(v: &[u8; 16]) -> [u8; 16] {
+    let mut r = [0u8; 16];
+    for i in 0..8 {
+        set_u16(&mut r, i, v[i] as u16);
+    }
+    r
+}
+
+#[inline]
+pub fn i16x8_extend_high_i8x16_s(v: &[u8; 16]) -> [u8; 16] {
+    let mut r = [0u8; 16];
+    for i in 0..8 {
+        set_i16(&mut r, i, v[i + 8] as i8 as i16);
+    }
+    r
+}
+
+#[inline]
+pub fn i16x8_extend_high_i8x16_u(v: &[u8; 16]) -> [u8; 16] {
+    let mut r = [0u8; 16];
+    for i in 0..8 {
+        set_u16(&mut r, i, v[i + 8] as u16);
+    }
+    r
+}
+
+#[inline]
+pub fn i16x8_q15mulr_sat_s(a: &[u8; 16], b: &[u8; 16]) -> [u8; 16] {
+    let mut r = [0u8; 16];
+    for i in 0..8 {
+        let va = get_i16(a, i) as i32;
+        let vb = get_i16(b, i) as i32;
+        // Q15 multiply: (a * b + 0x4000) >> 15, saturated to i16
+        let product = ((va * vb) + 0x4000) >> 15;
+        set_i16(&mut r, i, product.max(-32768).min(32767) as i16);
+    }
+    r
+}
+
+#[inline]
+pub fn i16x8_extadd_pairwise_i8x16_s(v: &[u8; 16]) -> [u8; 16] {
+    let mut r = [0u8; 16];
+    for i in 0..8 {
+        let a = v[i * 2] as i8 as i16;
+        let b = v[i * 2 + 1] as i8 as i16;
+        set_i16(&mut r, i, a + b);
+    }
+    r
+}
+
+#[inline]
+pub fn i16x8_extadd_pairwise_i8x16_u(v: &[u8; 16]) -> [u8; 16] {
+    let mut r = [0u8; 16];
+    for i in 0..8 {
+        let a = v[i * 2] as u16;
+        let b = v[i * 2 + 1] as u16;
+        set_u16(&mut r, i, a + b);
+    }
+    r
+}
+
+#[inline]
+pub fn i16x8_extmul_low_i8x16_s(a: &[u8; 16], b: &[u8; 16]) -> [u8; 16] {
+    let mut r = [0u8; 16];
+    for i in 0..8 {
+        let va = a[i] as i8 as i16;
+        let vb = b[i] as i8 as i16;
+        set_i16(&mut r, i, va * vb);
+    }
+    r
+}
+
+#[inline]
+pub fn i16x8_extmul_high_i8x16_s(a: &[u8; 16], b: &[u8; 16]) -> [u8; 16] {
+    let mut r = [0u8; 16];
+    for i in 0..8 {
+        let va = a[i + 8] as i8 as i16;
+        let vb = b[i + 8] as i8 as i16;
+        set_i16(&mut r, i, va * vb);
+    }
+    r
+}
+
+#[inline]
+pub fn i16x8_extmul_low_i8x16_u(a: &[u8; 16], b: &[u8; 16]) -> [u8; 16] {
+    let mut r = [0u8; 16];
+    for i in 0..8 {
+        let va = a[i] as u16;
+        let vb = b[i] as u16;
+        set_u16(&mut r, i, va * vb);
+    }
+    r
+}
+
+#[inline]
+pub fn i16x8_extmul_high_i8x16_u(a: &[u8; 16], b: &[u8; 16]) -> [u8; 16] {
+    let mut r = [0u8; 16];
+    for i in 0..8 {
+        let va = a[i + 8] as u16;
+        let vb = b[i + 8] as u16;
+        set_u16(&mut r, i, va * vb);
+    }
+    r
+}
+
+// ============================================================
+// i32x4 operations
+// ============================================================
+
+#[inline]
+pub fn i32x4_abs(v: &[u8; 16]) -> [u8; 16] {
+    let mut r = [0u8; 16];
+    for i in 0..4 {
+        set_i32(&mut r, i, get_i32(v, i).wrapping_abs());
+    }
+    r
+}
+
+#[inline]
+pub fn i32x4_neg(v: &[u8; 16]) -> [u8; 16] {
+    let mut r = [0u8; 16];
+    for i in 0..4 {
+        set_i32(&mut r, i, get_i32(v, i).wrapping_neg());
+    }
+    r
+}
+
+#[inline]
+pub fn i32x4_all_true(v: &[u8; 16]) -> bool {
+    for i in 0..4 {
+        if get_u32(v, i) == 0 {
+            return false;
+        }
+    }
+    true
+}
+
+#[inline]
+pub fn i32x4_bitmask(v: &[u8; 16]) -> u32 {
+    let mut mask = 0u32;
+    for i in 0..4 {
+        if get_i32(v, i) < 0 {
+            mask |= 1 << i;
+        }
+    }
+    mask
+}
+
+#[inline]
+pub fn i32x4_add(a: &[u8; 16], b: &[u8; 16]) -> [u8; 16] {
+    let mut r = [0u8; 16];
+    for i in 0..4 {
+        set_u32(&mut r, i, get_u32(a, i).wrapping_add(get_u32(b, i)));
+    }
+    r
+}
+
+#[inline]
+pub fn i32x4_sub(a: &[u8; 16], b: &[u8; 16]) -> [u8; 16] {
+    let mut r = [0u8; 16];
+    for i in 0..4 {
+        set_u32(&mut r, i, get_u32(a, i).wrapping_sub(get_u32(b, i)));
+    }
+    r
+}
+
+#[inline]
+pub fn i32x4_mul(a: &[u8; 16], b: &[u8; 16]) -> [u8; 16] {
+    let mut r = [0u8; 16];
+    for i in 0..4 {
+        set_u32(&mut r, i, get_u32(a, i).wrapping_mul(get_u32(b, i)));
+    }
+    r
+}
+
+#[inline]
+pub fn i32x4_shl(v: &[u8; 16], shift: u32) -> [u8; 16] {
+    let s = shift % 32;
+    let mut r = [0u8; 16];
+    for i in 0..4 {
+        set_u32(&mut r, i, get_u32(v, i) << s);
+    }
+    r
+}
+
+#[inline]
+pub fn i32x4_shr_s(v: &[u8; 16], shift: u32) -> [u8; 16] {
+    let s = shift % 32;
+    let mut r = [0u8; 16];
+    for i in 0..4 {
+        set_i32(&mut r, i, get_i32(v, i) >> s);
+    }
+    r
+}
+
+#[inline]
+pub fn i32x4_shr_u(v: &[u8; 16], shift: u32) -> [u8; 16] {
+    let s = shift % 32;
+    let mut r = [0u8; 16];
+    for i in 0..4 {
+        set_u32(&mut r, i, get_u32(v, i) >> s);
+    }
+    r
+}
+
+#[inline]
+pub fn i32x4_min_s(a: &[u8; 16], b: &[u8; 16]) -> [u8; 16] {
+    let mut r = [0u8; 16];
+    for i in 0..4 {
+        let va = get_i32(a, i);
+        let vb = get_i32(b, i);
+        set_i32(&mut r, i, if va < vb { va } else { vb });
+    }
+    r
+}
+
+#[inline]
+pub fn i32x4_min_u(a: &[u8; 16], b: &[u8; 16]) -> [u8; 16] {
+    let mut r = [0u8; 16];
+    for i in 0..4 {
+        set_u32(&mut r, i, get_u32(a, i).min(get_u32(b, i)));
+    }
+    r
+}
+
+#[inline]
+pub fn i32x4_max_s(a: &[u8; 16], b: &[u8; 16]) -> [u8; 16] {
+    let mut r = [0u8; 16];
+    for i in 0..4 {
+        let va = get_i32(a, i);
+        let vb = get_i32(b, i);
+        set_i32(&mut r, i, if va > vb { va } else { vb });
+    }
+    r
+}
+
+#[inline]
+pub fn i32x4_max_u(a: &[u8; 16], b: &[u8; 16]) -> [u8; 16] {
+    let mut r = [0u8; 16];
+    for i in 0..4 {
+        set_u32(&mut r, i, get_u32(a, i).max(get_u32(b, i)));
+    }
+    r
+}
+
+#[inline]
+pub fn i32x4_dot_i16x8_s(a: &[u8; 16], b: &[u8; 16]) -> [u8; 16] {
+    let mut r = [0u8; 16];
+    for i in 0..4 {
+        let a0 = get_i16(a, i * 2) as i32;
+        let a1 = get_i16(a, i * 2 + 1) as i32;
+        let b0 = get_i16(b, i * 2) as i32;
+        let b1 = get_i16(b, i * 2 + 1) as i32;
+        set_i32(&mut r, i, a0 * b0 + a1 * b1);
+    }
+    r
+}
+
+#[inline]
+pub fn i32x4_extend_low_i16x8_s(v: &[u8; 16]) -> [u8; 16] {
+    let mut r = [0u8; 16];
+    for i in 0..4 {
+        set_i32(&mut r, i, get_i16(v, i) as i32);
+    }
+    r
+}
+
+#[inline]
+pub fn i32x4_extend_low_i16x8_u(v: &[u8; 16]) -> [u8; 16] {
+    let mut r = [0u8; 16];
+    for i in 0..4 {
+        set_u32(&mut r, i, get_u16(v, i) as u32);
+    }
+    r
+}
+
+#[inline]
+pub fn i32x4_extend_high_i16x8_s(v: &[u8; 16]) -> [u8; 16] {
+    let mut r = [0u8; 16];
+    for i in 0..4 {
+        set_i32(&mut r, i, get_i16(v, i + 4) as i32);
+    }
+    r
+}
+
+#[inline]
+pub fn i32x4_extend_high_i16x8_u(v: &[u8; 16]) -> [u8; 16] {
+    let mut r = [0u8; 16];
+    for i in 0..4 {
+        set_u32(&mut r, i, get_u16(v, i + 4) as u32);
+    }
+    r
+}
+
+#[inline]
+pub fn i32x4_extadd_pairwise_i16x8_s(v: &[u8; 16]) -> [u8; 16] {
+    let mut r = [0u8; 16];
+    for i in 0..4 {
+        let a = get_i16(v, i * 2) as i32;
+        let b = get_i16(v, i * 2 + 1) as i32;
+        set_i32(&mut r, i, a + b);
+    }
+    r
+}
+
+#[inline]
+pub fn i32x4_extadd_pairwise_i16x8_u(v: &[u8; 16]) -> [u8; 16] {
+    let mut r = [0u8; 16];
+    for i in 0..4 {
+        let a = get_u16(v, i * 2) as u32;
+        let b = get_u16(v, i * 2 + 1) as u32;
+        set_u32(&mut r, i, a + b);
+    }
+    r
+}
+
+#[inline]
+pub fn i32x4_extmul_low_i16x8_s(a: &[u8; 16], b: &[u8; 16]) -> [u8; 16] {
+    let mut r = [0u8; 16];
+    for i in 0..4 {
+        let va = get_i16(a, i) as i32;
+        let vb = get_i16(b, i) as i32;
+        set_i32(&mut r, i, va * vb);
+    }
+    r
+}
+
+#[inline]
+pub fn i32x4_extmul_high_i16x8_s(a: &[u8; 16], b: &[u8; 16]) -> [u8; 16] {
+    let mut r = [0u8; 16];
+    for i in 0..4 {
+        let va = get_i16(a, i + 4) as i32;
+        let vb = get_i16(b, i + 4) as i32;
+        set_i32(&mut r, i, va * vb);
+    }
+    r
+}
+
+#[inline]
+pub fn i32x4_extmul_low_i16x8_u(a: &[u8; 16], b: &[u8; 16]) -> [u8; 16] {
+    let mut r = [0u8; 16];
+    for i in 0..4 {
+        let va = get_u16(a, i) as u32;
+        let vb = get_u16(b, i) as u32;
+        set_u32(&mut r, i, va * vb);
+    }
+    r
+}
+
+#[inline]
+pub fn i32x4_extmul_high_i16x8_u(a: &[u8; 16], b: &[u8; 16]) -> [u8; 16] {
+    let mut r = [0u8; 16];
+    for i in 0..4 {
+        let va = get_u16(a, i + 4) as u32;
+        let vb = get_u16(b, i + 4) as u32;
+        set_u32(&mut r, i, va * vb);
+    }
+    r
+}
+
+// ============================================================
+// i64x2 operations
+// ============================================================
+
+#[inline]
+pub fn i64x2_abs(v: &[u8; 16]) -> [u8; 16] {
+    let mut r = [0u8; 16];
+    for i in 0..2 {
+        set_i64(&mut r, i, get_i64(v, i).wrapping_abs());
+    }
+    r
+}
+
+#[inline]
+pub fn i64x2_neg(v: &[u8; 16]) -> [u8; 16] {
+    let mut r = [0u8; 16];
+    for i in 0..2 {
+        set_i64(&mut r, i, get_i64(v, i).wrapping_neg());
+    }
+    r
+}
+
+#[inline]
+pub fn i64x2_all_true(v: &[u8; 16]) -> bool {
+    get_u64(v, 0) != 0 && get_u64(v, 1) != 0
+}
+
+#[inline]
+pub fn i64x2_bitmask(v: &[u8; 16]) -> u32 {
+    let mut mask = 0u32;
+    if get_i64(v, 0) < 0 { mask |= 1; }
+    if get_i64(v, 1) < 0 { mask |= 2; }
+    mask
+}
+
+#[inline]
+pub fn i64x2_add(a: &[u8; 16], b: &[u8; 16]) -> [u8; 16] {
+    let mut r = [0u8; 16];
+    for i in 0..2 {
+        set_u64(&mut r, i, get_u64(a, i).wrapping_add(get_u64(b, i)));
+    }
+    r
+}
+
+#[inline]
+pub fn i64x2_sub(a: &[u8; 16], b: &[u8; 16]) -> [u8; 16] {
+    let mut r = [0u8; 16];
+    for i in 0..2 {
+        set_u64(&mut r, i, get_u64(a, i).wrapping_sub(get_u64(b, i)));
+    }
+    r
+}
+
+#[inline]
+pub fn i64x2_mul(a: &[u8; 16], b: &[u8; 16]) -> [u8; 16] {
+    let mut r = [0u8; 16];
+    for i in 0..2 {
+        set_u64(&mut r, i, get_u64(a, i).wrapping_mul(get_u64(b, i)));
+    }
+    r
+}
+
+#[inline]
+pub fn i64x2_shl(v: &[u8; 16], shift: u32) -> [u8; 16] {
+    let s = (shift % 64) as u64;
+    let mut r = [0u8; 16];
+    for i in 0..2 {
+        set_u64(&mut r, i, get_u64(v, i) << s);
+    }
+    r
+}
+
+#[inline]
+pub fn i64x2_shr_s(v: &[u8; 16], shift: u32) -> [u8; 16] {
+    let s = (shift % 64) as u64;
+    let mut r = [0u8; 16];
+    for i in 0..2 {
+        set_i64(&mut r, i, get_i64(v, i) >> s);
+    }
+    r
+}
+
+#[inline]
+pub fn i64x2_shr_u(v: &[u8; 16], shift: u32) -> [u8; 16] {
+    let s = (shift % 64) as u64;
+    let mut r = [0u8; 16];
+    for i in 0..2 {
+        set_u64(&mut r, i, get_u64(v, i) >> s);
+    }
+    r
+}
+
+#[inline]
+pub fn i64x2_extend_low_i32x4_s(v: &[u8; 16]) -> [u8; 16] {
+    let mut r = [0u8; 16];
+    for i in 0..2 {
+        set_i64(&mut r, i, get_i32(v, i) as i64);
+    }
+    r
+}
+
+#[inline]
+pub fn i64x2_extend_low_i32x4_u(v: &[u8; 16]) -> [u8; 16] {
+    let mut r = [0u8; 16];
+    for i in 0..2 {
+        set_u64(&mut r, i, get_u32(v, i) as u64);
+    }
+    r
+}
+
+#[inline]
+pub fn i64x2_extend_high_i32x4_s(v: &[u8; 16]) -> [u8; 16] {
+    let mut r = [0u8; 16];
+    for i in 0..2 {
+        set_i64(&mut r, i, get_i32(v, i + 2) as i64);
+    }
+    r
+}
+
+#[inline]
+pub fn i64x2_extend_high_i32x4_u(v: &[u8; 16]) -> [u8; 16] {
+    let mut r = [0u8; 16];
+    for i in 0..2 {
+        set_u64(&mut r, i, get_u32(v, i + 2) as u64);
+    }
+    r
+}
+
+#[inline]
+pub fn i64x2_extmul_low_i32x4_s(a: &[u8; 16], b: &[u8; 16]) -> [u8; 16] {
+    let mut r = [0u8; 16];
+    for i in 0..2 {
+        let va = get_i32(a, i) as i64;
+        let vb = get_i32(b, i) as i64;
+        set_i64(&mut r, i, va * vb);
+    }
+    r
+}
+
+#[inline]
+pub fn i64x2_extmul_high_i32x4_s(a: &[u8; 16], b: &[u8; 16]) -> [u8; 16] {
+    let mut r = [0u8; 16];
+    for i in 0..2 {
+        let va = get_i32(a, i + 2) as i64;
+        let vb = get_i32(b, i + 2) as i64;
+        set_i64(&mut r, i, va * vb);
+    }
+    r
+}
+
+#[inline]
+pub fn i64x2_extmul_low_i32x4_u(a: &[u8; 16], b: &[u8; 16]) -> [u8; 16] {
+    let mut r = [0u8; 16];
+    for i in 0..2 {
+        let va = get_u32(a, i) as u64;
+        let vb = get_u32(b, i) as u64;
+        set_u64(&mut r, i, va * vb);
+    }
+    r
+}
+
+#[inline]
+pub fn i64x2_extmul_high_i32x4_u(a: &[u8; 16], b: &[u8; 16]) -> [u8; 16] {
+    let mut r = [0u8; 16];
+    for i in 0..2 {
+        let va = get_u32(a, i + 2) as u64;
+        let vb = get_u32(b, i + 2) as u64;
+        set_u64(&mut r, i, va * vb);
+    }
+    r
+}
+
+// ============================================================
+// Conversion operations
+// ============================================================
+
+#[inline]
+pub fn i32x4_trunc_sat_f32x4_s(v: &[u8; 16]) -> [u8; 16] {
+    let mut r = [0u8; 16];
+    for i in 0..4 {
+        let f = get_f32(v, i);
+        let val = if f.is_nan() {
+            0i32
+        } else if f >= i32::MAX as f32 {
+            i32::MAX
+        } else if f <= i32::MIN as f32 {
+            i32::MIN
+        } else {
+            f as i32
+        };
+        set_i32(&mut r, i, val);
+    }
+    r
+}
+
+#[inline]
+pub fn i32x4_trunc_sat_f32x4_u(v: &[u8; 16]) -> [u8; 16] {
+    let mut r = [0u8; 16];
+    for i in 0..4 {
+        let f = get_f32(v, i);
+        let val = if f.is_nan() || f <= -1.0 {
+            0u32
+        } else if f >= u32::MAX as f32 {
+            u32::MAX
+        } else {
+            f as u32
+        };
+        set_u32(&mut r, i, val);
+    }
+    r
+}
+
+#[inline]
+pub fn f32x4_convert_i32x4_s(v: &[u8; 16]) -> [u8; 16] {
+    let mut r = [0u8; 16];
+    for i in 0..4 {
+        set_f32(&mut r, i, get_i32(v, i) as f32);
+    }
+    r
+}
+
+#[inline]
+pub fn f32x4_convert_i32x4_u(v: &[u8; 16]) -> [u8; 16] {
+    let mut r = [0u8; 16];
+    for i in 0..4 {
+        set_f32(&mut r, i, get_u32(v, i) as f32);
+    }
+    r
+}
+
+#[inline]
+pub fn i32x4_trunc_sat_f64x2_s_zero(v: &[u8; 16]) -> [u8; 16] {
+    let mut r = [0u8; 16];
+    for i in 0..2 {
+        let f = get_f64(v, i);
+        let val = if f.is_nan() {
+            0i32
+        } else if f >= i32::MAX as f64 {
+            i32::MAX
+        } else if f <= i32::MIN as f64 {
+            i32::MIN
+        } else {
+            f as i32
+        };
+        set_i32(&mut r, i, val);
+    }
+    // lanes 2 and 3 are zero (already zeroed)
+    r
+}
+
+#[inline]
+pub fn i32x4_trunc_sat_f64x2_u_zero(v: &[u8; 16]) -> [u8; 16] {
+    let mut r = [0u8; 16];
+    for i in 0..2 {
+        let f = get_f64(v, i);
+        let val = if f.is_nan() || f <= -1.0 {
+            0u32
+        } else if f >= u32::MAX as f64 {
+            u32::MAX
+        } else {
+            f as u32
+        };
+        set_u32(&mut r, i, val);
+    }
+    // lanes 2 and 3 are zero (already zeroed)
+    r
+}
+
+#[inline]
+pub fn f64x2_convert_low_i32x4_s(v: &[u8; 16]) -> [u8; 16] {
+    let mut r = [0u8; 16];
+    for i in 0..2 {
+        set_f64(&mut r, i, get_i32(v, i) as f64);
+    }
+    r
+}
+
+#[inline]
+pub fn f64x2_convert_low_i32x4_u(v: &[u8; 16]) -> [u8; 16] {
+    let mut r = [0u8; 16];
+    for i in 0..2 {
+        set_f64(&mut r, i, get_u32(v, i) as f64);
+    }
+    r
+}
+
+#[inline]
+pub fn f32x4_demote_f64x2_zero(v: &[u8; 16]) -> [u8; 16] {
+    let mut r = [0u8; 16];
+    for i in 0..2 {
+        set_f32(&mut r, i, get_f64(v, i) as f32);
+    }
+    // lanes 2 and 3 are zero (already zeroed)
+    r
+}
+
+#[inline]
+pub fn f64x2_promote_low_f32x4(v: &[u8; 16]) -> [u8; 16] {
+    let mut r = [0u8; 16];
+    for i in 0..2 {
+        set_f64(&mut r, i, get_f32(v, i) as f64);
+    }
+    r
+}
+
+// ============================================================
+// Ceil/Floor/Trunc/Nearest for floats (0xE2 = f32x4.ceil, etc.)
+// ============================================================
+
+#[inline]
+pub fn f32x4_ceil(v: &[u8; 16]) -> [u8; 16] {
+    let mut r = [0u8; 16];
+    for i in 0..4 {
+        set_f32(&mut r, i, get_f32(v, i).ceil());
+    }
+    r
+}
+
+#[inline]
+pub fn f32x4_floor(v: &[u8; 16]) -> [u8; 16] {
+    let mut r = [0u8; 16];
+    for i in 0..4 {
+        set_f32(&mut r, i, get_f32(v, i).floor());
+    }
+    r
+}
+
+#[inline]
+pub fn f32x4_trunc(v: &[u8; 16]) -> [u8; 16] {
+    let mut r = [0u8; 16];
+    for i in 0..4 {
+        set_f32(&mut r, i, get_f32(v, i).trunc());
+    }
+    r
+}
+
+#[inline]
+pub fn f32x4_nearest(v: &[u8; 16]) -> [u8; 16] {
+    let mut r = [0u8; 16];
+    for i in 0..4 {
+        let f = get_f32(v, i);
+        // Round to nearest, ties to even (banker's rounding)
+        let rounded = f.round();
+        // Check for tie: if the fractional part is exactly 0.5
+        let frac = (f - f.floor()).abs();
+        let result = if (frac - 0.5).abs() < f32::EPSILON {
+            // Tie: round to even
+            if rounded as i64 % 2 != 0 {
+                // rounded is odd, go to even
+                if f > 0.0 { rounded - 1.0 } else { rounded + 1.0 }
+            } else {
+                rounded
+            }
+        } else {
+            rounded
+        };
+        set_f32(&mut r, i, result);
+    }
+    r
+}
+
+#[inline]
+pub fn f64x2_ceil(v: &[u8; 16]) -> [u8; 16] {
+    let mut r = [0u8; 16];
+    for i in 0..2 {
+        set_f64(&mut r, i, get_f64(v, i).ceil());
+    }
+    r
+}
+
+#[inline]
+pub fn f64x2_floor(v: &[u8; 16]) -> [u8; 16] {
+    let mut r = [0u8; 16];
+    for i in 0..2 {
+        set_f64(&mut r, i, get_f64(v, i).floor());
+    }
+    r
+}
+
+#[inline]
+pub fn f64x2_trunc(v: &[u8; 16]) -> [u8; 16] {
+    let mut r = [0u8; 16];
+    for i in 0..2 {
+        set_f64(&mut r, i, get_f64(v, i).trunc());
+    }
+    r
+}
+
+#[inline]
+pub fn f64x2_nearest(v: &[u8; 16]) -> [u8; 16] {
+    let mut r = [0u8; 16];
+    for i in 0..2 {
+        let f = get_f64(v, i);
+        let rounded = f.round();
+        let frac = (f - f.floor()).abs();
+        let result = if (frac - 0.5).abs() < f64::EPSILON {
+            if rounded as i64 % 2 != 0 {
+                if f > 0.0 { rounded - 1.0 } else { rounded + 1.0 }
+            } else {
+                rounded
+            }
+        } else {
+            rounded
+        };
+        set_f64(&mut r, i, result);
+    }
+    r
+}

--- a/wrt-runtime/src/stackless/simd_ops.rs
+++ b/wrt-runtime/src/stackless/simd_ops.rs
@@ -5,6 +5,38 @@
 //! V128 value representation.
 
 // ============================================================
+// NaN canonicalization helpers
+// ============================================================
+// WebAssembly spec requires all NaN results to be canonical quiet NaN.
+// Canonical NaN: f32 = 0x7FC00000, f64 = 0x7FF8000000000000
+
+/// Canonical quiet NaN for f32 (positive, quiet, no payload)
+const CANONICAL_NAN_F32: u32 = 0x7FC0_0000;
+
+/// Canonical quiet NaN for f64 (positive, quiet, no payload)
+const CANONICAL_NAN_F64: u64 = 0x7FF8_0000_0000_0000;
+
+/// If the f32 value is NaN, replace with canonical quiet NaN.
+#[inline]
+pub fn canonicalize_f32(v: f32) -> f32 {
+    if v.is_nan() {
+        f32::from_bits(CANONICAL_NAN_F32)
+    } else {
+        v
+    }
+}
+
+/// If the f64 value is NaN, replace with canonical quiet NaN.
+#[inline]
+pub fn canonicalize_f64(v: f64) -> f64 {
+    if v.is_nan() {
+        f64::from_bits(CANONICAL_NAN_F64)
+    } else {
+        v
+    }
+}
+
+// ============================================================
 // Lane accessor helpers
 // ============================================================
 
@@ -1366,7 +1398,7 @@ pub fn f64x2_convert_low_i32x4_u(v: &[u8; 16]) -> [u8; 16] {
 pub fn f32x4_demote_f64x2_zero(v: &[u8; 16]) -> [u8; 16] {
     let mut r = [0u8; 16];
     for i in 0..2 {
-        set_f32(&mut r, i, get_f64(v, i) as f32);
+        set_f32(&mut r, i, canonicalize_f32(get_f64(v, i) as f32));
     }
     // lanes 2 and 3 are zero (already zeroed)
     r
@@ -1376,7 +1408,7 @@ pub fn f32x4_demote_f64x2_zero(v: &[u8; 16]) -> [u8; 16] {
 pub fn f64x2_promote_low_f32x4(v: &[u8; 16]) -> [u8; 16] {
     let mut r = [0u8; 16];
     for i in 0..2 {
-        set_f64(&mut r, i, get_f32(v, i) as f64);
+        set_f64(&mut r, i, canonicalize_f64(get_f32(v, i) as f64));
     }
     r
 }
@@ -1389,7 +1421,7 @@ pub fn f64x2_promote_low_f32x4(v: &[u8; 16]) -> [u8; 16] {
 pub fn f32x4_ceil(v: &[u8; 16]) -> [u8; 16] {
     let mut r = [0u8; 16];
     for i in 0..4 {
-        set_f32(&mut r, i, get_f32(v, i).ceil());
+        set_f32(&mut r, i, canonicalize_f32(get_f32(v, i).ceil()));
     }
     r
 }
@@ -1398,7 +1430,7 @@ pub fn f32x4_ceil(v: &[u8; 16]) -> [u8; 16] {
 pub fn f32x4_floor(v: &[u8; 16]) -> [u8; 16] {
     let mut r = [0u8; 16];
     for i in 0..4 {
-        set_f32(&mut r, i, get_f32(v, i).floor());
+        set_f32(&mut r, i, canonicalize_f32(get_f32(v, i).floor()));
     }
     r
 }
@@ -1407,7 +1439,7 @@ pub fn f32x4_floor(v: &[u8; 16]) -> [u8; 16] {
 pub fn f32x4_trunc(v: &[u8; 16]) -> [u8; 16] {
     let mut r = [0u8; 16];
     for i in 0..4 {
-        set_f32(&mut r, i, get_f32(v, i).trunc());
+        set_f32(&mut r, i, canonicalize_f32(get_f32(v, i).trunc()));
     }
     r
 }
@@ -1417,31 +1449,46 @@ pub fn f32x4_nearest(v: &[u8; 16]) -> [u8; 16] {
     let mut r = [0u8; 16];
     for i in 0..4 {
         let f = get_f32(v, i);
-        // Round to nearest, ties to even (banker's rounding)
-        let rounded = f.round();
-        // Check for tie: if the fractional part is exactly 0.5
-        let frac = (f - f.floor()).abs();
-        let result = if (frac - 0.5).abs() < f32::EPSILON {
-            // Tie: round to even
-            if rounded as i64 % 2 != 0 {
-                // rounded is odd, go to even
-                if f > 0.0 { rounded - 1.0 } else { rounded + 1.0 }
-            } else {
-                rounded
-            }
-        } else {
-            rounded
-        };
-        set_f32(&mut r, i, result);
+        let result = wasm_nearest_f32(f);
+        set_f32(&mut r, i, canonicalize_f32(result));
     }
     r
+}
+
+/// WebAssembly nearest (round-to-nearest-even) for f32.
+/// Preserves -0.0, NaN, and infinities. Ties round to even.
+/// When result is zero, sign matches the input.
+#[inline]
+fn wasm_nearest_f32(f: f32) -> f32 {
+    if f.is_nan() || f.is_infinite() || f == 0.0 {
+        return f; // preserves -0.0, +0.0, NaN, +-inf
+    }
+    let rounded = f.round();
+    // Check for tie: if the fractional part is exactly 0.5
+    let result = if (f - f.floor()).abs() == 0.5 {
+        // Tie: round to even
+        if rounded % 2.0 != 0.0 {
+            // rounded is odd, go to even
+            if f > 0.0 { rounded - 1.0 } else { rounded + 1.0 }
+        } else {
+            rounded
+        }
+    } else {
+        rounded
+    };
+    // Preserve sign of zero: if result is zero, sign matches input
+    if result == 0.0 && f.is_sign_negative() {
+        -0.0_f32
+    } else {
+        result
+    }
 }
 
 #[inline]
 pub fn f64x2_ceil(v: &[u8; 16]) -> [u8; 16] {
     let mut r = [0u8; 16];
     for i in 0..2 {
-        set_f64(&mut r, i, get_f64(v, i).ceil());
+        set_f64(&mut r, i, canonicalize_f64(get_f64(v, i).ceil()));
     }
     r
 }
@@ -1450,7 +1497,7 @@ pub fn f64x2_ceil(v: &[u8; 16]) -> [u8; 16] {
 pub fn f64x2_floor(v: &[u8; 16]) -> [u8; 16] {
     let mut r = [0u8; 16];
     for i in 0..2 {
-        set_f64(&mut r, i, get_f64(v, i).floor());
+        set_f64(&mut r, i, canonicalize_f64(get_f64(v, i).floor()));
     }
     r
 }
@@ -1459,7 +1506,7 @@ pub fn f64x2_floor(v: &[u8; 16]) -> [u8; 16] {
 pub fn f64x2_trunc(v: &[u8; 16]) -> [u8; 16] {
     let mut r = [0u8; 16];
     for i in 0..2 {
-        set_f64(&mut r, i, get_f64(v, i).trunc());
+        set_f64(&mut r, i, canonicalize_f64(get_f64(v, i).trunc()));
     }
     r
 }
@@ -1469,18 +1516,37 @@ pub fn f64x2_nearest(v: &[u8; 16]) -> [u8; 16] {
     let mut r = [0u8; 16];
     for i in 0..2 {
         let f = get_f64(v, i);
-        let rounded = f.round();
-        let frac = (f - f.floor()).abs();
-        let result = if (frac - 0.5).abs() < f64::EPSILON {
-            if rounded as i64 % 2 != 0 {
-                if f > 0.0 { rounded - 1.0 } else { rounded + 1.0 }
-            } else {
-                rounded
-            }
-        } else {
-            rounded
-        };
-        set_f64(&mut r, i, result);
+        let result = wasm_nearest_f64(f);
+        set_f64(&mut r, i, canonicalize_f64(result));
     }
     r
+}
+
+/// WebAssembly nearest (round-to-nearest-even) for f64.
+/// Preserves -0.0, NaN, and infinities. Ties round to even.
+/// When result is zero, sign matches the input.
+#[inline]
+fn wasm_nearest_f64(f: f64) -> f64 {
+    if f.is_nan() || f.is_infinite() || f == 0.0 {
+        return f; // preserves -0.0, +0.0, NaN, +-inf
+    }
+    let rounded = f.round();
+    // Check for tie: if the fractional part is exactly 0.5
+    let result = if (f - f.floor()).abs() == 0.5 {
+        // Tie: round to even
+        if rounded % 2.0 != 0.0 {
+            // rounded is odd, go to even
+            if f > 0.0 { rounded - 1.0 } else { rounded + 1.0 }
+        } else {
+            rounded
+        }
+    } else {
+        rounded
+    };
+    // Preserve sign of zero: if result is zero, sign matches input
+    if result == 0.0 && f.is_sign_negative() {
+        -0.0_f64
+    } else {
+        result
+    }
 }

--- a/wrt-runtime/src/table.rs
+++ b/wrt-runtime/src/table.rs
@@ -221,6 +221,7 @@ impl wrt_foundation::traits::Checksummable for Table {
         let element_type_byte = match self.ty.element_type {
             WrtRefType::Funcref => 0u8,
             WrtRefType::Externref => 1u8,
+            WrtRefType::Gc(_) => 2u8,
         };
         checksum.update_slice(&element_type_byte.to_le_bytes());
         checksum.update_slice(&self.ty.limits.min.to_le_bytes());
@@ -243,6 +244,7 @@ impl wrt_foundation::traits::ToBytes for Table {
         let element_type_byte = match self.ty.element_type {
             WrtRefType::Funcref => 0u8,
             WrtRefType::Externref => 1u8,
+            WrtRefType::Gc(_) => 2u8,
         };
         writer.write_all(&element_type_byte.to_le_bytes())?;
         writer.write_all(&self.ty.limits.min.to_le_bytes())
@@ -309,6 +311,7 @@ impl Table {
         let init_val = match ty.element_type {
             WrtRefType::Funcref => Some(WrtValue::FuncRef(None)),
             WrtRefType::Externref => Some(WrtValue::ExternRef(None)),
+            WrtRefType::Gc(_) => Some(WrtValue::FuncRef(None)), // GC null ref
         };
 
         #[cfg(feature = "tracing")]
@@ -452,7 +455,7 @@ impl Table {
         }
 
         if let Some(ref val) = value {
-            let val_matches = matches!((&val, &self.ty.element_type), (WrtValue::FuncRef(_), WrtRefType::Funcref) | (WrtValue::ExternRef(_), WrtRefType::Externref));
+            let val_matches = matches!((&val, &self.ty.element_type), (WrtValue::FuncRef(_), WrtRefType::Funcref) | (WrtValue::ExternRef(_), WrtRefType::Externref) | (WrtValue::FuncRef(_), WrtRefType::Gc(_)) | (WrtValue::ExternRef(_), WrtRefType::Gc(_)));
             if !val_matches {
                 return Err(Error::validation_error(
                     "Element value type doesn't match table element type",
@@ -494,7 +497,7 @@ impl Table {
         }
 
         if let Some(ref val) = value {
-            let val_matches = matches!((&val, &self.ty.element_type), (WrtValue::FuncRef(_), WrtRefType::Funcref) | (WrtValue::ExternRef(_), WrtRefType::Externref));
+            let val_matches = matches!((&val, &self.ty.element_type), (WrtValue::FuncRef(_), WrtRefType::Funcref) | (WrtValue::ExternRef(_), WrtRefType::Externref) | (WrtValue::FuncRef(_), WrtRefType::Gc(_)) | (WrtValue::ExternRef(_), WrtRefType::Gc(_)));
             if !val_matches {
                 return Err(Error::validation_error(
                     "Element value type doesn't match table element type",
@@ -522,7 +525,7 @@ impl Table {
     ///
     /// Returns an error if the table cannot be grown
     pub fn grow_shared(&self, delta: u32, init_value_from_arg: WrtValue) -> Result<u32> {
-        let init_val_matches = matches!((&init_value_from_arg, &self.ty.element_type), (WrtValue::FuncRef(_), WrtRefType::Funcref) | (WrtValue::ExternRef(_), WrtRefType::Externref));
+        let init_val_matches = matches!((&init_value_from_arg, &self.ty.element_type), (WrtValue::FuncRef(_), WrtRefType::Funcref) | (WrtValue::ExternRef(_), WrtRefType::Externref) | (WrtValue::FuncRef(_), WrtRefType::Gc(_)) | (WrtValue::ExternRef(_), WrtRefType::Gc(_)));
         if !init_val_matches {
             return Err(Error::validation_error(
                 "Grow operation init value type doesn't match table element type",
@@ -678,7 +681,7 @@ impl Table {
         }
         for (i, val_opt) in init_data.iter().enumerate() {
             if let Some(val) = val_opt {
-                let val_matches = matches!((&val, &self.ty.element_type), (WrtValue::FuncRef(_), WrtRefType::Funcref) | (WrtValue::ExternRef(_), WrtRefType::Externref));
+                let val_matches = matches!((&val, &self.ty.element_type), (WrtValue::FuncRef(_), WrtRefType::Funcref) | (WrtValue::ExternRef(_), WrtRefType::Externref) | (WrtValue::FuncRef(_), WrtRefType::Gc(_)) | (WrtValue::ExternRef(_), WrtRefType::Gc(_)));
                 if !val_matches {
                     return Err(Error::validation_error("Table init value type mismatch"));
                 }
@@ -703,7 +706,7 @@ impl Table {
     ///
     /// Returns an error if the table cannot be grown
     pub fn grow(&mut self, delta: u32, init_value_from_arg: WrtValue) -> Result<u32> {
-        let init_val_matches = matches!((&init_value_from_arg, &self.ty.element_type), (WrtValue::FuncRef(_), WrtRefType::Funcref) | (WrtValue::ExternRef(_), WrtRefType::Externref));
+        let init_val_matches = matches!((&init_value_from_arg, &self.ty.element_type), (WrtValue::FuncRef(_), WrtRefType::Funcref) | (WrtValue::ExternRef(_), WrtRefType::Externref) | (WrtValue::FuncRef(_), WrtRefType::Gc(_)) | (WrtValue::ExternRef(_), WrtRefType::Gc(_)));
         if !init_val_matches {
             return Err(Error::validation_error(
                 "Grow operation init value type doesn't match table element type",
@@ -760,7 +763,7 @@ impl Table {
     /// Returns an error if the index is out of bounds or the table element type
     /// isn't a funcref
     pub fn set_func(&mut self, idx: u32, func_idx: u32) -> Result<()> {
-        if !matches!(self.ty.element_type, WrtRefType::Funcref) {
+        if !matches!(self.ty.element_type, WrtRefType::Funcref | WrtRefType::Gc(_)) {
             return Err(Error::runtime_execution_error(
                 "Table element type must be funcref",
             ));
@@ -799,7 +802,7 @@ impl Table {
         }
         for (i, val_opt) in init_data.iter().enumerate() {
             if let Some(val) = val_opt {
-                let val_matches = matches!((&val, &self.ty.element_type), (WrtValue::FuncRef(_), WrtRefType::Funcref) | (WrtValue::ExternRef(_), WrtRefType::Externref));
+                let val_matches = matches!((&val, &self.ty.element_type), (WrtValue::FuncRef(_), WrtRefType::Funcref) | (WrtValue::ExternRef(_), WrtRefType::Externref) | (WrtValue::FuncRef(_), WrtRefType::Gc(_)) | (WrtValue::ExternRef(_), WrtRefType::Gc(_)));
                 if !val_matches {
                     return Err(Error::validation_error("Table init value type mismatch"));
                 }

--- a/wrt-runtime/src/table.rs
+++ b/wrt-runtime/src/table.rs
@@ -211,6 +211,7 @@ impl Default for Table {
                 min: 0,
                 max: Some(1),
             },
+            table64: false,
         };
         Self::new(table_type).unwrap()
     }
@@ -277,6 +278,7 @@ impl wrt_foundation::traits::FromBytes for Table {
                 min,
                 max: Some(min + 1),
             },
+            table64: false,
         };
         Self::new(table_type)
     }
@@ -365,6 +367,7 @@ impl Table {
                 min: capacity,
                 max: Some(capacity),
             },
+            table64: false,
         };
         Self::new(table_type)
     }


### PR DESCRIPTION
## Summary
- Add SIMD instruction type validation (v128 load/store/ops)
- Add memory64 address type validation for load/store/grow/size
- Fix spectest memory and table import resolution
- Add cross-module table import support
- Fix externref element segment initialization
- Improve GC type subtyping and reference type validation
- Fix unreachable code polymorphic stack handling
- Add memory64 field to MemoryType across decoder/runtime/component

## Test plan
- [x] WAST test suite: +432 assertions passing over previous commit
- [x] block.wast: 223/223 passing
- [x] call_indirect.wast: 250/253 passing
- [x] UTF-8 tests: 704/704 passing
- [ ] CI checks