### PR TITLE
fix(runtime): enforce fuel budget per instruction so --fuel bounds execution (#270)

### DIFF
--- a/kiln-runtime/src/engine/capability_engine.rs
+++ b/kiln-runtime/src/engine/capability_engine.rs
@@ -425,6 +425,14 @@ impl CapabilityAwareEngine {
         }
     }
 
+    /// Set the execution fuel budget (instruction count) for subsequent runs.
+    ///
+    /// Delegates to the inner [`StacklessEngine`]. When the budget is exhausted
+    /// the engine traps, enforcing bounded execution (REQ_FUNC_003).
+    pub fn set_fuel(&self, fuel: u64) {
+        self.inner.set_fuel(fuel);
+    }
+
     /// Enable WASI support with the current capability constraints
     pub fn enable_wasi(&mut self) -> Result<()> {
         match self.preset {

--- a/kiln-runtime/src/stackless/engine.rs
+++ b/kiln-runtime/src/stackless/engine.rs
@@ -1414,17 +1414,12 @@ impl StacklessEngine {
                     resume_state = None;
                 }
                 Err(e) => {
-                    eprintln!("[DEBUG-TRAMPOLINE-ERR] error={}, has_active_exception={}, pending_frames={}", e, self.active_exception.is_some(), pending_frames.len());
                     // Handle exception unwinding through pending frames
                     if self.active_exception.is_some() {
                         // Current function (which errored) is done
                         self.call_frames_count = self.call_frames_count.saturating_sub(1);
                         let mut found_handler = false;
                         while let Some(mut frame) = pending_frames.pop() {
-                            eprintln!("[DEBUG-TRAMPOLINE-ERR] Checking frame: instance_id={}, func_idx={}, pc={}, block_stack_len={}", frame.instance_id, frame.func_idx, frame.pc, frame.block_stack.len());
-                            for (i, (bt, bpc, bti, _)) in frame.block_stack.iter().enumerate() {
-                                eprintln!("[DEBUG-TRAMPOLINE-ERR]   block_stack[{}] = ({}, pc={}, bti={})", i, bt, bpc, bti);
-                            }
                             if self.find_and_apply_exception_handler(&mut frame) {
                                 // Handler found - resume this frame
                                 current_instance_id = frame.instance_id;
@@ -1840,6 +1835,20 @@ impl StacklessEngine {
             } // end of fresh-call initialization
 
             while pc < instructions.len() {
+                // Fuel metering (REQ_FUNC_003 bounded execution): charge one unit
+                // per instruction and trap when the configured budget is exhausted.
+                // This is the single chokepoint every executed instruction — including
+                // every backward branch / loop iteration — passes through, so it bounds
+                // otherwise-non-terminating modules. Default fuel is u64::MAX (set in
+                // StacklessEngine::new), so runs without an explicit budget are
+                // effectively unbounded and unaffected.
+                if self.fuel.load(Ordering::Relaxed) == 0 {
+                    return Err(kiln_error::Error::runtime_trap(
+                        "fuel exhausted: execution exceeded the configured instruction budget",
+                    ));
+                }
+                self.fuel.fetch_sub(1, Ordering::Relaxed);
+
                 let instruction = instructions.get(pc)
                     .ok_or_else(|| kiln_error::Error::runtime_error("Instruction index out of bounds"))?;
 
@@ -11479,6 +11488,16 @@ impl StacklessEngine {
     /// Get the remaining fuel for execution
     pub fn remaining_fuel(&self) -> Option<u64> {
         Some(self.fuel.load(Ordering::Relaxed))
+    }
+
+    /// Set the remaining execution fuel (instruction budget).
+    ///
+    /// One unit is charged per executed instruction; when the budget reaches
+    /// zero the engine traps with a "fuel exhausted" error. Defaults to
+    /// `u64::MAX` (effectively unbounded) until set. This is the mechanism that
+    /// enforces bounded execution (REQ_FUNC_003).
+    pub fn set_fuel(&self, fuel: u64) {
+        self.fuel.store(fuel, Ordering::Relaxed);
     }
 
     /// Get the current instruction pointer

--- a/kilnd/src/main.rs
+++ b/kilnd/src/main.rs
@@ -204,7 +204,9 @@ pub struct KilndConfig {
 impl Default for KilndConfig {
     fn default() -> Self {
         Self {
-            max_fuel: 100_000_000, // 100M fuel for large components (yolo, etc.)
+            // Unbounded by default; an explicit `--fuel N` sets a finite
+            // instruction budget that the engine now enforces (issue #270).
+            max_fuel: u64::MAX,
             max_memory: 64 * 1024 * 1024, // 64MB default
             function_name: None,
             module_data: None,
@@ -736,6 +738,11 @@ impl KilndEngine {
             let mut engine = CapabilityAwareEngine::with_preset(preset)
                 .map_err(|_| Error::runtime_error("Failed to create engine"))?;
 
+            // Enforce the configured fuel budget (instruction count). Without
+            // this the engine runs with effectively unbounded fuel and a
+            // non-terminating module hangs regardless of --fuel (issue #270).
+            engine.set_fuel(self.config.max_fuel);
+
             // Wire up WASI dispatcher as the host import handler
             // This is the SINGLE dispatch path for ALL host function calls
             #[cfg(feature = "wasi")]
@@ -805,11 +812,10 @@ impl KilndEngine {
             let has_main = engine.has_function(instance, function_name).unwrap_or(false);
 
             if has_main {
-                let results = engine
-                    .execute(instance, function_name, &[])
-                    .map_err(|e| {
-                        Error::runtime_execution_error("Function execution failed")
-                    })?;
+                // Propagate the engine's error verbatim so the actual cause
+                // (e.g. "fuel exhausted", a trap message) reaches the user
+                // instead of a generic "Function execution failed".
+                let results = engine.execute(instance, function_name, &[])?;
 
                 if !results.is_empty() {
                     println!("\n✓ Function '{}' returned {} value(s):", function_name, results.len());

--- a/safety/requirements/functional-requirements.yaml
+++ b/safety/requirements/functional-requirements.yaml
@@ -65,6 +65,12 @@ artifacts:
     tags: [runtime, safety]
     fields:
       implementation: kiln-runtime/src/stackless/engine.rs (fuel mechanism)
+      note: >
+        Enforced per-instruction in the StacklessEngine execution loop:
+        one fuel unit is charged per executed instruction and the engine
+        traps when the budget is exhausted. kilnd's `--fuel N` sets the
+        budget (default unbounded). Prior to issue #270 the loop never
+        decremented fuel, so the budget was not actually enforced.
 
   - id: REQ_FUNC_033
     type: requirement


### PR DESCRIPTION
## Root cause (#270 bug b)

Two disconnected gaps meant `--fuel` was completely inert:
1. The `StacklessEngine` execution loop **never decremented `self.fuel`** — fuel defaulted to `u64::MAX` and stayed there.
2. kilnd **never passed `--fuel`/`max_fuel` to the engine** (only an unrelated *estimate* stat).

So `falcon run-position-hold` hung at 99% CPU regardless of `--fuel`, and the bounded-execution guarantee (REQ_FUNC_003) was not actually enforced.

## Fix

- **Per-instruction metering** in the main loop (`while pc < instructions.len()`): charge 1 fuel/instruction, trap `"fuel exhausted"` at 0. Every instruction — including every backward branch / loop iteration — passes through here, so it bounds non-terminating modules.
- `StacklessEngine::set_fuel` + `CapabilityAwareEngine::set_fuel`.
- kilnd wires `config.max_fuel` into the engine; **default is now `u64::MAX` (unbounded)** so unfuelled runs are unaffected, and `--fuel N` is a real enforced budget.
- kilnd propagates the engine error verbatim → user sees `fuel exhausted`, not a generic `Function execution failed`.
- Removed `[DEBUG-TRAMPOLINE-ERR]` eprintln spam from the error path.

## Verification (oracle — run against the issue artifact)

`falcon.fused.wasm`, sha256 `d07c0f06…`:

| Command | Before | After |
|---|---|---|
| `run-stabilization` (no `--fuel`) | completes `0.0234` | ✅ completes `0.0234` |
| `run-position-hold --fuel 100000` | **hangs forever** | ✅ **traps "fuel exhausted" in <1s** |

## Scope

This fixes bug **(b)** — fuel now bounds execution, turning the hang into a clean bounded error. Bug **(a)** — *why* position-hold diverges (loops forever where wasmtime returns `0.1317415`) — is a separate interpreter-correctness issue still under investigation; with this fix it's at least bounded by `--fuel`.

Pre-existing `fuel_consumption_tests.rs` tests an unimplemented per-instruction-type cost model (separate from this flat-rate enforcement); noted for follow-up.

Traceability: `Trace: SC-3` (Resource budgets must be enforced with detection); updates `REQ_FUNC_003` note to reflect actual enforcement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)