### PR TITLE
chore(rivet): close traceability gate — 16 validate errors → 0 (#280)

### DIFF
--- a/safety/requirements/architecture-components.yaml
+++ b/safety/requirements/architecture-components.yaml
@@ -35,6 +35,10 @@ artifacts:
         target: REQ_LFUNC_005
       - type: satisfies
         target: REQ_LFUNC_018
+      - type: satisfies
+        target: REQ_TEMPORAL_001
+      - type: satisfies
+        target: REQ_FUNC_003
     fields:
       previous-id: ARCH_COMP_001
       implementation: kiln-runtime/src/stackless/engine.rs
@@ -55,6 +59,10 @@ artifacts:
         target: REQ_MEM_SAFETY_005
       - type: satisfies
         target: REQ_MEM_SAFETY_002
+      - type: satisfies
+        target: REQ_MEM_SAFETY_004
+      - type: satisfies
+        target: REQ_VERIFY_002
     fields:
       previous-id: ARCH_COMP_002
       implementation: kiln-foundation/src/safe_memory.rs, kiln-foundation/src/capabilities/
@@ -94,6 +102,8 @@ artifacts:
     links:
       - type: satisfies
         target: REQ_LFUNC_018
+      - type: satisfies
+        target: REQ_DATAFLOW_003
     fields:
       previous-id: ARCH_COMP_004
       implementation: kiln-decoder/src/streaming_decoder.rs
@@ -110,6 +120,8 @@ artifacts:
     links:
       - type: satisfies
         target: REQ_PLATFORM_001
+      - type: satisfies
+        target: REQ_TEMPORAL_004
     fields:
       previous-id: ARCH_COMP_005
       implementation: kiln-platform/src/
@@ -129,6 +141,12 @@ artifacts:
     links:
       - type: satisfies
         target: REQ_ERROR_001
+      - type: satisfies
+        target: REQ_ERROR_002
+      - type: satisfies
+        target: REQ_ERROR_003
+      - type: satisfies
+        target: REQ_SAFETY_003
     fields:
       previous-id: ARCH_COMP_010
       implementation: kiln-error/src/
@@ -282,6 +300,8 @@ artifacts:
     links:
       - type: satisfies
         target: REQ_VERIFY_010
+      - type: satisfies
+        target: REQ_SAFETY_004
     fields:
       implementation: "Kani proofs in kiln-foundation, kiln-runtime"
 
@@ -297,6 +317,10 @@ artifacts:
     links:
       - type: satisfies
         target: REQ_FUNC_033
+      - type: satisfies
+        target: REQ_CONFIG_001
+      - type: satisfies
+        target: REQ_CONFIG_003
     fields:
       implementation: kilnd/src/
 
@@ -317,6 +341,12 @@ artifacts:
     links:
       - type: satisfies
         target: REQ_RESOURCE_004
+      - type: satisfies
+        target: REQ_RESOURCE_003
+      - type: satisfies
+        target: REQ_VERIFY_004
+      - type: satisfies
+        target: REQ_SAFETY_001
     fields:
       previous-id: IMPL_RESOURCE_SAFETY_001
       implementation: kiln-foundation/src/monitoring.rs, kiln-foundation/src/safety_monitor.rs

--- a/safety/requirements/architecture-decisions.yaml
+++ b/safety/requirements/architecture-decisions.yaml
@@ -127,13 +127,49 @@ artifacts:
         target: REQ_FUNC_002
       - type: satisfies
         target: REQ_LFUNC_006
+      - type: satisfies
+        target: REQ_MEM_SAFETY_005
     fields:
       rationale: >
         Trait-based abstractions with conditional compilation enable the same
         API surface across std, no_std+alloc, and no_std+no_alloc environments
-        without runtime overhead.
+        without runtime overhead. The MemoryProvider abstraction backs the
+        capability-based safe_managed_alloc! allocator, whose RAII guards give
+        deterministic, explicit memory lifetime (no use-after-free / double-free)
+        across all three tiers.
       previous-id: ARCH_DEC_PATTERNS_001
       implementation: kiln-foundation/src/safe_memory.rs, kiln-foundation/src/bounded.rs
+
+  - id: AD-EXEC-001
+    type: design-decision
+    title: Stackless, resumable interpreter execution model
+    description: >
+      The interpreter executes WebAssembly with an explicit operand/control
+      stack held in a data structure rather than recursing on the host call
+      stack. Execution is driven by a step loop over a program counter, so it
+      can be suspended and resumed at instruction boundaries. This is what makes
+      fuel-based bounded execution possible: the engine decrements fuel per step
+      and yields when exhausted, without unwinding native frames.
+    status: implemented
+    tags: [architecture, runtime, execution-model, bounded-execution]
+    links:
+      - type: satisfies
+        target: REQ_FUNC_001
+      - type: satisfies
+        target: REQ_LFUNC_005
+    fields:
+      rationale: >
+        A stackless design bounds host stack usage (no recursion on guest call
+        depth), enables deterministic suspend/resume for fuel metering and
+        cooperative scheduling, and keeps worst-case host stack depth
+        independent of the guest program — all prerequisites for the
+        embedded / no_std execution path.
+      alternatives-considered: >
+        (1) Recursive tree-walking on the host stack — rejected: guest call
+        depth would drive host stack usage (unbounded, overflow risk) and could
+        not be suspended for fuel/scheduling. (2) Native-thread-per-task with
+        stack switching — rejected for no_std / no-alloc targets.
+      implementation: kiln-runtime/src/stackless/engine.rs
 
   # =========================================================================
   # Tooling & Verification Decisions
@@ -186,6 +222,66 @@ artifacts:
       previous-id: SPEC_VERIFY_001, IMPL_VERIFICATION_001
       implementation: kiln-foundation/src/verification.rs
 
+  - id: AD-QUALITY-001
+    type: design-decision
+    title: Defense-in-depth verification strategy (formal + dynamic)
+    description: >
+      Correctness is established by combining independent verification
+      techniques rather than relying on any single one: formal proof of
+      bounded-collection invariants (Verus, CI-gating), bounded model checking
+      of critical paths (Kani), fuzzing of parsers and bounded structures,
+      WAST conformance against the official WebAssembly test suite, and Miri
+      for UB detection. Each technique has different blind spots; combining
+      them shrinks the residual faster than deepening any one.
+    status: implemented
+    tags: [verification, defense-in-depth, formal-methods, fuzzing, testing]
+    links:
+      - type: satisfies
+        target: REQ_VERIFY_010
+      - type: satisfies
+        target: REQ_QA_010
+    fields:
+      rationale: >
+        Per the PulseEngine defense-in-depth methodology, in safety-relevant
+        domains a portfolio of techniques (proofs + model checkers + fuzzing +
+        conformance + sanitizers) covers more failure modes than tightening a
+        single technique. Verus is the only CI-gating formal method today;
+        Kani is weekly/manual (#237); fuzzing and WAST run in CI.
+      alternatives-considered: >
+        (1) Single formal method end-to-end — rejected: no tractable proof of
+        the whole interpreter exists, and a single technique leaves correlated
+        blind spots. (2) Tests-only — rejected: gives no invariant guarantees
+        for the embedded cert scope.
+      implementation: "Verus: kiln-foundation/src/verus_proofs/; Kani harnesses; fuzz/; kiln-build-core/src/wast_execution.rs"
+
+  - id: AD-DEBUG-001
+    type: design-decision
+    title: Source-level, WIT-aware debugging via DWARF mapping
+    description: >
+      Debugging maps running core-WebAssembly execution back to original source
+      through DWARF debug information, and is WIT-aware so component-model
+      execution can be inspected at the interface-type level rather than only as
+      raw core values. Breakpoints and stack traces operate over the stackless
+      engine's explicit frames. This is a QM reference-interpreter capability
+      (developer-facing), not part of the certified embedded scope.
+    status: implemented
+    tags: [tooling, debugging, dwarf, wit]
+    links:
+      - type: satisfies
+        target: REQ_FUNC_032
+    fields:
+      rationale: >
+        Source-level and WIT-aware debugging is what makes the interpreter
+        usable as a behavioral reference and oracle for the fused embedded core:
+        a developer can observe component-level semantics, not just core opcodes.
+        DWARF reuse avoids a bespoke debug-info format.
+      alternatives-considered: >
+        (1) printf/trace-only debugging — rejected: cannot inspect interface
+        types or set breakpoints. (2) Core-wasm-only debugging without WIT
+        mapping — rejected: component execution would be opaque at the ABI
+        boundary, defeating the reference-oracle purpose.
+      implementation: kiln-runtime/src/debug/
+
   # =========================================================================
   # WASI Architecture
   # =========================================================================
@@ -209,6 +305,12 @@ artifacts:
     links:
       - type: satisfies
         target: REQ_FUNC_034
+      - type: satisfies
+        target: REQ_FUNC_015
+      - type: satisfies
+        target: REQ_FUNC_035
+      - type: satisfies
+        target: REQ_FUNC_036
     fields:
       rationale: >
         Trait-based dispatch decouples the engine from any specific host

--- a/safety/stpa/control-structure.yaml
+++ b/safety/stpa/control-structure.yaml
@@ -351,6 +351,37 @@ controllers:
       - from: PROC-GALE
         info: Target architecture constraints, memory layout
 
+  - id: CTRL-BUILTINS
+    name: kiln-builtins Host Intrinsics (Embedded/Fused Path)
+    type: automated
+    description: >
+      no_std host-intrinsic layer that synth-compiled (Meld-fused) native code
+      calls for operations the embedded core cannot perform inline: linear-memory
+      stream read/write, resource-handle lifecycle, threading/waitable stubs,
+      canonical return-value delivery, and async task-return/cancellation. This
+      is the no_std/no-alloc analogue of CTRL-WASI on the std interpreter path,
+      and is the host trust boundary for the certified embedded variant. The
+      unsafe control actions of this controller are analysed in UCA-BI-1..6.
+    source-crate: kiln-builtins
+    control-actions:
+      - ca: CA-BI-1
+        target: PROC-INSTANCE
+        action: Return canonical-ABI value to synth-compiled caller per the declared signature
+      - ca: CA-BI-2
+        target: PROC-MEMORY
+        action: Read/write guest linear memory for stream and buffer intrinsics (bounds-checked)
+      - ca: CA-BI-3
+        target: PROC-RESOURCE
+        action: Allocate/drop resource handles via resource-table intrinsics
+      - ca: CA-BI-4
+        target: PROC-INSTANCE
+        action: Threading/waitable and async task-return/cancellation intrinsics
+    feedback:
+      - from: PROC-MEMORY
+        info: Bounds-check result, access fault
+      - from: PROC-RESOURCE
+        info: Handle validity, free-list state
+
 controlled-processes:
   - id: PROC-INSTRUCTION
     name: Instruction Stream

--- a/safety/stpa/cross-toolchain-consistency.yaml
+++ b/safety/stpa/cross-toolchain-consistency.yaml
@@ -192,15 +192,11 @@ cross-toolchain-hazards:
 fixture-coverage:
   meld-core:
     status: "All 14 passing"
-    fixtures: [numbers, strings, lists, records, variants, options,
-               many-arguments, flavorful, resources, results,
-               lists-alias, strings-alias, strings-simple, fixed-length-lists]
+    fixtures: [numbers, strings, lists, records, variants, options, many-arguments, flavorful, resources, results, lists-alias, strings-alias, strings-simple, fixed-length-lists]
 
   meld-component:
     status: "13 passing, 1 graceful degradation"
-    fixtures: [numbers, strings, lists, records, variants, options,
-               many-arguments, flavorful, results,
-               lists-alias, strings-alias, strings-simple]
+    fixtures: [numbers, strings, lists, records, variants, options, many-arguments, flavorful, results, lists-alias, strings-alias, strings-simple]
     degraded: [fixed-length-lists]
 
   kiln-runtime:


### PR DESCRIPTION
## What

Closes the **error-severity** half of the release traceability gate: `rivet validate` goes from **16 errors → 0**. This is the gate the `release-execution` skill (step 4) treats as a hard, blocking entry condition before tagging — and it had been RED since v0.3.1 (never historically enforced). Directly addresses #280's "rivet validate still has open errors."

All closures are **honest V-model links**, not gate-gaming. The status-gated rule is: an `implemented` requirement must trace up to **both** a `feature` and a `design-decision`.

### Requirement → existing-parent links (23 reqs)
WASI→AD-WASI-001; RAII→AD-PATTERNS-001; bounded-exec→AC-RUNTIME; mem-integrity→AC-MEMORY; error→AC-ERROR; monitoring/resource→AC-MONITORING; dataflow→AC-DECODER; temporal→AC-PLATFORM; config→AC-KILND; safety-independence→AC-FORMAL.

### New design-decisions (document real existing decisions)
- **AD-EXEC-001** — stackless/resumable execution model (REQ_FUNC_001, REQ_LFUNC_005)
- **AD-QUALITY-001** — defense-in-depth verification: Verus+Kani+fuzz+WAST+Miri (REQ_VERIFY_010, REQ_QA_010)
- **AD-DEBUG-001** — WIT-aware DWARF debugging (REQ_FUNC_032)

### STPA control structure
- Add **CTRL-BUILTINS** controller — the kiln-builtins host-intrinsic trust boundary (no_std analogue of CTRL-WASI). UCA-BI-1..6 already pointed `issued-by` at it but the node was missing; this resolves 6 orphaned UCAs.
- Fix malformed wrapped flow-sequences in `cross-toolchain-consistency.yaml` (rivet's YAML parser rejected the multi-line `[...]`).

## Result
`rivet validate`: **16 errors → 0**. Broken cross-refs 39→33.

## Residual (NOT in this PR — neither is error-severity)
- **87 warnings**: undeclared schema fields (`implementation`, `verification-method`, `iso-26262`…) → schema-completeness task.
- **33 broken cross-refs**: mostly `kiln:`-prefixed refs *from* synth/meld pointing back into kiln (`UnknownPrefix("kiln")`) — external-graph, not kiln artifact defects.

## Tool friction noted
`rivet validate --explain` shows only the basic OR-rule as satisfied and does **not** surface the *failing* status-gated rule (feature AND design-decision); and the error list is display-capped at 16, hiding the true count until earlier ones are fixed. Worth a rivet issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)