### PR TITLE
chore(rivet): close bootstrap-scaffolding gaps (externals, STPA-Sec source, version)

### DIFF
--- a/rivet.yaml
+++ b/rivet.yaml
@@ -1,6 +1,6 @@
 project:
   name: kiln
-  version: "0.1.0"
+  version: "0.3.1"
   description: >
     WebAssembly runtime for safety-critical systems. Implements the
     WebAssembly Core Spec 3.0, Component Model, and WASI Preview 2
@@ -12,6 +12,8 @@ project:
 
 sources:
   - path: safety/stpa
+    format: stpa-yaml
+  - path: safety/stpa-sec
     format: stpa-yaml
   - path: safety/requirements
     format: generic-yaml
@@ -59,3 +61,15 @@ externals:
     path: /Volumes/Home/git/pulseengine/synth
     ref: main
     prefix: synth
+
+  gale:
+    git: https://github.com/pulseengine/gale.git
+    path: /Volumes/Home/git/pulseengine/gale
+    ref: main
+    prefix: gale
+
+  sigil:
+    git: https://github.com/pulseengine/sigil.git
+    path: /Volumes/Home/git/pulseengine/sigil
+    ref: main
+    prefix: sigil


### PR DESCRIPTION
Part of a bootstrap-verification audit (ISO 26262 ASIL-D + IEC 61508 SIL-3 + DO-178C). Three clearly-correct scaffolding fixes:
- **gale + sigil externals** — kiln references `gale:*`/`sigil:*` artifacts but only meld+synth were declared → **broken cross-refs 57 → 43**.
- **Load `safety/stpa-sec`** — the STPA-Sec pass was authored but never declared as a source (invisible to validate/check).
- **Version 0.1.0 → 0.3.1** (was stale).

Remaining gaps are STPA control-structure completeness + multi-standard formalization, tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)