### PR TITLE
ci(verus): gate static_string_verify — a passing proof that wasn't CI-run (#280)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -270,11 +270,12 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: "1.93.0"
-      - name: Run Verus verification (StaticVec + StaticQueue)
+      - name: Run Verus verification (StaticVec + StaticQueue + StaticString)
         run: |
           bazel test \
             //kiln-foundation/src/verus_proofs:static_vec_verify \
-            //kiln-foundation/src/verus_proofs:static_queue_verify
+            //kiln-foundation/src/verus_proofs:static_queue_verify \
+            //kiln-foundation/src/verus_proofs:static_string_verify
 
   extended_static_analysis:
     name: Extended Static Analysis (Miri, Kani)


### PR DESCRIPTION
Closes half of #280. The `verus_verification` job gated StaticVec + StaticQueue but **not** `static_string_verify`, despite it existing and passing. Verified locally (`bazel test … :static_string_verify` → **PASSED in 5.2s**), so wiring it in is safe: **3 of 3** verus_test proofs now gate.

The remaining #280 gap — the proofs verify an *abstract model* with no refinement link to the production types — stays open and tracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)