### PR TITLE
feat(async): mark_ready wake path + dispatch_next (kiln-async Phase 1)

### DIFF
--- a/kiln-async/src/lib.rs
+++ b/kiln-async/src/lib.rs
@@ -111,6 +111,65 @@ impl<const NTASK: usize, const NREADY: usize> Scheduler<NTASK, NREADY> {
         Ok(id)
     }
 
+    /// Wake a task: admit a `Blocked` task back into the ready set.
+    ///
+    /// This is the safe wake entry point the (Phase 1, isolated-`unsafe`) waker
+    /// vtable will call — design R1 in the plan doc.
+    ///
+    /// Semantics follow the standard `Waker` contract, where wakes may
+    /// legitimately race with task completion and may be duplicated:
+    ///
+    /// - `Blocked` → transitions to `Ready`, enqueues, returns `Ok(true)`.
+    /// - Already `Ready` → idempotent no-op, `Ok(false)` (preserves the
+    ///   at-most-once-in-ready-set invariant).
+    /// - Stale/unknown handle, free slot, or terminal state → `Ok(false)`.
+    ///   A waker outliving its task is normal asynchrony per the contract —
+    ///   this is *specified* spurious-wake behavior, not a masked error.
+    /// - `Spawned` or `Running` → loud error. Waking an unadmitted task is an
+    ///   FSM violation; waking a `Running` task needs the wake-pending flag
+    ///   (deferred with the poll loop) — erroring here means a lost wakeup is
+    ///   impossible to introduce silently.
+    pub fn mark_ready(&mut self, id: TaskId) -> Result<bool> {
+        match self.tasks.state_of(id) {
+            // Spurious wake (stale handle / freed slot) or duplicate wake of a
+            // task already in the ready set, or a terminal task: specified
+            // no-op per the Waker contract.
+            None | Some(TaskState::Ready | TaskState::Completed | TaskState::Cancelled) => {
+                Ok(false)
+            }
+            Some(TaskState::Blocked) => {
+                // Enqueue before the FSM step: if the (invariant-unreachable)
+                // push fails, the task is still consistently Blocked. The Wake
+                // transition after a successful push cannot fail (handle just
+                // validated, Blocked--Wake-->Ready is legal).
+                self.ready.push(id)?;
+                self.tasks.transition(id, TaskEvent::Wake)?;
+                Ok(true)
+            }
+            Some(TaskState::Spawned) => Err(Error::invalid_state_error(
+                "kiln-async: wake of a task that was never admitted",
+            )),
+            Some(TaskState::Running) => Err(Error::not_implemented_error(
+                "kiln-async: wake during poll needs the wake-pending flag (poll-loop increment)",
+            )),
+        }
+    }
+
+    /// Dispatch the oldest ready task: dequeue it and drive `Ready -> Running`.
+    ///
+    /// Returns `Ok(None)` when the ready set is empty. A stale queue entry is
+    /// an invariant violation today (nothing removes a queued task yet) and
+    /// fails loud rather than being skipped.
+    pub fn dispatch_next(&mut self) -> Result<Option<TaskId>> {
+        let Some(id) = self.ready.pop() else {
+            return Ok(None);
+        };
+        // A queued task must be Ready; anything else is an invariant violation
+        // and the transition's own validation propagates it loudly.
+        self.tasks.transition(id, TaskEvent::Dispatch)?;
+        Ok(Some(id))
+    }
+
     /// Run one cooperative poll round: select a ready task, poll it for one fuel
     /// slice, and re-dispatch per the result.
     ///
