### PR TITLE
ci: migrate 4 of 9 ci.yml jobs to smithy self-hosted runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
 
   code_quality:
     name: Code Quality Checks
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, rust-cpu]
     steps:
       - uses: actions/checkout@v5
       - uses: actions-rs/toolchain@v1
@@ -135,7 +135,7 @@ jobs:
 
   core_tests_and_analysis:
     name: Core Tests, Analysis & Coverage
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, rust-cpu]
     # This job runs on push, PR, and all manual triggers (regardless of input)
     steps:
       - uses: actions/checkout@v5
@@ -200,7 +200,7 @@ jobs:
 
   safety_verification:
     name: SCORE-Inspired Safety Verification
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, rust-cpu]
     # Run safety verification on all pushes and PRs
     steps:
       - uses: actions/checkout@v5
@@ -322,7 +322,7 @@ jobs:
 # Coverage job is still Linux-only as tarpaulin only supports Linux
   coverage:
     name: Code Coverage
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, rust-cpu]
     steps:
       - uses: actions/checkout@v5
       - uses: actions/cache@v5


### PR DESCRIPTION
## Summary

Conservative first pass for kiln, mirroring the pattern proven on
spar (#201) and rivet (#262). Migrates only the jobs whose steps
work cleanly under smithy's hardened runner systemd unit; the other
five stay on hosted with the existing config (each with a clear
reason).

## Migrated → smithy `rust-cpu`

- `code_quality`
- `core_tests_and_analysis`
- `safety_verification`
- `coverage`

All four `cargo install --path cargo-kiln --force` to install the
local binary; this works under smithy's per-runner CARGO_HOME
(writable, lives on lv_runners with 500 G).

## Stays on `ubuntu-latest` (in-place reasons in this PR for context)

| Job | Why hosted |
|---|---|
| `ci_checks_and_docs` | `sudo apt-get install plantuml`; smithy runners have no sudo |
| `verus_verification` | `macos-latest`; smithy is Linux x86_64 only |
| `extended_static_analysis` | Miri + Kani; kani-verifier bundles CBMC (~100 MB), not pre-installed on smithy |
| `audit` | `matrix.os` Linux + macOS; the macOS half can't come, splitting the matrix is a separate PR |
| `vxworks_cross_build` | `sudo ln` + VxWorks toolchain not on smithy |

## Expected win

Same as spar / rivet: queue elimination on the org-free Actions
tier dominates total wall time. We saw ~470× end-to-end on spar's
clippy. kiln runs are similarly queue-bound today.

## Test plan

- [ ] Four migrated jobs land on `rust-cpu` runners and finish green
- [ ] Five hosted jobs remain unchanged
- [ ] No EACCES events in smithy's `journalctl -u smithy-trace-eacces.service`
- [ ] No "no space left on device" — TMPDIR fix from earlier today should hold

## Rollback

Revert this commit; all four jobs flip back to `ubuntu-latest`.