### PR TITLE
chore(kilnd): remove [VXDBG] debug spam from the execution path

### DIFF
--- a/kilnd/src/main.rs
+++ b/kilnd/src/main.rs
@@ -527,20 +527,14 @@ impl KilndEngine {
     /// inter-component calls are routed through the nested component engines.
     #[cfg(feature = "component-model")]
     fn execute_component(&mut self, data: &[u8]) -> Result<()> {
-        eprintln!("[VXDBG] execute_component: {} bytes", data.len());
-
         #[cfg(feature = "component-model")]
         {
-            eprintln!("[VXDBG] Initializing memory system (component path)");
             use kiln_foundation::memory_init::MemoryInitializer;
             MemoryInitializer::initialize()
-                .map_err(|e| { eprintln!("[VXDBG] Memory init failed: {:?}", e); Error::runtime_error("Failed to initialize memory system") })?;
-            eprintln!("[VXDBG] Memory system OK");
+                .map_err(|_| Error::runtime_error("Failed to initialize memory system"))?;
 
-            eprintln!("[VXDBG] Decoding component");
             let mut parsed_component = Box::new(decode_component(data)
-                .map_err(|e| { eprintln!("[VXDBG] Component decode failed: {:?}", e); Error::parse_error("Failed to parse component binary") })?);
-            eprintln!("[VXDBG] Component decoded OK");
+                .map_err(|_| Error::parse_error("Failed to parse component binary"))?);
 
             // Create and initialize component instance (passes by reference to avoid stack overflow)
             // This includes executing start functions and transitioning to Running state
@@ -711,16 +705,12 @@ impl KilndEngine {
 
     /// Execute a traditional WebAssembly module
     fn execute_traditional_module(&mut self, data: &[u8]) -> Result<()> {
-        eprintln!("[VXDBG] execute_traditional_module: {} bytes", data.len());
-
         // Execute with actual Kiln engine if available
         #[cfg(all(feature = "std", feature = "kiln-execution"))]
         {
-            eprintln!("[VXDBG] Initializing memory system");
             use kiln_foundation::memory_init::MemoryInitializer;
             MemoryInitializer::initialize()
-                .map_err(|e| { eprintln!("[VXDBG] Memory init failed: {:?}", e); Error::runtime_error("Failed to initialize memory system") })?;
-            eprintln!("[VXDBG] Memory system OK");
+                .map_err(|_| Error::runtime_error("Failed to initialize memory system"))?;
 
             use kiln_runtime::engine::{
                 CapabilityAwareEngine,
@@ -728,7 +718,6 @@ impl KilndEngine {
                 EnginePreset,
             };
 
-            eprintln!("[VXDBG] Creating engine");
             let preset = if cfg!(feature = "asil-d") {
                 EnginePreset::AsilD
             } else if cfg!(feature = "asil-c") {
@@ -744,10 +733,8 @@ impl KilndEngine {
             };
 
             // Create engine with appropriate capabilities
-            eprintln!("[VXDBG] Creating CapabilityAwareEngine with preset {:?}", preset);
             let mut engine = CapabilityAwareEngine::with_preset(preset)
-                .map_err(|e| { eprintln!("[VXDBG] Engine creation failed: {:?}", e); Error::runtime_error("Failed to create engine") })?;
-            eprintln!("[VXDBG] Engine created OK");
+                .map_err(|_| Error::runtime_error("Failed to create engine"))?;
 
             // Wire up WASI dispatcher as the host import handler
             // This is the SINGLE dispatch path for ALL host function calls
@@ -897,14 +884,11 @@ impl KilndEngine {
         const MAX_MODULE_SIZE: usize = 8 * 1024 * 1024; // 8 MiB limit
 
         if let Some(ref path) = self.config.module_path {
-            eprintln!("[VXDBG] load_module_bounded: path={}", path);
             // Check file size first
-            eprintln!("[VXDBG] Calling fs::metadata");
             let metadata = fs::metadata(path)
-                .map_err(|e| { eprintln!("[VXDBG] metadata error: {:?}", e); Error::system_io_error("Failed to read module metadata") })?;
+                .map_err(|_| Error::system_io_error("Failed to read module metadata"))?;
 
             let file_size = metadata.len() as usize;
-            eprintln!("[VXDBG] File size: {} bytes", file_size);
             if file_size > MAX_MODULE_SIZE {
                 return Err(Error::runtime_execution_error("Module file too large"));
             }
@@ -943,9 +927,8 @@ impl KilndEngine {
             // For non-safety-critical mode, use standard loading but with size check
             #[cfg(not(feature = "safety-critical"))]
             {
-                eprintln!("[VXDBG] Calling fs::read");
-                let data = fs::read(path).map_err(|e| { eprintln!("[VXDBG] fs::read error: {:?}", e); Error::system_io_error("Failed to read module") })?;
-                eprintln!("[VXDBG] fs::read OK: {} bytes", data.len());
+                let data = fs::read(path)
+                    .map_err(|_| Error::system_io_error("Failed to read module"))?;
                 Ok(data)
             }
         } else if let Some(data) = &self.config.module_data {
@@ -962,13 +945,9 @@ impl KilndEngine {
     pub fn execute_module(&mut self) -> Result<()> {
         let _ = self.logger.handle_minimal_log(LogLevel::Info, "Starting module execution");
 
-        // VxWorks debug: trace each step with direct stderr writes
-        eprintln!("[VXDBG] About to load module file");
-
         // Determine execution mode and module source with bounded allocations
         #[cfg(feature = "std")]
         let module_data = self.load_module_bounded()?;
-        eprintln!("[VXDBG] Module loaded: {} bytes", module_data.len());
 
         #[cfg(not(feature = "std"))]
         let module_data = self
@@ -977,9 +956,7 @@ impl KilndEngine {
             .ok_or_else(|| Error::parse_error("No module data provided for no_std execution"))?;
 
         // Check if this is a component or module
-        eprintln!("[VXDBG] Detecting component format");
         let is_component = self.detect_component_format(&module_data)?;
-        eprintln!("[VXDBG] is_component={}", is_component);
 
         // Get module size for resource estimation
         #[cfg(feature = "std")]
@@ -1007,7 +984,6 @@ impl KilndEngine {
         }
 
         // Route execution based on binary type
-        eprintln!("[VXDBG] Routing execution: is_component={}, module_size={}", is_component, module_size);
         if is_component {
             // Execute as WebAssembly component
             #[cfg(feature = "component-model")]
@@ -1032,9 +1008,7 @@ impl KilndEngine {
             }
         } else {
             // Execute as traditional WebAssembly module
-            eprintln!("[VXDBG] Calling execute_traditional_module");
             self.execute_traditional_module(&module_data)?;
-            eprintln!("[VXDBG] execute_traditional_module returned OK");
         }
 
         // Update statistics


### PR DESCRIPTION
## Why

kilnd printed **29 `[VXDBG]` eprintln debug lines** to stderr on every module/component execution — leftover VxWorks bring-up scaffolding. It clutters normal CLI output (a common-UX problem) and violates the project rule against `eprintln` debugging (use the tracing framework).

## What

- Removed all 29 `[VXDBG]` prints across `execute_component`, `execute_traditional_module`, `load_module_bounded`, and the run/dispatch path.
- Where a `[VXDBG]` print sat inside `.map_err(|e| { eprintln!(...); Error::x(...) })`, the closure is reduced to `.map_err(|_| Error::x(...))` — **exact same error behavior**, just without the debug print.
- Left legitimate user-facing output untouched (e.g. `✗ Execution failed`, WASI capability failures, memory-system warnings).

## Verification

`cargo check -p kilnd` passes; `grep VXDBG` → 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)