### PR TITLE
chore(rivet): add kiln-async/ to traced-paths

### DIFF
--- a/rivet.yaml
+++ b/rivet.yaml
@@ -43,6 +43,7 @@ commits:
     - kiln-error/
     - kiln-instructions/
     - kiln-sync/
+    - kiln-async/
     - kiln-host/
     - kiln-intercept/
     - kiln-wasi/


### PR DESCRIPTION
## What

Adds `kiln-async/` to `rivet.yaml` `traced-paths`.

## Why

`kiln-async` is the certified embedded async-scheduler crate (no_std / no_alloc, ASIL-D scope). It was already governed by the commit-msg hook, but absent from `traced-paths` — so its source files and commits sat **outside** the traceability surface that `rivet commits` / `rivet audit` analyze. This puts the crate formally in scope alongside its peers (`kiln-sync`, `kiln-foundation`, …).

The crate's source already carries `// SW-REQ-ID: REQ_ASYNC_SCHED` (same in-source convention as the other traced crates), and `SM-ASYNC-001` (design-decision) satisfies that requirement.

## Verification

`rivet validate` stays at **0 errors** before and after (87 schema-field warnings + 33 external `synth:`/circular cross-refs unchanged — pre-existing, non-blocking noise).

Closes the traced-paths follow-up noted in #293.

🤖 Generated with [Claude Code](https://claude.com/claude-code)