### PR TITLE
feat(async): scaffold kiln-async — no_std/no_alloc cooperative scheduler (Phase 0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1146,6 +1146,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "kiln-async"
+version = "0.3.1"
+dependencies = [
+ "kiln-error",
+]
+
+[[package]]
 name = "kiln-build-core"
 version = "0.3.1"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ members = [
     "kiln-panic",
     "kiln-build-core",
     "kiln-builtins",
+    "kiln-async",
     "cargo-kiln"]
 exclude = ["examples/wasi-nn/inference_module"]
 resolver = "2"  # Use edition 2021 resolver

--- a/kiln-async/Cargo.toml
+++ b/kiln-async/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "kiln-async"
+version.workspace = true
+edition = "2024"
+description = "no_std/no_alloc cooperative async scheduler for Kiln's embedded base — backs the WASM Component Model P3 async ABI (REQ_ASYNC_SCHED / SM-ASYNC-001)"
+license = "MIT"
+repository.workspace = true
+
+# rlib for workspace builds/tests. Build as a staticlib for ARM/embedded targets:
+#   cargo rustc -p kiln-async --target thumbv7em-none-eabi --release -- --crate-type staticlib
+[lib]
+crate-type = ["rlib"]
+
+[dependencies]
+# Unified error type only — no_std, no alloc (default-features = false in the
+# workspace). No kiln-foundation/provider dependency: the scheduler uses plain
+# const-generic arrays to keep the embedded TCB minimal (see SM-ASYNC-001).
+kiln-error = { workspace = true }
+
+[features]
+default = []

--- a/kiln-async/src/config.rs
+++ b/kiln-async/src/config.rs
@@ -1,0 +1,41 @@
+// Kiln - kiln-async :: config
+// SW-REQ-ID: REQ_ASYNC_SCHED
+// SPDX-License-Identifier: MIT
+
+//! Compile-time and runtime scheduler configuration.
+
+/// Default fixed capacities for a small embedded target (Cortex-M class).
+///
+/// These are the `const` generic arguments callers pass to
+/// [`crate::Scheduler`]; collected here as a documented default profile.
+pub mod defaults {
+    /// Maximum concurrent tasks.
+    pub const NTASK: usize = 16;
+    /// Ready-queue capacity (size `== NTASK`; never overflows by invariant).
+    pub const NREADY: usize = 16;
+    /// Maximum tracked waitables (futures + streams + sets).
+    pub const NWAIT: usize = 16;
+}
+
+/// Runtime-tunable scheduler configuration.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SchedConfig {
+    /// Fuel charged per task poll slice — the deterministic time quantum.
+    pub fuel_slice: u64,
+    /// Number of priority levels (`1` = FIFO; `> 1` = fixed-priority bitmap).
+    pub priorities: u8,
+}
+
+impl SchedConfig {
+    /// A sensible default: 10k fuel per slice, single-level FIFO.
+    pub const DEFAULT: Self = Self {
+        fuel_slice: 10_000,
+        priorities: 1,
+    };
+}
+
+impl Default for SchedConfig {
+    fn default() -> Self {
+        Self::DEFAULT
+    }
+}

