### PR TITLE
feat(async): scheduler task admission (spawn → admit → ready)

### DIFF
--- a/kiln-async/src/lib.rs
+++ b/kiln-async/src/lib.rs
@@ -80,6 +80,37 @@ impl<const NTASK: usize, const NREADY: usize> Scheduler<NTASK, NREADY> {
         self.tasks.len()
     }
 
+    /// Number of tasks currently in the ready set.
+    #[must_use]
+    pub const fn ready_len(&self) -> usize {
+        self.ready.len()
+    }
+
+    /// The lifecycle state of a task, or `None` for a stale/unknown handle.
+    #[must_use]
+    pub fn task_state(&self, id: TaskId) -> Option<TaskState> {
+        self.tasks.state_of(id)
+    }
+
+    /// Spawn a task and admit it to the ready set.
+    ///
+    /// Allocates a free table slot (`Spawned`), drives it `Spawned -> Ready`
+    /// through the FSM, and enqueues it. Fails loud if the task table is full;
+    /// the ready queue is sized `== NTASK` so its push cannot be the limiting
+    /// factor. Returns the new task's handle.
+    pub fn spawn(&mut self) -> Result<TaskId> {
+        let id = self.tasks.spawn()?;
+        // Admit the freshly spawned task: Spawned -> Ready, then enqueue. On the
+        // (invariant-unreachable) ready-queue overflow, roll back the slot so the
+        // table and ready set stay consistent rather than leaking a live task.
+        self.tasks.transition(id, TaskEvent::Admit)?;
+        if let Err(e) = self.ready.push(id) {
+            self.tasks.remove(id)?;
+            return Err(e);
+        }
+        Ok(id)
+    }
+
     /// Run one cooperative poll round: select a ready task, poll it for one fuel
     /// slice, and re-dispatch per the result.
     ///
@@ -90,5 +121,42 @@ impl<const NTASK: usize, const NREADY: usize> Scheduler<NTASK, NREADY> {
         Err(Error::not_implemented_error(
             "kiln-async: cooperative poll loop is implemented in Phase 1",
         ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    type Sched = Scheduler<4, 4>;
+
+    #[test]
+    fn spawn_admits_a_task_to_the_ready_set() {
+        let mut s = Sched::new(SchedConfig::DEFAULT);
+        assert_eq!(s.task_count(), 0);
+        assert_eq!(s.ready_len(), 0);
+
+        let id = s.spawn().unwrap();
+
+        assert_eq!(s.task_count(), 1);
+        assert_eq!(s.ready_len(), 1);
+        assert_eq!(s.task_state(id), Some(TaskState::Ready));
+    }
+
+    #[test]
+    fn spawn_uses_distinct_handles_per_task() {
+        let mut s = Sched::new(SchedConfig::DEFAULT);
+        let a = s.spawn().unwrap();
+        let b = s.spawn().unwrap();
+        assert_ne!(a, b);
+        assert_eq!(s.ready_len(), 2);
+    }
+
+    #[test]
+    fn spawn_errors_when_the_task_table_is_full() {
+        let mut s: Scheduler<2, 2> = Scheduler::new(SchedConfig::DEFAULT);
+        s.spawn().unwrap();
+        s.spawn().unwrap();
+        assert!(s.spawn().is_err()); // explicit capacity error, never silent drop
     }
 }

--- a/kiln-async/src/task.rs
+++ b/kiln-async/src/task.rs
@@ -193,6 +193,30 @@ impl<const N: usize> TaskTable<N> {
         ))
     }
 
