### PR TITLE
build(platform): make kilnd compile on Windows (unblocks 5-platform release)

### DIFF
--- a/kiln-platform/src/lib.rs
+++ b/kiln-platform/src/lib.rs
@@ -107,6 +107,10 @@ pub mod ipc;
 #[cfg(all(feature = "std", target_os = "linux"))]
 pub mod linux_ipc;
 
+// Windows IPC implementation (requires std)
+#[cfg(all(feature = "std", target_os = "windows"))]
+pub mod windows_ipc;
+
 #[cfg(feature = "std")]
 pub mod high_availability;
 

--- a/kiln-platform/src/random.rs
+++ b/kiln-platform/src/random.rs
@@ -132,7 +132,7 @@ impl PlatformRandom {
         };
 
         #[link(name = "bcrypt")]
-        extern "system" {
+        unsafe extern "system" {
             fn BCryptGenRandom(
                 hAlgorithm: *mut c_void,
                 pbBuffer: *mut u8,

--- a/kiln-platform/src/time.rs
+++ b/kiln-platform/src/time.rs
@@ -121,7 +121,7 @@ impl PlatformTime {
     fn windows_monotonic_ns() -> u64 {
         use std::mem;
 
-        extern "system" {
+        unsafe extern "system" {
             fn QueryPerformanceCounter(lpPerformanceCount: *mut i64) -> i32;
             fn QueryPerformanceFrequency(lpFrequency: *mut i64) -> i32;
         }
@@ -131,7 +131,7 @@ impl PlatformTime {
             static INIT: std::sync::Once = std::sync::Once::new();
 
             INIT.call_once(|| {
-                QueryPerformanceFrequency(&mut FREQUENCY);
+                QueryPerformanceFrequency(&raw mut FREQUENCY);
             });
 
             let mut counter = mem::zeroed::<i64>();
@@ -385,7 +385,7 @@ impl PlatformTime {
             high: u32,
         }
 
-        extern "system" {
+        unsafe extern "system" {
             fn GetCurrentProcess() -> isize;
             fn GetProcessTimes(
                 process: isize,
@@ -427,7 +427,7 @@ impl PlatformTime {
             high: u32,
         }
 
-        extern "system" {
+        unsafe extern "system" {
             fn GetCurrentThread() -> isize;
             fn GetThreadTimes(
                 thread: isize,

--- a/kiln-platform/src/windows_ipc.rs
+++ b/kiln-platform/src/windows_ipc.rs
@@ -1,0 +1,135 @@
+//! Windows-specific IPC implementation using named pipes.
+//!
+//! Windows named-pipe IPC is not yet implemented. This module exists so the
+//! `target_os = "windows"` arm of [`crate::ipc`] resolves and the runtime
+//! compiles on Windows; every channel operation returns an explicit
+//! not-implemented error rather than silently succeeding. Wiring up real
+//! named-pipe transport is tracked separately.
+
+use core::{
+    fmt,
+    time::Duration,
+};
+use std::{
+    boxed::Box,
+    string::String,
+};
+
+use kiln_error::{
+    codes,
+    Error,
+    ErrorCategory,
+    Result,
+};
+
+use crate::ipc::{
+    ChannelId,
+    ClientId,
+    IpcChannel,
+    Message,
+};
+
+/// Windows named-pipe implementation of IPC channel (not yet implemented).
+pub struct WindowsNamedPipe {
+    /// Pipe name for this channel
+    pipe_name:  String,
+    /// Channel ID
+    channel_id: ChannelId,
+}
+
+impl fmt::Debug for WindowsNamedPipe {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("WindowsNamedPipe")
+            .field("pipe_name", &self.pipe_name)
+            .field("channel_id", &self.channel_id)
+            .finish()
+    }
+}
+
+impl WindowsNamedPipe {
+    /// Create a new Windows named-pipe channel handle.
+    pub fn new(pipe_name: String) -> Self {
+        Self {
+            pipe_name,
+            channel_id: ChannelId(rand::random()),
+        }
+    }
+}
+
+impl IpcChannel for WindowsNamedPipe {
+    fn create_server(_name: &str) -> Result<Self>
+    where
+        Self: Sized,
+    {
+        Err(Error::new(
+            ErrorCategory::System,
+            codes::NOT_IMPLEMENTED,
+            "Windows named-pipe IPC server not implemented",
+        ))
+    }
+
+    fn connect(_name: &str) -> Result<Self>
+    where
+        Self: Sized,
+    {
+        Err(Error::new(
+            ErrorCategory::System,
+            codes::NOT_IMPLEMENTED,
+            "Windows named-pipe IPC connect not implemented",
+        ))
+    }
+
+    fn send(&self, _msg: &Message) -> Result<()> {
+        Err(Error::new(
+            ErrorCategory::System,
+            codes::NOT_IMPLEMENTED,
+            "Windows named-pipe IPC send not implemented",
+        ))
+    }
+
+    fn receive(&self) -> Result<(Message, ClientId)> {
+        Err(Error::new(
+            ErrorCategory::System,
+            codes::NOT_IMPLEMENTED,
+            "Windows named-pipe IPC receive not implemented",
+        ))
+    }
+
+    fn send_receive(&self, _msg: &Message, _timeout: Duration) -> Result<Message> {
+        Err(Error::new(
+            ErrorCategory::System,
+            codes::NOT_IMPLEMENTED,
+            "Windows named-pipe IPC send_receive not implemented",
+        ))
+    }
+
+    fn reply(&self, _client: ClientId, _msg: &Message) -> Result<()> {
+        Err(Error::new(
+            ErrorCategory::System,
+            codes::NOT_IMPLEMENTED,
+            "Windows named-pipe IPC reply not implemented",
+        ))
+    }
+
+    fn id(&self) -> ChannelId {
+        self.channel_id
+    }
+
+    fn close(self) -> Result<()> {
+        Ok(())
+    }
+}
+
+// Simple counter-based ID generation, mirroring linux_ipc.
+mod rand {
+    use std::sync::atomic::{
+        AtomicU64,
+        Ordering,
+    };
+
+    static COUNTER: AtomicU64 = AtomicU64::new(1);
+
+    pub fn random() -> u64 {
+        COUNTER.fetch_add(1, Ordering::Relaxed)
+    }
+}


### PR DESCRIPTION
## Why

The v0.3.0 release run failed: the `x86_64-pc-windows-msvc` leg of the new release matrix never compiled. kilnd has **never** built on Windows — these gaps were invisible because no CI job builds the Windows target. This unblocks the 5th release platform.

## Fixes (4 pre-existing Windows-only gaps)

1. `kiln-platform::ipc` referenced `super::windows_ipc::WindowsNamedPipe`, but the module **never existed** (only `linux_ipc` is declared; the QNX/Windows arms reference absent modules). Added `windows_ipc.rs` implementing `IpcChannel` with explicit `NOT_IMPLEMENTED` errors — honest (loud, never silent `Ok`) per CLAUDE.md; real named-pipe transport is a follow-up.
2. `random.rs` / `time.rs` `extern "system"` blocks → `unsafe extern` (edition 2024 requirement).
3. `time.rs` took `&mut` on a `static mut` → `&raw mut` (edition 2024 `static_mut_refs`).

## Verification

- `cargo check --target x86_64-pc-windows-msvc -p kilnd` ✓ (was failing)
- `cargo check -p kilnd` (native) ✓ — all changes are `cfg(windows)`-gated or edition-2024 syntax valid on every target.

Once merged, I'll move the (unpublished) `v0.3.0` tag onto the fix and re-run the release so all five platforms publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)