### PR TITLE
fix(kilnd): actionable meld-first guidance when a component is run directly

### DIFF
--- a/kilnd/src/main.rs
+++ b/kilnd/src/main.rs
@@ -1012,9 +1012,19 @@ impl KilndEngine {
             // Execute as WebAssembly component
             #[cfg(feature = "component-model")]
             {
-                eprintln!("[VXDBG] Calling execute_component");
-                self.execute_component(&module_data)?;
-                eprintln!("[VXDBG] execute_component returned OK");
+                if let Err(e) = self.execute_component(&module_data) {
+                    // Direct Component Model execution is not the supported path
+                    // (RFC #46): components are lowered to core modules by meld at
+                    // build time, and kiln runs the resulting core module. Surface
+                    // actionable guidance, but keep the underlying error.
+                    let _ = self.logger.handle_minimal_log(
+                        LogLevel::Error,
+                        "This file is a WebAssembly Component Model component. kiln \
+                         runs core modules; lower it first with `meld fuse <file> -o \
+                         <file>.core.wasm` and run the resulting core module (RFC #46).",
+                    );
+                    return Err(e);
+                }
             }
             #[cfg(not(feature = "component-model"))]
             {


### PR DESCRIPTION
## Why

Follows the resolution on #269: direct Component Model instantiation is **not** the supported path (RFC #46) — components are lowered to core modules by `meld` at build time, and kiln runs the resulting core module. Making direct instantiation work (the zero-serialized-size `unit()` bug) is explicitly out of scope per the issue author.

## What

When `execute_component` fails, kilnd now logs a clear, actionable message:

> This file is a WebAssembly Component Model component. kiln runs core modules; lower it first with `meld fuse <file> -o <file>.core.wasm` and run the resulting core module (RFC #46).

The underlying error is still returned (not masked) so debugging detail is preserved. Also removes two stray `[VXDBG]` eprintln debug lines in the rewritten block.

## Traceability

- `Trace: SM-RECOVERY-001` (fail-safe state transition) — degrading to actionable guidance instead of a cryptic internal error is the fail-safe behavior.
- Builds on `REQ_CMP_021` (graceful failure on component type construction): the failure is now graceful **and** actionable.

## Verification

`cargo check -p kilnd` (component-model is a default feature) passes.

## Follow-up noted

kilnd's run path still contains **31 `[VXDBG]` eprintln debug lines** that spam stderr on every execution — a separate UX cleanup (and CLAUDE.md violation) worth its own focused PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)