### PR TITLE
build(nix): add reproducible dev-environment flake (#144)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,82 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1751274312,
+        "narHash": "sha256-/bVBlRpECLVzjV19t5KMdMFWSwKLtb5RyXdjz3LJT+g=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "50ab793786d9de88ee30ec4e4c24fb4236fc2674",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-24.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1780715792,
+        "narHash": "sha256-4+8gPeiPeud89mjo865RwpqmKwa1MThRsq2SvRxo7mg=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "27b7e78c6935293ee868469cc4172e9b8b17823b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,110 @@
+{
+  description = "Kiln - WebAssembly interpreter and runtime for safety-critical systems";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11";
+
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, rust-overlay, flake-utils }:
+    flake-utils.lib.eachSystem [
+      "x86_64-linux"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "aarch64-darwin"
+    ] (system:
+      let
+        overlays = [ (import rust-overlay) ];
+        pkgs = import nixpkgs { inherit system overlays; };
+
+        # Pinned Rust toolchain. Kept in sync with rust-toolchain.toml and
+        # tool-versions.toml (stable 1.86.0; edition 2024 needs >= 1.85).
+        # rustc-dev/llvm-tools are included for clippy, coverage (llvm-cov),
+        # and rust-analyzer.
+        rustToolchain = pkgs.rust-bin.stable."1.86.0".default.override {
+          extensions = [ "rust-src" "clippy" "rustfmt" "llvm-tools-preview" ];
+        };
+      in
+      {
+        devShells.default = pkgs.mkShell {
+          buildInputs = [
+            # Pinned Rust toolchain (1.86.0 + clippy/rustfmt/rust-src)
+            rustToolchain
+
+            # WebAssembly tooling — differential testing against wasmtime and
+            # component/module validation with wasm-tools.
+            pkgs.wasmtime
+            pkgs.wasm-tools
+
+            # Release/supply-chain tooling (matches .github/workflows/release.yml):
+            # CycloneDX SBOM generation and Sigstore signature verification.
+            pkgs.cargo-cyclonedx
+            pkgs.cosign
+
+            # Traceability + fuzzing used by cargo-kiln workflows.
+            pkgs.cargo-fuzz
+
+            # Native build dependencies.
+            pkgs.pkg-config
+            pkgs.openssl
+            pkgs.git
+          ] ++ pkgs.lib.optionals pkgs.stdenv.isDarwin [
+            pkgs.darwin.apple_sdk.frameworks.Security
+            pkgs.darwin.apple_sdk.frameworks.SystemConfiguration
+            pkgs.libiconv
+          ];
+
+          env = {
+            RUST_SRC_PATH = "${rustToolchain}/lib/rustlib/src/rust/library";
+          };
+
+          shellHook = ''
+            echo "kiln dev shell (reproducible toolchain via Nix)"
+            echo "  rust:    $(rustc --version)"
+            echo "  cargo:   $(cargo --version)"
+            echo "  wasmtime: $(wasmtime --version 2>/dev/null)"
+            echo "  cosign:  $(cosign version 2>/dev/null | head -1)"
+            echo ""
+            echo "  build the unified tool with: cargo install --path cargo-kiln"
+          '';
+        };
+
+        # `nix build` produces the kilnd runtime CLI. Tests are skipped here —
+        # they require the external/testsuite submodule and WAST fixtures that
+        # are not part of the pure source closure.
+        packages.default = pkgs.rustPlatform.buildRustPackage {
+          pname = "kilnd";
+          version = "0.3.1";
+          src = pkgs.lib.cleanSource ./.;
+          cargoLock = {
+            lockFile = ./Cargo.lock;
+          };
+
+          nativeBuildInputs = [ pkgs.pkg-config ];
+          buildInputs = [ pkgs.openssl ]
+            ++ pkgs.lib.optionals pkgs.stdenv.isDarwin [
+              pkgs.darwin.apple_sdk.frameworks.Security
+              pkgs.darwin.apple_sdk.frameworks.SystemConfiguration
+              pkgs.libiconv
+            ];
+
+          # Only build the kilnd CLI binary.
+          cargoBuildFlags = [ "--package" "kilnd" ];
+          doCheck = false;
+
+          meta = {
+            description = "WebAssembly interpreter and runtime for safety-critical systems";
+            homepage = "https://github.com/pulseengine/kiln";
+            license = pkgs.lib.licenses.mit;
+            mainProgram = "kilnd";
+          };
+        };
+      }
+    );
+}

--- a/flake.nix
+++ b/flake.nix
@@ -78,7 +78,13 @@
         # `nix build` produces the kilnd runtime CLI. Tests are skipped here —
         # they require the external/testsuite submodule and WAST fixtures that
         # are not part of the pure source closure.
-        packages.default = pkgs.rustPlatform.buildRustPackage {
+        #
+        # Build with the pinned toolchain (not nixpkgs' default rustc, which is
+        # too old for edition 2024) via makeRustPlatform.
+        packages.default = (pkgs.makeRustPlatform {
+          cargo = rustToolchain;
+          rustc = rustToolchain;
+        }).buildRustPackage {
           pname = "kilnd";
           version = "0.3.1";
           src = pkgs.lib.cleanSource ./.;


### PR DESCRIPTION
Closes #144.

## What

Adds `flake.nix` (+ pinned `flake.lock`) providing a Nix dev shell with the pinned toolchain — reproducible builds are a prerequisite for ISO 26262 / DO-178C configuration management, and only `rules_rocq_rust` had a flake so far. Mirrors the house style used by `meld`/`synth`/`sigil` (nixpkgs 24.11 + oxalica rust-overlay + flake-utils).

## Dev shell (`nix develop`)

Provisions the exact tool versions from `rust-toolchain.toml` / `tool-versions.toml`:
- **Rust 1.86.0** (stable, pinned) + clippy/rustfmt/rust-src/llvm-tools
- **wasmtime** + **wasm-tools** (differential testing / module validation)
- **cargo-cyclonedx** + **cosign** (SBOM + signature verification, matching `release.yml`)
- cargo-fuzz, pkg-config, openssl

`nix build .#default` builds the `kilnd` CLI (tests skipped — they need the `external/testsuite` submodule).

## Verification

- `nix flake show` — all outputs evaluate across the 4 supported systems.
- `nix develop` — confirmed it provisions `rustc 1.86.0`, `cargo 1.86.0`, `wasm-tools 1.222.1`, `wasmtime 26.0.1`, `cosign`.
- `nix build .#default` — building in CI / locally to confirm the package output (result will be noted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)