--- a/kiln-async/src/intrinsics.rs
+++ b/kiln-async/src/intrinsics.rs
@@ -1,0 +1,83 @@
+// Kiln - kiln-async :: intrinsics
+// SW-REQ-ID: REQ_ASYNC_SCHED
+// SPDX-License-Identifier: MIT
+
+//! WASM Component Model **P3 async ABI** surface.
+//!
+//! These functions enumerate the canonical-ABI intrinsics the scheduler backs
+//! on the embedded path (per RFC #46, Meld lowers the component-level async
+//! constructs to these core import calls). Every one is a **Phase 1** stub that
+//! returns an explicit `NOT_IMPLEMENTED` error — never a silent `Ok` — so the
+//! scaffold cannot be mistaken for a working implementation.
+//!
+//! Phase 1 wires each of these to [`crate::Scheduler`] over the bounded
+//! task/ready/waitable structures.
+
+use kiln_error::{Error, Result};
+
+use crate::task::TaskId;
+
+macro_rules! phase1_stub {
+    ($name:literal) => {
+        Err(Error::not_implemented_error(concat!(
+            "kiln-async: P3 intrinsic `",
+            $name,
+            "` is implemented in Phase 1"
+        )))
+    };
+}
+
+/// `task.yield` — cooperatively re-enqueue the current task at its priority tail.
+pub fn task_yield() -> Result<()> {
+    phase1_stub!("task.yield")
+}
+
+/// `task.wait` — block the current task until any member of a waitable set fires.
+pub fn task_wait() -> Result<TaskId> {
+    phase1_stub!("task.wait")
+}
+
+/// `task.poll` — non-blocking check of a waitable set.
+pub fn task_poll() -> Result<Option<TaskId>> {
+    phase1_stub!("task.poll")
+}
+
+/// `task.cancel` — transition a subtask to `Cancelled` and free its slot.
+pub fn task_cancel(_subtask: TaskId) -> Result<()> {
+    phase1_stub!("task.cancel")
+}
+
+/// `task.backpressure` — gate admission of new subtasks.
+pub fn task_backpressure(_enable: bool) -> Result<()> {
+    phase1_stub!("task.backpressure")
+}
+
+/// `stream.new` — create a bounded SPSC stream with credit-based flow control.
+pub fn stream_new() -> Result<TaskId> {
+    phase1_stub!("stream.new")
+}
+
+/// `stream.read` — read from a stream, granting a credit (wakes a blocked writer).
+pub fn stream_read() -> Result<()> {
+    phase1_stub!("stream.read")
+}
+
+/// `stream.write` — write to a stream; blocks the writer when credits hit zero.
+pub fn stream_write() -> Result<()> {
+    phase1_stub!("stream.write")
+}
+
+/// `future.new` — create a single-shot future.
+pub fn future_new() -> Result<TaskId> {
+    phase1_stub!("future.new")
+}
+
+/// `waitable-set.new` — create a set tracking future/stream readiness.
+pub fn waitable_set_new() -> Result<TaskId> {
+    phase1_stub!("waitable-set.new")
+}
+
+/// `error-context.new` — create an error-context handle for async propagation.
+pub fn error_context_new() -> Result<TaskId> {
+    phase1_stub!("error-context.new")
+}

