### PR TITLE
ci(kani): re-enable KANI formal verification as weekly + manual (#237)

### DIFF
--- a/.github/workflows/kani-verification.yml
+++ b/.github/workflows/kani-verification.yml
@@ -1,20 +1,11 @@
 name: Formal Verification with KANI
 
 on:
-  push:
-    branches: [ main, develop ]
-    paths:
-      - '**.rs'
-      - '**/Cargo.toml'
-      - '**/Kani.toml'
-      - '.github/workflows/kani-verification.yml'
-  pull_request:
-    branches: [ main, develop ]
-    paths:
-      - '**.rs'
-      - '**/Cargo.toml'
-      - '**/Kani.toml'
-      - '.github/workflows/kani-verification.yml'
+  # Re-enabled (#237) as scheduled + manual ONLY — not push/PR-gating. The Kani
+  # suite was disabled for CI stability (commit ce4e585b); running it weekly
+  # restores visibility on kiln's 22 Kani harnesses without blocking PRs.
+  # Promote back to push/pull_request gating once it is proven consistently
+  # green (the "full circle" — see #280).
   schedule:
     # Run weekly verification on Sunday at 2 AM UTC
     - cron: '0 2 * * 0'


### PR DESCRIPTION
Re-enables the disabled KANI workflow so kiln's **22 Kani harnesses run again** — the biggest verification gap from the corpus audit (#280).

**Safe scoping:**  (weekly) +  only — **not** push/PR, so it can't block PRs (the reason it was disabled under "CI stabilization", commit ce4e585b). Once it's proven consistently green on the weekly cadence, promote back to push/PR gating for the full circle.

Partial fix for #237 (the Kani part); the other disabled workflows can follow the same staged path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)