### PR TITLE
fix(component): graceful error instead of panic on component type construction (#269)

### DIFF
--- a/kiln-component/src/components/component_instantiation.rs
+++ b/kiln-component/src/components/component_instantiation.rs
@@ -2794,10 +2794,17 @@ impl ComponentInstance {
             // Create an export value based on the sort
             let export_value = match &export.sort {
                 Sort::Function => {
-                    // Create a function export with placeholder signature
+                    // Create a function export with placeholder signature.
+                    // Surface failures as a graceful Result error instead of
+                    // panicking — a malformed/zero-sized component type must not
+                    // crash the runtime (see issue #269).
                     let provider = NoStdProvider::<4096>::default();
-                    let signature = kiln_foundation::ComponentType::unit(provider)
-                        .expect("Failed to create component type");
+                    let signature = kiln_foundation::ComponentType::unit(provider).map_err(|_| {
+                        kiln_error::Error::component_resource_lifecycle_error(
+                            "failed to construct unit component type for function export \
+                             signature during export resolution",
+                        )
+                    })?;
 
                     let func_export = FunctionExport {
                         signature,

--- a/safety/requirements/architecture-components.yaml
+++ b/safety/requirements/architecture-components.yaml
@@ -76,6 +76,8 @@ artifacts:
         target: REQ_FUNC_021
       - type: satisfies
         target: REQ_CMP_020
+      - type: satisfies
+        target: REQ_CMP_021
     fields:
       previous-id: ARCH_COMP_003
       implementation: kiln-component/src/

--- a/safety/requirements/functional-requirements.yaml
+++ b/safety/requirements/functional-requirements.yaml
@@ -160,6 +160,31 @@ artifacts:
       implementation: kiln-component/src/components/resource_management.rs
       note: "Subsumed by STPA requirements SR-12 (no-aliasing) and SR-13 (double-drop)"
 
+  - id: REQ_CMP_021
+    type: requirement
+    title: Graceful failure on component type construction
+    description: >
+      Component instantiation and export resolution shall never panic on a
+      malformed, empty, or zero-sized component type. When a component type
+      cannot be constructed (e.g. a unit type whose item serialized size is
+      zero), the runtime shall return a graceful Result error that propagates
+      to the kilnd CLI, rather than aborting the process. This preserves a
+      consistent user experience: kilnd either executes the requested export
+      or reports an actionable error.
+    status: partial
+    tags: [component-model, robustness, error-handling]
+    links:
+      - type: derives-from
+        target: REQ_FUNC_014
+    fields:
+      implementation: kiln-component/src/components/component_instantiation.rs
+      issue: "https://github.com/pulseengine/kiln/issues/269"
+      note: >
+        Panic site (.expect on ComponentType::unit) replaced with map_err/?
+        propagation. Root cause (zero serialized size for a component type)
+        and whether direct component instantiation should be supported vs.
+        redirected to meld per RFC #46 are tracked in issue #269.
+
   # =========================================================================
   # WASI Support
   # =========================================================================


### PR DESCRIPTION
## Summary

Fixes the panic reported in #269 when `kilnd` instantiates a Component Model component directly.

`resolve_exports` called `.expect("Failed to create component type")` on `ComponentType::unit()`. For a unit component type whose item serialized size is zero with non-zero capacity, `BoundedVec::new()` returns an error — which the `.expect()` turned into a process-aborting panic.

This replaces the panic with `map_err`/`?` propagation, so the failure surfaces as a graceful `Result` error to the CLI (a fail-safe transition). `kilnd` now either executes the export or reports an actionable error — never panics on this path.

## Scope / what this does NOT do

This is the **panic → graceful-error** fix the issue explicitly asks for as step 1. It does **not** yet resolve the deeper question of *why* a component type reports zero serialized size, nor whether direct component instantiation should be fully supported vs. redirected to `meld` per RFC #46. That architectural decision is under discussion in #269 — the contrast in the issue (meld-fused path works, direct instantiation does not) suggests Meld may be the intended path.

## Traceability (rivet)

- **REQ_CMP_021** — *Graceful failure on component type construction* (new), satisfied by `AC-COMPONENT`, derives-from `REQ_FUNC_014`.
- Commit traced to **SM-RECOVERY-001** (*Fail-safe state transition on fault detection*).
- `rivet validate`: no new errors (16 pre-existing WAST cross-ref failures unchanged); REQ_CMP_021 fully traced.

## Verification

- `cargo check -p kilnd` compiles cleanly with the change.
- Change is a localized panic→error conversion; type-checked by the compiler.

Closes #269 (the panic). Deeper root-cause investigation continues in the issue thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)