--- a/kiln-async/src/lib.rs
+++ b/kiln-async/src/lib.rs
@@ -1,0 +1,94 @@
+// Kiln - kiln-async
+// SW-REQ-ID: REQ_ASYNC_SCHED
+// Design: SM-ASYNC-001, docs/architecture/async-scheduler-plan.md
+//
+// Copyright (c) 2026 Ralf Anton Beier
+// Licensed under the MIT license.
+// SPDX-License-Identifier: MIT
+
+//! # kiln-async — cooperative async scheduler for Kiln's embedded base
+//!
+//! A `no_std`, **no-`alloc`** cooperative scheduler that backs the WebAssembly
+//! Component Model P3 async ABI (task / stream / future / waitable-set, with
+//! credit-based backpressure) for synth-compiled targets on gale/Zephyr/
+//! Cortex-M. Per RFC #46, async is *not* a feature of the std interpreter — this
+//! crate is the host-intrinsic backing for the embedded path only.
+//!
+//! ## Status — Phase 0 scaffold
+//!
+//! This crate currently provides the **foundational types** (task identity,
+//! lifecycle FSM, bounded ready queue, compile-time config) which are real, and
+//! **stubbed behavior** (the cooperative poll loop and the P3 intrinsic surface)
+//! which returns an explicit `NOT_IMPLEMENTED` error — never a silent `Ok` (see
+//! the project's fail-loud rule). Phase 1 implements the scheduler; Phase 3/5
+//! add the Verus + Lean/Aeneas proofs (reusing spar's RTA/RM/EDF theory).
+//!
+//! ## Design invariants
+//!
+//! - Fixed-capacity arrays parameterized by compile-time const generics — no
+//!   heap, no provider machinery (minimal trusted computing base).
+//! - `#![forbid(unsafe_code)]` — the only planned `unsafe` (the waker vtable) is
+//!   isolated and arrives in Phase 1.
+//! - Scheduling is fuel-bounded: a task's poll slice is a fuel budget, so
+//!   execution is deterministic and replayable.
+
+#![no_std]
+#![forbid(unsafe_code)]
+
+pub mod config;
+pub mod intrinsics;
+pub mod ready;
+pub mod task;
+
+pub use config::SchedConfig;
+pub use ready::ReadyQueue;
+pub use task::{TaskEvent, TaskId, TaskState, TaskTable};
+
+use kiln_error::{Error, Result};
+
+/// Cooperative, fuel-bounded async scheduler over fixed-capacity storage.
+///
+/// `NTASK` is the maximum number of concurrent tasks; `NREADY` is the ready-queue
+/// capacity (size it `== NTASK`: the per-slot "in ready set at most once"
+/// invariant means it can never overflow).
+pub struct Scheduler<const NTASK: usize, const NREADY: usize> {
+    tasks: TaskTable<NTASK>,
+    ready: ReadyQueue<NREADY>,
+    config: SchedConfig,
+}
+
+impl<const NTASK: usize, const NREADY: usize> Scheduler<NTASK, NREADY> {
+    /// Create an empty scheduler: all task slots free, ready queue empty.
+    #[must_use]
+    pub const fn new(config: SchedConfig) -> Self {
+        Self {
+            tasks: TaskTable::new(),
+            ready: ReadyQueue::new(),
+            config,
+        }
+    }
+
+    /// The active scheduler configuration (fuel slice, priority levels).
+    #[must_use]
+    pub const fn config(&self) -> SchedConfig {
+        self.config
+    }
+
+    /// Number of live (non-free) task slots.
+    #[must_use]
+    pub const fn task_count(&self) -> usize {
+        self.tasks.len()
+    }
+
+    /// Run one cooperative poll round: select a ready task, poll it for one fuel
+    /// slice, and re-dispatch per the result.
+    ///
+    /// **Phase 1** — not yet implemented. Returns an explicit error rather than a
+    /// silent `Ok`, so callers cannot mistake the scaffold for a working loop.
+    pub fn poll_round(&mut self) -> Result<()> {
+        let _ = &mut self.ready;
+        Err(Error::not_implemented_error(
+            "kiln-async: cooperative poll loop is implemented in Phase 1",
+        ))
+    }
+}