+    /// Drive a task slot through one FSM transition, validating the handle.
+    ///
+    /// The table owns slot state, so all state changes go through the
+    /// [`TaskState::step`] FSM here — a slot can never hold an FSM-invalid
+    /// state, and an illegal event fails loud rather than mutating the slot.
+    /// Returns the new state on success.
+    pub fn transition(&mut self, id: TaskId, event: TaskEvent) -> Result<TaskState> {
+        let slot = self
+            .slots
+            .get_mut(id.index as usize)
+            .filter(|s| s.generation == id.generation)
+            .ok_or_else(|| {
+                Error::validation_error("kiln-async: transition on a stale or unknown task handle")
+            })?;
+        let current = slot.state.ok_or_else(|| {
+            Error::validation_error("kiln-async: transition on a free task slot")
+        })?;
+        // `step` validates the event; an illegal transition errors here and the
+        // slot is left untouched (no partial write).
+        let next = current.step(event)?;
+        slot.state = Some(next);
+        Ok(next)
+    }
+
     /// Free a task slot, validating the handle, and bump its generation so any
     /// stale [`TaskId`] referring to the old occupant is detectably invalid.
     pub fn remove(&mut self, id: TaskId) -> Result<()> {
@@ -317,6 +341,35 @@ mod tests {
         assert_ne!(new.generation, old.generation);
         assert_eq!(t.state_of(new), Some(TaskState::Spawned));
         assert!(t.state_of(old).is_none());
+    }
+
+    #[test]
+    fn transition_drives_a_slot_through_a_valid_event() {
+        let mut t: TaskTable<2> = TaskTable::new();
+        let id = t.spawn().unwrap();
+        assert_eq!(t.state_of(id), Some(TaskState::Spawned));
+        let next = t.transition(id, TaskEvent::Admit).unwrap();
+        assert_eq!(next, TaskState::Ready);
+        assert_eq!(t.state_of(id), Some(TaskState::Ready));
+    }
+
+    #[test]
+    fn transition_rejects_an_illegal_event_without_mutating() {
+        let mut t: TaskTable<2> = TaskTable::new();
+        let id = t.spawn().unwrap();
+        // Spawned --Complete--> is illegal (must be Admit'd then run first).
+        assert!(t.transition(id, TaskEvent::Complete).is_err());
+        // Slot state is unchanged — fail-loud, never a silent half-transition.
+        assert_eq!(t.state_of(id), Some(TaskState::Spawned));
+    }
+
+    #[test]
+    fn transition_rejects_a_stale_or_unknown_handle() {
+        let mut t: TaskTable<1> = TaskTable::new();
+        assert!(t.transition(TaskId::NONE, TaskEvent::Admit).is_err());
+        let id = t.spawn().unwrap();
+        t.remove(id).unwrap();
+        assert!(t.transition(id, TaskEvent::Admit).is_err()); // freed slot
     }
 
     #[test]


### PR DESCRIPTION
## What

Wires the `Scheduler`'s task-admission path on top of the Phase-1 `TaskTable` and `ReadyQueue` primitives — the **safe scheduling bookkeeping** the cooperative poll loop will sit on. The poll loop itself (and its isolated-`unsafe` waker + no-alloc future storage, design R1) remain deliberately deferred to a focused pass.

## Changes

- **`TaskTable::transition(id, event)`** — the table owns slot state, so all state changes go through the `TaskState` FSM here. An illegal event **fails loud and leaves the slot untouched** (no partial write); a stale/free handle is rejected. This is the natural Verus target for *"the table never holds an FSM-invalid state."*
- **`Scheduler::spawn()`** — allocate a slot (`Spawned`), drive `Spawned → Ready` via the FSM, enqueue. Rolls the slot back if the (invariant-unreachable) ready-queue push fails, so the table and ready set stay consistent — no leaked live task.
- **`Scheduler::ready_len()` / `task_state()`** — observability.

## Verification

- **TDD**: 6 new tests written RED → GREEN (3 `transition`, 3 `Scheduler::spawn`); **20 total green**.
- **no_std** `thumbv7em-none-eabi` build clean.
- **clippy** clean (no code lints).
- **`#![forbid(unsafe_code)]` intact** — no unsafe added.
- **rivet validate**: 0 errors (unchanged). `kiln-async/` is in `traced-paths` (#294); source carries `// SW-REQ-ID: REQ_ASYNC_SCHED`, satisfied by `SM-ASYNC-001`.

## Scope / what's deliberately NOT here

The cooperative `poll_round` still returns `not_implemented` — it's coupled to the one ASIL-D `unsafe` exception (the `RawWaker` vtable) and the no-alloc future-storage representation, which warrant a deliberate design checkpoint rather than being rushed in.

Trace: SM-ASYNC-001

🤖 Generated with [Claude Code](https://claude.com/claude-code)