### PR TITLE
chore(rivet): product-line variant model — interpreter-QM vs embedded-cert scope

### DIFF
--- a/bindings/embedded-asil-d.yaml
+++ b/bindings/embedded-asil-d.yaml
@@ -1,0 +1,16 @@
+# bindings/embedded-asil-d.yaml
+# The certified target: the no_std / no-alloc embedded core that runs after
+# `meld fuse` on the synth/gale native path. ISO 26262 ASIL-D. Kept APART from
+# the std interpreter. The safety case binds here.
+name: embedded-asil-d
+selects: [embedded-asil-d, no_std, no-alloc]
+bindings:
+  no_std:
+    artifacts: []
+    source: ["kiln-builtins/**", "kiln-async/**"]
+  no-alloc:
+    artifacts: [REQ_ASYNC_SCHED]
+    source: ["kiln-async/**"]
+  embedded-asil-d:
+    artifacts: [REQ_ASYNC_SCHED, SM-ASYNC-001, SM-ASYNC-002]
+    source: ["kiln-builtins/**", "kiln-async/**"]

--- a/bindings/interpreter-std-qm.yaml
+++ b/bindings/interpreter-std-qm.yaml
@@ -1,0 +1,10 @@
+# bindings/interpreter-std-qm.yaml
+# The std interpreter: Quality-Managed reference / proof vehicle. Demonstrates
+# the work body (including the meld-fused embedded core) executes correctly in a
+# normal environment. OUT of certification scope — no ASIL/SIL/DAL obligations.
+name: interpreter-std-qm
+selects: [interpreter-qm, std, heap-alloc]
+bindings:
+  interpreter-qm:
+    artifacts: []
+    source: ["kiln-runtime/**", "kilnd/**", "kiln-component/**", "kiln-decoder/**"]

--- a/feature-model.yaml
+++ b/feature-model.yaml
@@ -1,0 +1,69 @@
+# feature-model.yaml — Kiln product-line / certification-variant model.
+#
+# Purpose: bind the safety case to the *shipped variant*, not the
+# std × no_std × alloc × integrity-level combinatorial product. This is the
+# variant-pruning that collapses MC/DC and verification scope onto a single
+# certified artifact (per the PulseEngine variant-pruning method).
+#
+# Cert-scope split (RFC #46 architecture):
+#   - The std INTERPRETER is the QM reference / proof vehicle: it demonstrates
+#     the whole work body — INCLUDING the meld-fused embedded core — executes
+#     correctly in a normal environment (differential oracle vs wasmtime;
+#     behavioral reference for the fused core). It is OUT of certification scope.
+#   - The no_std / no-alloc EMBEDDED core is the certified target: what runs
+#     after `meld fuse` on the synth/gale native path. Certified ASIL-D / SIL-3
+#     / DAL, kept APART from the interpreter.
+#
+# Full reference: docs/feature-model-schema.md
+kind: feature-model
+
+root: kiln
+
+features:
+  kiln:
+    group: mandatory
+    children: [environment, allocation, scope]
+
+  # ---- Runtime environment (exactly one) ----
+  environment:
+    group: alternative
+    children: [std, no_std]
+  std:
+    group: leaf
+  no_std:
+    group: leaf
+
+  # ---- Allocation strategy (exactly one) ----
+  allocation:
+    group: alternative
+    children: [heap-alloc, no-alloc]
+  heap-alloc:
+    group: leaf
+  no-alloc:
+    group: leaf
+
+  # ---- Certification scope of this build (exactly one) ----
+  scope:
+    group: alternative
+    children: [interpreter-qm, embedded-asil-d, embedded-sil-3, embedded-dal-b]
+  # std reference / proof vehicle — Quality-Managed, out of cert scope
+  interpreter-qm:
+    group: leaf
+  # ISO 26262 ASIL-D embedded core
+  embedded-asil-d:
+    group: leaf
+  # IEC 61508 SIL-3 embedded core
+  embedded-sil-3:
+    group: leaf
+  # DO-178C DAL-B embedded core (flight / cFS direction)
+  embedded-dal-b:
+    group: leaf
+
+# Cross-tree constraints (s-expression syntax).
+constraints:
+  # The interpreter is the std, heap-allocating, QM reference/proof.
+  - (implies interpreter-qm (and std heap-alloc))
+  # Every embedded certification scope is no_std with NO heap allocation.
+  - (implies embedded-asil-d (and no_std no-alloc))
+  - (implies embedded-sil-3 (and no_std no-alloc))
+  - (implies embedded-dal-b (and no_std no-alloc))


### PR DESCRIPTION
Operationalizes the RFC #46 certification-scope split via rivet variant management, so the safety case binds to the **shipped variant**, not the std×no_std×alloc×integrity combinatorial product (variant pruning → MC/DC scope collapse).

- `feature-model.yaml` — environment (std|no_std) × allocation (heap|no-alloc) × scope (interpreter-qm | embedded-asil-d | embedded-sil-3 | embedded-dal-b); constraints bind each embedded scope to no_std+no-alloc and the interpreter to std+heap.
- `bindings/interpreter-std-qm.yaml` — the std interpreter as the **QM reference/proof vehicle** (out of cert scope).
- `bindings/embedded-asil-d.yaml` — the **certified no_std/no-alloc embedded core** (kiln-builtins, kiln-async); binds REQ_ASYNC_SCHED + SM-ASYNC-001/002.

Both variants solve cleanly (`rivet variant check`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)