--- a/kiln-async/src/ready.rs
+++ b/kiln-async/src/ready.rs
@@ -1,0 +1,138 @@
+// Kiln - kiln-async :: ready
+// SW-REQ-ID: REQ_ASYNC_SCHED
+// SPDX-License-Identifier: MIT
+
+//! Bounded, no-alloc FIFO ready queue (O(1) push/pop).
+
+use kiln_error::{Error, Result};
+
+use crate::task::TaskId;
+
+/// Fixed-capacity FIFO ring of ready task handles.
+///
+/// Sized `== NTASK` in the scheduler: with the "a task is in the ready set at
+/// most once" invariant, it can never overflow. Push/pop are O(1) with no heap.
+/// This bounded-queue invariant is the target of the Verus no-overflow /
+/// ordering proof (property P1 in the design doc).
+pub struct ReadyQueue<const N: usize> {
+    buf: [TaskId; N],
+    head: usize,
+    len: usize,
+}
+
+impl<const N: usize> ReadyQueue<N> {
+    /// Create an empty ready queue.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            buf: [TaskId::NONE; N],
+            head: usize::MIN,
+            len: usize::MIN,
+        }
+    }
+
+    /// Capacity (`N`).
+    #[must_use]
+    pub const fn capacity(&self) -> usize {
+        N
+    }
+
+    /// Number of queued tasks.
+    #[must_use]
+    pub const fn len(&self) -> usize {
+        self.len
+    }
+
+    /// Whether the queue is empty.
+    #[must_use]
+    pub const fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    /// Whether the queue is full.
+    #[must_use]
+    pub const fn is_full(&self) -> bool {
+        self.len == N
+    }
+
+    /// Enqueue a task at the tail. O(1).
+    ///
+    /// Returns an error if the queue is full — which, given the
+    /// at-most-once-in-ready invariant and `N == NTASK`, should be unreachable
+    /// in correct use, but is checked rather than silently dropped.
+    pub fn push(&mut self, id: TaskId) -> Result<()> {
+        if self.is_full() {
+            return Err(Error::validation_error(
+                "kiln-async: ready queue at capacity",
+            ));
+        }
+        let tail = (self.head + self.len) % N;
+        self.buf[tail] = id;
+        self.len += 1;
+        Ok(())
+    }
+
+    /// Dequeue the head task. O(1). Returns `None` when empty.
+    pub fn pop(&mut self) -> Option<TaskId> {
+        if self.len == 0 {
+            return None;
+        }
+        let id = self.buf[self.head];
+        self.head = (self.head + 1) % N;
+        self.len -= 1;
+        Some(id)
+    }
+}
+
+impl<const N: usize> Default for ReadyQueue<N> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tid(i: u16) -> TaskId {
+        TaskId {
+            index: i,
+            generation: 0,
+        }
+    }
+
+    #[test]
+    fn fifo_order() {
+        let mut q: ReadyQueue<4> = ReadyQueue::new();
+        assert!(q.is_empty());
+        q.push(tid(1)).unwrap();
+        q.push(tid(2)).unwrap();
+        q.push(tid(3)).unwrap();
+        assert_eq!(q.len(), 3);
+        assert_eq!(q.pop(), Some(tid(1)));
+        assert_eq!(q.pop(), Some(tid(2)));
+        assert_eq!(q.pop(), Some(tid(3)));
+        assert_eq!(q.pop(), None);
+    }
+
+    #[test]
+    fn ring_wraparound() {
+        let mut q: ReadyQueue<2> = ReadyQueue::new();
+        q.push(tid(1)).unwrap();
+        q.pop();
+        q.push(tid(2)).unwrap();
+        q.push(tid(3)).unwrap();
+        assert!(q.is_full());
+        assert_eq!(q.pop(), Some(tid(2)));
+        assert_eq!(q.pop(), Some(tid(3)));
+        assert!(q.is_empty());
+    }
+
+    #[test]
+    fn full_queue_rejects_rather_than_dropping() {
+        let mut q: ReadyQueue<1> = ReadyQueue::new();
+        q.push(tid(1)).unwrap();
+        assert!(q.is_full());
+        assert!(q.push(tid(2)).is_err());
+    }
+}