@@ -158,5 +217,71 @@ mod tests {
         s.spawn().unwrap();
         s.spawn().unwrap();
         assert!(s.spawn().is_err()); // explicit capacity error, never silent drop
+    }
+
+    #[test]
+    fn dispatch_next_runs_the_oldest_ready_task() {
+        let mut s = Sched::new(SchedConfig::DEFAULT);
+        let a = s.spawn().unwrap();
+        let b = s.spawn().unwrap();
+
+        let dispatched = s.dispatch_next().unwrap();
+
+        assert_eq!(dispatched, Some(a)); // FIFO: oldest first
+        assert_eq!(s.task_state(a), Some(TaskState::Running));
+        assert_eq!(s.task_state(b), Some(TaskState::Ready));
+        assert_eq!(s.ready_len(), 1);
+    }
+
+    #[test]
+    fn dispatch_next_on_empty_ready_set_returns_none() {
+        let mut s = Sched::new(SchedConfig::DEFAULT);
+        assert_eq!(s.dispatch_next().unwrap(), None);
+    }
+
+    #[test]
+    fn mark_ready_wakes_a_blocked_task() {
+        let mut s = Sched::new(SchedConfig::DEFAULT);
+        let id = s.spawn().unwrap();
+        s.dispatch_next().unwrap();
+        // Park it (the poll loop's task.wait path; wired in a later increment).
+        s.tasks.transition(id, TaskEvent::Wait).unwrap();
+        assert_eq!(s.ready_len(), 0);
+
+        assert!(s.mark_ready(id).unwrap()); // woke it
+
+        assert_eq!(s.task_state(id), Some(TaskState::Ready));
+        assert_eq!(s.ready_len(), 1);
+    }
+
+    #[test]
+    fn mark_ready_is_idempotent_for_an_already_ready_task() {
+        let mut s = Sched::new(SchedConfig::DEFAULT);
+        let id = s.spawn().unwrap(); // Ready, queued once
+        assert!(!s.mark_ready(id).unwrap()); // duplicate wake: no-op
+        assert_eq!(s.ready_len(), 1); // still at most once in the ready set
+    }
+
+    #[test]
+    fn mark_ready_tolerates_a_spurious_wake_of_a_dead_task() {
+        let mut s = Sched::new(SchedConfig::DEFAULT);
+        let id = s.spawn().unwrap();
+        s.dispatch_next().unwrap();
+        s.tasks.transition(id, TaskEvent::Complete).unwrap();
+        s.tasks.remove(id).unwrap();
+
+        // A waker outliving its task is normal per the Waker contract.
+        assert!(!s.mark_ready(id).unwrap());
+        assert_eq!(s.ready_len(), 0);
+    }
+
+    #[test]
+    fn mark_ready_during_running_fails_loud() {
+        let mut s = Sched::new(SchedConfig::DEFAULT);
+        let id = s.spawn().unwrap();
+        s.dispatch_next().unwrap();
+        // Wake-during-poll needs the wake-pending flag (deferred); silently
+        // ignoring it would lose the wakeup, so it must error.
+        assert!(s.mark_ready(id).is_err());
     }
 }


### PR DESCRIPTION
## What

The two halves of the scheduling cycle around the poll loop — the safe wake entry point and the ready→running dispatch step. With these, the only Phase-1 pieces left are the wake-pending flag, the isolated `RawWaker` vtable (design R1), the fuel-sliced `poll_round`, and the P3 intrinsic wiring.

## Changes

- **`Scheduler::mark_ready(id)`** — the safe wake entry the isolated waker vtable (R1) will call. Semantics follow the standard `Waker` contract:
  - `Blocked` → `Ready` + enqueue, returns `Ok(true)`
  - duplicate wake of a `Ready` task and spurious wake of a stale/terminal task are **specified no-ops** (`Ok(false)`) — a waker outliving its task is normal asynchrony per the contract, not a masked error
  - wake of `Spawned` (never admitted) → loud FSM-violation error
  - wake of `Running` → loud error: silently ignoring it would **lose the wakeup**; the wake-pending flag lands with the poll loop
  - enqueues *before* the FSM step so a failed push leaves the task consistently `Blocked` (no half-transition)
- **`Scheduler::dispatch_next()`** — FIFO-pop the oldest ready task, drive `Ready → Running` via the FSM. `Ok(None)` on empty; a stale queue entry fails loud through the transition's own validation.

## Verification

- **TDD**: 6 new tests RED → GREEN; **26 total green**
- no_std `thumbv7em-none-eabi` build clean; clippy clean; `forbid(unsafe_code)` intact (no unsafe)
- `rivet validate`: 0 errors / 87 warnings (no regression); traced via `SM-ASYNC-001` / `REQ_ASYNC_SCHED`

Trace: SM-ASYNC-001

🤖 Generated with [Claude Code](https://claude.com/claude-code)