### PR TITLE
ci(release): bump to 0.3.1

### DIFF
--- a/.github/release-notes/v0.3.1.md
+++ b/.github/release-notes/v0.3.1.md
@@ -1,0 +1,39 @@
+# kiln v0.3.1
+
+Patch release: bounded-execution enforcement, clearer component-model UX, and a quieter CLI.
+
+## Fixes
+
+- **Fuel now actually bounds execution (#270).** The interpreter loop never decremented fuel and kilnd never passed `--fuel` to the engine, so a non-terminating module hung at 99% CPU regardless of the budget. The engine now charges one fuel unit per instruction and traps `"fuel exhausted"` when the budget is reached; `kilnd --fuel N` sets a real, enforced budget (default unbounded). Restores the REQ_FUNC_003 bounded-execution guarantee. *(`run-position-hold --fuel 100000` now returns a bounded error in <1s instead of hanging.)*
+- **Actionable guidance for direct component runs (#269).** Running a WebAssembly Component Model component directly on kilnd now reports an actionable message — lower it with `meld fuse <file> -o <file>.core.wasm` and run the core module (per RFC #46) — instead of a cryptic internal error.
+- **Quieter CLI.** Removed 29 `[VXDBG]` and the `[DEBUG-TRAMPOLINE-ERR]` debug lines that printed to stderr on every run; execution errors now surface the real cause (e.g. `fuel exhausted`) instead of a generic message.
+
+## Known issues
+
+- `falcon run-position-hold` still diverges from wasmtime (loops where wasmtime returns a value) — an interpreter-correctness bug tracked in #270. With this release it is at least bounded by `--fuel`.
+
+## Release assets
+
+```
+kiln-v0.3.1-<triple>.{tar.gz|zip}    # 5 platforms
+kiln-0.3.1.cdx.json                  # CycloneDX SBOM
+rivet-snapshot-v0.3.1.json           # rivet artifact-graph snapshot
+SHA256SUMS.txt(.sig|.pem|.cosign.bundle)
+build-env.txt
+```
+
+## Verifying this release
+
+```sh
+cosign verify-blob \
+  --certificate-identity-regexp \
+    'https://github.com/pulseengine/kiln/.github/workflows/release.yml@.*' \
+  --certificate-oidc-issuer \
+    'https://token.actions.githubusercontent.com' \
+  --bundle SHA256SUMS.txt.cosign.bundle SHA256SUMS.txt
+
+sha256sum --check --ignore-missing SHA256SUMS.txt
+
+gh attestation verify kiln-v0.3.1-x86_64-unknown-linux-gnu.tar.gz \
+  --repo pulseengine/kiln
+```

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -253,7 +253,7 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cargo-kiln"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1184,7 +1184,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-build-core"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1214,7 +1214,7 @@ version = "0.1.0"
 
 [[package]]
 name = "kiln-component"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "criterion 0.5.1",
  "kiln-decoder",
@@ -1231,7 +1231,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-debug"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "kiln-error",
  "kiln-format",
@@ -1240,7 +1240,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-decoder"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "criterion 0.6.0",
  "hex",
@@ -1257,11 +1257,11 @@ dependencies = [
 
 [[package]]
 name = "kiln-error"
-version = "0.3.0"
+version = "0.3.1"
 
 [[package]]
 name = "kiln-format"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "kani-verifier",
  "kiln-error",
@@ -1271,7 +1271,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-foundation"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "criterion 0.6.0",
  "hashbrown 0.15.4",
@@ -1289,7 +1289,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-host"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "kiln-error",
  "kiln-foundation",
@@ -1300,7 +1300,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-instructions"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "kiln-error",
  "kiln-foundation",
@@ -1312,7 +1312,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-intercept"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "chrono",
  "kani-verifier",
@@ -1325,7 +1325,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-logging"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "kiln-error",
  "kiln-foundation",
@@ -1335,7 +1335,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-math"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "kiln-error",
  "kiln-platform",
@@ -1344,11 +1344,11 @@ dependencies = [
 
 [[package]]
 name = "kiln-panic"
-version = "0.3.0"
+version = "0.3.1"
 
 [[package]]
 name = "kiln-platform"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "criterion 0.6.0",
  "kiln-error",
@@ -1358,7 +1358,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-runtime"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "kiln-debug",
  "kiln-decoder",
@@ -1376,7 +1376,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-sync"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "kani-verifier",
  "kiln-error",
@@ -1385,7 +1385,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-wasi"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "kiln-error",
  "kiln-format",
@@ -1398,7 +1398,7 @@ dependencies = [
 
 [[package]]
 name = "kilnd"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "kiln-component",
  "kiln-debug",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ edition = "2024"
 rust-version = "1.85.0"
 license = "MIT"
 repository = "https://github.com/pulseengine/kiln"
-version = "0.3.0"
+version = "0.3.1"
 
 
 [workspace.dependencies]
@@ -36,22 +36,22 @@ anyhow = "1.0"
 wit-bindgen = "0.41.0"
 
 # Internal crate versions
-kiln-error = { path = "kiln-error", version = "0.3.0", default-features = false }
-kiln-sync = { path = "kiln-sync", version = "0.3.0", default-features = false }
-kiln-format = { path = "kiln-format", version = "0.3.0", default-features = false }
-kiln-foundation = { path = "kiln-foundation", version = "0.3.0", default-features = false }
-kiln-decoder = { path = "kiln-decoder", version = "0.3.0", default-features = false, features = ["std"] }
-kiln-debug = { path = "kiln-debug", version = "0.3.0", default-features = false }
-kiln-runtime = { path = "kiln-runtime", version = "0.3.0", default-features = false }
-kiln-logging = { path = "kiln-logging", version = "0.3.0", default-features = false }
-kiln-instructions = { path = "kiln-instructions", version = "0.3.0", default-features = false }
-kiln-component = { path = "kiln-component", version = "0.3.0", default-features = false }
-kiln-host = { path = "kiln-host", version = "0.3.0", default-features = false }
-kiln-intercept = { path = "kiln-intercept", version = "0.3.0", default-features = false }
-kiln-math = { path = "kiln-math", version = "0.3.0", default-features = false }
-kiln-platform = { path = "kiln-platform", version = "0.3.0", default-features = false }
-kiln-panic = { path = "kiln-panic", version = "0.3.0", default-features = false }
-kiln-wasi = { path = "kiln-wasi", version = "0.3.0", default-features = false }
+kiln-error = { path = "kiln-error", version = "0.3.1", default-features = false }
+kiln-sync = { path = "kiln-sync", version = "0.3.1", default-features = false }
+kiln-format = { path = "kiln-format", version = "0.3.1", default-features = false }
+kiln-foundation = { path = "kiln-foundation", version = "0.3.1", default-features = false }
+kiln-decoder = { path = "kiln-decoder", version = "0.3.1", default-features = false, features = ["std"] }
+kiln-debug = { path = "kiln-debug", version = "0.3.1", default-features = false }
+kiln-runtime = { path = "kiln-runtime", version = "0.3.1", default-features = false }
+kiln-logging = { path = "kiln-logging", version = "0.3.1", default-features = false }
+kiln-instructions = { path = "kiln-instructions", version = "0.3.1", default-features = false }
+kiln-component = { path = "kiln-component", version = "0.3.1", default-features = false }
+kiln-host = { path = "kiln-host", version = "0.3.1", default-features = false }
+kiln-intercept = { path = "kiln-intercept", version = "0.3.1", default-features = false }
+kiln-math = { path = "kiln-math", version = "0.3.1", default-features = false }
+kiln-platform = { path = "kiln-platform", version = "0.3.1", default-features = false }
+kiln-panic = { path = "kiln-panic", version = "0.3.1", default-features = false }
+kiln-wasi = { path = "kiln-wasi", version = "0.3.1", default-features = false }
 
 # Note: Safety level presets should be defined in individual crate Cargo.toml files
 # as workspace.features is not supported by Cargo


### PR DESCRIPTION
Patch release rolling up fixes merged since v0.3.0:

- **#276** — fuel budget now enforced per instruction; `--fuel` bounds execution (#270 bug b)
- **#274** — actionable meld-first guidance for direct component runs (#269)
- **#275** — removed 29 `[VXDBG]` debug-spam lines from the kilnd run path

Workspace + internal crate versions bumped 0.3.0 → 0.3.1 in lockstep; `Cargo.lock` regenerated; `cargo check -p kilnd` passes. Release notes (with cosign/SLSA verification one-liner) at `.github/release-notes/v0.3.1.md`.

After merge: `git tag v0.3.1 && git push origin v0.3.1` triggers the release workflow (5 platforms, SBOM, rivet snapshot, signed SHA256SUMS, SLSA, cosign).

🤖 Generated with [Claude Code](https://claude.com/claude-code)