--- a/kiln-async/src/task.rs
+++ b/kiln-async/src/task.rs
@@ -1,0 +1,247 @@
+// Kiln - kiln-async :: task
+// SW-REQ-ID: REQ_ASYNC_SCHED
+// SPDX-License-Identifier: MIT
+
+//! Task identity, the lifecycle state machine, and the fixed-capacity task table.
+
+use kiln_error::{Error, Result};
+
+/// ABA-safe task handle: a slot index plus a generation counter.
+///
+/// Reusing a slot bumps its generation, so a stale [`TaskId`] referring to a
+/// freed-and-reused slot is detectably invalid.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TaskId {
+    /// Index into the task table.
+    pub index: u16,
+    /// Generation at the time this handle was issued.
+    pub generation: u32,
+}
+
+impl TaskId {
+    /// Sentinel "no task" handle (used as the empty ready-queue fill value).
+    pub const NONE: Self = Self {
+        index: u16::MAX,
+        generation: 0,
+    };
+
+    /// Whether this is the [`TaskId::NONE`] sentinel.
+    #[must_use]
+    pub const fn is_none(self) -> bool {
+        self.index == u16::MAX
+    }
+}
+
+/// Task lifecycle states.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TaskState {
+    /// Created, not yet admitted to the ready set.
+    Spawned,
+    /// Eligible to run, in the ready queue.
+    Ready,
+    /// Currently being polled.
+    Running,
+    /// Parked on a waitable (future/stream/set).
+    Blocked,
+    /// Finished successfully (terminal).
+    Completed,
+    /// Cancelled (terminal).
+    Cancelled,
+}
+
+/// Events that drive [`TaskState`] transitions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TaskEvent {
+    /// Admit a freshly spawned task to the ready set.
+    Admit,
+    /// Dispatch a ready task to be polled.
+    Dispatch,
+    /// A running task yielded cooperatively.
+    Yield,
+    /// A running task parked on a waitable.
+    Wait,
+    /// A blocked task's waitable fired.
+    Wake,
+    /// A running task finished.
+    Complete,
+    /// Cancel a non-terminal task.
+    Cancel,
+}
+
+impl TaskState {
+    /// Total lifecycle transition function.
+    ///
+    /// Illegal transitions return an explicit error (fail-loud — never a silent
+    /// default). This pure function is the target of the Verus FSM-soundness
+    /// proof (property P3 in the design doc).
+    pub fn step(self, event: TaskEvent) -> Result<Self> {
+        use TaskEvent::{Admit, Cancel, Complete, Dispatch, Wait, Wake, Yield};
+        use TaskState::{Blocked, Cancelled, Completed, Ready, Running, Spawned};
+
+        let next = match (self, event) {
+            (Spawned, Admit) => Ready,
+            (Ready, Dispatch) => Running,
+            (Running, Yield) => Ready,
+            (Running, Wait) => Blocked,
+            (Running, Complete) => Completed,
+            (Blocked, Wake) => Ready,
+            (Spawned | Ready | Running | Blocked, Cancel) => Cancelled,
+            _ => {
+                return Err(Error::invalid_state_error(
+                    "kiln-async: illegal task lifecycle transition",
+                ));
+            }
+        };
+        Ok(next)
+    }
+
+    /// Whether this is a terminal state (no further transitions).
+    #[must_use]
+    pub const fn is_terminal(self) -> bool {
+        matches!(self, Self::Completed | Self::Cancelled)
+    }
+}
+
+/// One task table slot. `Copy` so the table is a plain `[TaskSlot; N]` with no
+/// heap and a `const` initializer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct TaskSlot {
+    /// Lifecycle state, or `None` when the slot is free.
+    state: Option<TaskState>,
+    /// Generation, bumped each time the slot is reused.
+    generation: u32,
+}
+
+impl TaskSlot {
+    const FREE: Self = Self {
+        state: None,
+        generation: 0,
+    };
+}
+
+/// Fixed-capacity table of tasks, indexed by [`TaskId::index`].
+///
+/// No heap: a plain `[TaskSlot; N]`. Phase 1 adds the intrusive free-list and
+/// `spawn`/`remove`; Phase 0 provides the storage, capacity accounting, and the
+/// generation-checked lookup.
+pub struct TaskTable<const N: usize> {
+    slots: [TaskSlot; N],
+    live: usize,
+}
+
+impl<const N: usize> TaskTable<N> {
+    /// Create an empty table — all `N` slots free.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            slots: [TaskSlot::FREE; N],
+            live: usize::MIN,
+        }
+    }
+
+    /// Capacity (`N`).
+    #[must_use]
+    pub const fn capacity(&self) -> usize {
+        N
+    }
+
+    /// Number of live (occupied) slots.
+    #[must_use]
+    pub const fn len(&self) -> usize {
+        self.live
+    }
+
+    /// Whether no slots are occupied.
+    #[must_use]
+    pub const fn is_empty(&self) -> bool {
+        self.live == 0
+    }
+
+    /// Look up a task's state, validating the handle's generation.
+    ///
+    /// Returns `None` for an out-of-range index, a free slot, or a stale
+    /// generation (the slot was reused since the handle was issued).
+    #[must_use]
+    pub fn state_of(&self, id: TaskId) -> Option<TaskState> {
+        let slot = self.slots.get(id.index as usize)?;
+        if slot.generation == id.generation {
+            slot.state
+        } else {
+            None
+        }
+    }
+
+    /// Admit a new task into a free slot.
+    ///
+    /// **Phase 1** — not yet implemented (the slot's poll thunk and waker wiring
+    /// land with the executor). Returns an explicit error, not a silent `Ok`.
+    pub fn spawn(&mut self) -> Result<TaskId> {
+        Err(Error::not_implemented_error(
+            "kiln-async: TaskTable::spawn is implemented in Phase 1",
+        ))
+    }
+}
+
+impl<const N: usize> Default for TaskTable<N> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fsm_happy_path() {
+        let s = TaskState::Spawned
+            .step(TaskEvent::Admit)
+            .unwrap();
+        assert_eq!(s, TaskState::Ready);
+        let s = s.step(TaskEvent::Dispatch).unwrap();
+        assert_eq!(s, TaskState::Running);
+        let s = s.step(TaskEvent::Wait).unwrap();
+        assert_eq!(s, TaskState::Blocked);
+        let s = s.step(TaskEvent::Wake).unwrap();
+        assert_eq!(s, TaskState::Ready);
+        let s = s.step(TaskEvent::Dispatch).unwrap();
+        let s = s.step(TaskEvent::Complete).unwrap();
+        assert_eq!(s, TaskState::Completed);
+        assert!(s.is_terminal());
+    }
+
+    #[test]
+    fn fsm_illegal_transitions_error() {
+        assert!(TaskState::Completed.step(TaskEvent::Dispatch).is_err());
+        assert!(TaskState::Spawned.step(TaskEvent::Complete).is_err());
+        assert!(TaskState::Cancelled.step(TaskEvent::Wake).is_err());
+    }
+
+    #[test]
+    fn cancel_from_any_nonterminal() {
+        for s in [
+            TaskState::Spawned,
+            TaskState::Ready,
+            TaskState::Running,
+            TaskState::Blocked,
+        ] {
+            assert_eq!(s.step(TaskEvent::Cancel).unwrap(), TaskState::Cancelled);
+        }
+    }
+
+    #[test]
+    fn taskid_none_is_sentinel() {
+        assert!(TaskId::NONE.is_none());
+        assert!(!TaskId { index: 0, generation: 0 }.is_none());
+    }
+
+    #[test]
+    fn table_starts_empty_and_spawn_is_phase1() {
+        let t: TaskTable<8> = TaskTable::new();
+        assert_eq!(t.capacity(), 8);
+        assert!(t.is_empty());
+        assert!(t.state_of(TaskId::NONE).is_none());
+        let mut t = t;
+        assert!(t.spawn().is_err()); // explicit not-implemented, never silent Ok
+    }
+}

