### PR TITLE
chore(rivet): correct AC-WAST status — verified 332 WAST failures (not ~1,500)

### DIFF
--- a/safety/requirements/architecture-components.yaml
+++ b/safety/requirements/architecture-components.yaml
@@ -42,7 +42,7 @@ artifacts:
     fields:
       previous-id: ARCH_COMP_001
       implementation: kiln-runtime/src/stackless/engine.rs
-      note: "Infrastructure implemented; ~1,500 WAST assertion failures remain (Issue 149)"
+      note: "Infrastructure implemented; 332 WAST assertion failures remain across 74/280 files (verified 2026-06-13, testsuite @7e0b83a), down from ~1,500. Dominated by GC subtyping (type-subtyping, br_on_cast×4, i31, struct/array, ref_*), linking/imports (instance, imports*), tables/elem. Issue 149; unreached-invalid excess-value cases are Issue 146."
 
   - id: AC-MEMORY
     type: feature


### PR DESCRIPTION
Backlog-triage sweep corrected a stale conformance figure in `AC-WAST`.

Ran the full suite (`cargo-kiln testsuite --run-wast`, testsuite @`7e0b83a`): **65310/65642 assertions pass, 332 fail across 74/280 files**. The note had said "~1,500 failures" — stale by a long conformance push. Updated to the verified number + the failure-cluster breakdown (GC subtyping dominant; linking/imports; tables/elem).

Issues #146 and #149 updated with the same verified data (kept open — not resolved, contrary to some commit-message-based claims). #133 closed as superseded by #237.

`rivet validate` 0 errors (unchanged).

Trace: AD-QUALITY-001

🤖 Generated with [Claude Code](https://claude.com/claude-code)