--- a/safety/requirements/roadmap-requirements.yaml
+++ b/safety/requirements/roadmap-requirements.yaml
@@ -175,7 +175,9 @@ artifacts:
       (WCRT), and schedulability. Replaces the deleted ~32k-LOC simulation
       module (kiln-component/src/async_/) which contradicted RFC #46 and was
       never integrated. Design: docs/architecture/async-scheduler-plan.md.
-    status: planned
+      Phase 0 scaffold landed (kiln-async crate: types, FSM, bounded ready
+      queue; intrinsics stubbed; builds no_std/no_alloc for thumbv7em).
+    status: partial
     tags: [async, scheduler, no-std, no-alloc, embedded, formal-verification, roadmap]
     links:
       - type: derives-from

--- a/safety/requirements/safety-mechanisms.yaml
+++ b/safety/requirements/safety-mechanisms.yaml
@@ -327,3 +327,39 @@ artifacts:
         unique to PulseEngine and directly addresses STPA loss scenarios
         LS-W-1 (unauthorized resource access) and LS-W-2 (clock manipulation).
       implementation: kiln-wasi/src/dispatcher.rs, kiln-foundation/src/traits.rs
+
+  - id: SM-ASYNC-001
+    type: design-decision
+    title: kiln-async — minimal-TCB no_std/no_alloc cooperative scheduler crate
+    description: >
+      The async scheduler for the embedded base is a dedicated crate
+      (kiln-async), no_std with no alloc, forbidding unsafe code (except a
+      single isolated waker), using fixed-capacity arrays parameterized by a
+      compile-time SchedConfig rather than heap or provider-backed collections.
+      All P3 async intrinsics return an explicit NOT_IMPLEMENTED error until
+      implemented — never a silent Ok. Scheduling is fuel-bounded (a poll slice
+      is a fuel budget) for deterministic, replayable execution.
+    status: partial
+    tags: [async, scheduler, no-std, no-alloc, embedded, mechanism]
+    links:
+      - type: satisfies
+        target: REQ_ASYNC_SCHED
+    fields:
+      rationale: >
+        A separate minimal-dependency crate (mirroring kiln-builtins) keeps the
+        trusted computing base small and auditable, lets Charon/Aeneas translate
+        the scheduler in isolation for Lean verification, and keeps the std
+        interpreter from ever linking it (RFC #46: async is not an interpreter
+        feature). Plain const-generic arrays — not provider-backed BoundedVec —
+        guarantee no heap on Cortex-M and are the easiest surface to prove with
+        Verus and refine against spar's Lean RTA/RM/EDF theory. Explicit
+        NOT_IMPLEMENTED (not silent Ok) keeps the scaffold honest per the
+        project's fail-loud rule.
+      alternatives: >
+        (a) A module inside kiln-builtins — rejected: larger TCB, couples the
+        scheduler's translation unit to builtins. (b) Reuse kiln-foundation's
+        provider-backed BoundedVec — deferred to a Phase-1 evaluation. (c)
+        Resurrect the deleted kiln-component/src/async_ simulation — rejected:
+        contradicts RFC #46 and was never functional.
+      design-doc: docs/architecture/async-scheduler-plan.md
+      implementation: kiln-async/ (Phase 0 scaffold)


### PR DESCRIPTION
Phase 0 of the clean-room async scheduler (`REQ_ASYNC_SCHED` / `SM-ASYNC-001`, design at `docs/architecture/async-scheduler-plan.md`), run through the PulseEngine feature loop. Replaces the deleted ~32k-LOC simulation that contradicted RFC #46.

## New crate `kiln-async`
`no_std`, **no `alloc`**, `forbid(unsafe_code)`, dep only on `kiln-error` (minimal TCB, per SM-ASYNC-001).

- **Real foundational types:** `TaskId` (ABA-safe handle), `TaskState` lifecycle FSM with a **total** `step()` (illegal transitions return an explicit error — the Verus FSM-soundness target), `TaskTable` storage, a bounded **O(1) FIFO `ReadyQueue`** over plain const-generic arrays (no heap — the Verus no-overflow target), `SchedConfig`.
- **Stubbed behavior (Phase 1):** the cooperative poll loop, `TaskTable::spawn`, and all **11** P3 async intrinsics return an explicit `NOT_IMPLEMENTED` error — never a silent `Ok`.
- 8 unit tests (FSM + ready queue).

## Feature-loop evidence
| Step | Result |
|---|---|
| spar/AADL + WIT | Deferred — kiln isn't wired to spar; WIT N/A for a no-behavior scaffold (documented, not skipped) |
| rivet | `SM-ASYNC-001` satisfies `REQ_ASYNC_SCHED`; `rivet validate` adds **no new errors** (16 baseline) |
| code + oracle | builds workspace + **`thumbv7em-none-eabi`** (real no_std/no_alloc proof); no std/alloc usage; explicit error stubs |
| witness / sigil | N/A — no Wasm artifact, no shipped build |
| clean-room verify | Cold subagent: 6/7 confirmed; caught + corrected one count overstatement (12→11) |

**Not a release** (no runtime behavior change).

**Next Phase-0 step:** remove the dead `kiln-component/src/async_/` surface (entangled with `threading/`, `post_return`, `types.rs`) per RFC #46.

🤖 Generated with [Claude Code](https://claude.com/claude-code)