### PR TITLE
feat(async): wire task.wait/poll over waitable-sets into the Scheduler

### DIFF
--- a/kiln-async/benches/scheduler_baseline.rs
+++ b/kiln-async/benches/scheduler_baseline.rs
@@ -111,7 +111,7 @@ fn scheduler_spawn(c: &mut Criterion) {
     // The composed admission path: slot allocation + FSM Admit + ready enqueue.
     c.bench_function("scheduler/spawn_admit", |b| {
         b.iter_batched(
-            || Scheduler::<N, N, N>::new(SchedConfig::DEFAULT),
+            || Scheduler::<N, N, N, N>::new(SchedConfig::DEFAULT),
             |mut s| {
                 black_box(s.spawn().unwrap());
                 s
@@ -125,7 +125,7 @@ fn scheduler_poll_round(c: &mut Criterion) {
     // The full cycle: dispatch → poll (trivial yielding body) → re-enqueue.
     // This is the per-task scheduling overhead a fuel slice pays.
     c.bench_function("scheduler/poll_round_yield_cycle", |b| {
-        let mut s = Scheduler::<N, N, N>::new(SchedConfig::DEFAULT);
+        let mut s = Scheduler::<N, N, N, N>::new(SchedConfig::DEFAULT);
         s.spawn().unwrap();
         b.iter(|| {
             black_box(

--- a/kiln-async/src/intrinsics.rs
+++ b/kiln-async/src/intrinsics.rs
@@ -21,13 +21,16 @@
 //! - `future.write` → [`crate::Scheduler::future_write`] (wakes the reader).
 //! - `future.read` → [`crate::Scheduler::future_read`] +
 //!   [`crate::Scheduler::wait_on_future`] (read-or-park).
+//! - `waitable-set.new/join/drop` → [`crate::Scheduler::waitable_set_new`] /
+//!   [`crate::Scheduler::waitable_set_join`] / [`crate::Scheduler::waitable_set_drop`].
+//! - `task.wait` → [`crate::Scheduler::task_wait`] (arm-or-already-ready).
+//! - `task.poll` → [`crate::Scheduler::task_poll`] (non-blocking).
 //!
-//! ## Stubbed — remaining waitable surface (next increments)
+//! ## Stubbed — Phase 2+ surface
 //!
-//! `task.wait`/`task.poll` over a multi-member waitable-set, streams (Phase 2),
-//! and error-context still need their bounded backing. Each returns an explicit
-//! `NOT_IMPLEMENTED` error — never a silent `Ok` — so the scaffold cannot be
-//! mistaken for a working implementation.
+//! Streams (Phase 2) and error-context still need their bounded backing. Each
+//! returns an explicit `NOT_IMPLEMENTED` error — never a silent `Ok` — so the
+//! scaffold cannot be mistaken for a working implementation.
 
 use kiln_error::{Error, Result};
 
@@ -38,19 +41,9 @@ macro_rules! phase1_stub {
         Err(Error::not_implemented_error(concat!(
             "kiln-async: P3 intrinsic `",
             $name,
-            "` is implemented in Phase 1"
+            "` is implemented in Phase 2"
         )))
     };
-}
-
-/// `task.wait` — block the current task until any member of a waitable set fires.
-pub fn task_wait() -> Result<TaskId> {
-    phase1_stub!("task.wait")
-}
-
-/// `task.poll` — non-blocking check of a waitable set.
-pub fn task_poll() -> Result<Option<TaskId>> {
-    phase1_stub!("task.poll")
 }
 
 /// `stream.new` — create a bounded SPSC stream with credit-based flow control.
@@ -66,11 +59,6 @@ pub fn stream_read() -> Result<()> {
 /// `stream.write` — write to a stream; blocks the writer when credits hit zero.
 pub fn stream_write() -> Result<()> {
     phase1_stub!("stream.write")
-}
-
-/// `waitable-set.new` — create a set tracking future/stream readiness.
-pub fn waitable_set_new() -> Result<TaskId> {
-    phase1_stub!("waitable-set.new")
 }
 
 /// `error-context.new` — create an error-context handle for async propagation.

--- a/kiln-async/src/lib.rs
+++ b/kiln-async/src/lib.rs
@@ -82,18 +82,25 @@ pub enum PollRound {
 /// `NTASK` is the maximum number of concurrent tasks; `NREADY` is the ready-queue
 /// capacity (size it `== NTASK`: the per-slot "in ready set at most once"
 /// invariant means it can never overflow); `NFUT` is the single-shot future
-/// table capacity (the waitable backing for `future.*` / `task.wait`).
-pub struct Scheduler<const NTASK: usize, const NREADY: usize, const NFUT: usize> {
+/// table capacity (also the per-set member capacity); `NSET` is the
+/// waitable-set table capacity (the backing for `task.wait`/`task.poll`).
+pub struct Scheduler<
+    const NTASK: usize,
+    const NREADY: usize,
+    const NFUT: usize,
+    const NSET: usize,
+> {
     tasks: TaskTable<NTASK>,
     ready: ReadyQueue<NREADY>,
     futures: FutureTable<NFUT>,
+    sets: WaitableSetTable<NSET, NFUT>,
     config: SchedConfig,
     /// When set, new-task admission is refused (`task.backpressure`).
     backpressure: bool,
 }
 
-impl<const NTASK: usize, const NREADY: usize, const NFUT: usize>
-    Scheduler<NTASK, NREADY, NFUT>
+impl<const NTASK: usize, const NREADY: usize, const NFUT: usize, const NSET: usize>
+    Scheduler<NTASK, NREADY, NFUT, NSET>
 {
     /// Create an empty scheduler: all task slots free, ready queue empty.
     #[must_use]
@@ -102,6 +109,7 @@ impl<const NTASK: usize, const NREADY: usize, const NFUT: usize>
             tasks: TaskTable::new(),
             ready: ReadyQueue::new(),
             futures: FutureTable::new(),
+            sets: WaitableSetTable::new(),
             config,
             backpressure: false,
         }
@@ -253,7 +261,57 @@ impl<const NTASK: usize, const NREADY: usize, const NFUT: usize>
         if let Some(reader) = self.futures.complete(future)? {
             self.mark_ready(reader)?;
         }
+        // Wake any waitable-set waiter whose set now has a ready member. Collect
+        // first (bounded by NSET) so the sets borrow ends before mark_ready.
+        let mut woken: [TaskId; NSET] = [TaskId::NONE; NSET];
+        let mut n = 0usize;
+        self.sets.take_ready_waiters(&self.futures, |w| {
+            woken[n] = w;
+            n += 1;
+        });
+        for &w in &woken[..n] {
+            self.mark_ready(w)?;
+        }
         Ok(())
+    }
+
+    /// `waitable-set.new` — allocate an empty waitable-set.
+    pub fn waitable_set_new(&mut self) -> Result<SetId> {
+        self.sets.create()
+    }
+
+    /// `waitable-set.join` — add a future to a set (by handle).
+    pub fn waitable_set_join(&mut self, set: SetId, future: FutureId) -> Result<()> {
+        self.sets
+            .get_mut(set)
+            .ok_or_else(|| Error::validation_error("kiln-async: join into a stale/unknown set"))?
+            .join(future)
+    }
+
+    /// `waitable-set.drop` — free a set.
+    pub fn waitable_set_drop(&mut self, set: SetId) -> Result<()> {
+        self.sets.drop_set(set)
+    }
+
+    /// `task.wait` on a set: park `task` unless a member is already ready (see
+    /// [`WaitResult`]). The caller ends its slice with [`TaskOutcome::Waited`]
+    /// when [`WaitResult::Parked`] is returned.
+    pub fn task_wait(&mut self, task: TaskId, set: SetId) -> Result<WaitResult> {
+        let futures = &self.futures;
+        let s = self
+            .sets
+            .get_mut(set)
+            .ok_or_else(|| Error::validation_error("kiln-async: wait on a stale/unknown set"))?;
+        s.arm(futures, task)
+    }
+
+    /// `task.poll` — non-blocking: the first ready member of `set`, or `None`.
+    pub fn task_poll(&self, set: SetId) -> Result<Option<FutureId>> {
+        let s = self
+            .sets
+            .get(set)
+            .ok_or_else(|| Error::validation_error("kiln-async: poll of a stale/unknown set"))?;
+        Ok(s.poll_ready(&self.futures))
     }
 
     /// `future.read` (non-blocking half) — if the future is ready, consume it
@@ -335,7 +393,7 @@ impl<const NTASK: usize, const NREADY: usize, const NFUT: usize>
 mod tests {
     use super::*;
 
-    type Sched = Scheduler<4, 4, 4>;
+    type Sched = Scheduler<4, 4, 4, 4>;
 
     #[test]
     fn spawn_admits_a_task_to_the_ready_set() {
@@ -361,7 +419,7 @@ mod tests {
 
     #[test]
     fn spawn_errors_when_the_task_table_is_full() {
-        let mut s: Scheduler<2, 2, 2> = Scheduler::new(SchedConfig::DEFAULT);
+        let mut s: Scheduler<2, 2, 2, 2> = Scheduler::new(SchedConfig::DEFAULT);
         s.spawn().unwrap();
         s.spawn().unwrap();
         assert!(s.spawn().is_err()); // explicit capacity error, never silent drop
@@ -603,9 +661,71 @@ mod tests {
 
     #[test]
     fn future_new_errors_when_the_table_is_full() {
-        let mut s: Scheduler<2, 2, 1> = Scheduler::new(SchedConfig::DEFAULT);
+        let mut s: Scheduler<2, 2, 1, 1> = Scheduler::new(SchedConfig::DEFAULT);
         s.future_new().unwrap();
         assert!(s.future_new().is_err()); // capacity 1: explicit error
+    }
+
+    #[test]
+    fn task_waiting_on_a_set_is_woken_when_a_member_future_is_written() {
+        let mut s = Sched::new(SchedConfig::DEFAULT);
+        let waiter = s.spawn().unwrap();
+        let writer = s.spawn().unwrap();
+        let set = s.waitable_set_new().unwrap();
+        let f = s.future_new().unwrap();
+        s.waitable_set_join(set, f).unwrap();
+
+        // Waiter runs: nothing ready in the set → parks on it.
+        s.poll_round(|sched, tid, _| {
+            assert_eq!(tid, waiter);
+            assert_eq!(sched.task_poll(set).unwrap(), None); // non-blocking: not ready
+            assert_eq!(sched.task_wait(tid, set).unwrap(), WaitResult::Parked);
+            Ok(TaskOutcome::Waited)
+        })
+        .unwrap();
+        assert_eq!(s.task_state(waiter), Some(TaskState::Blocked));
+
+        // Writer runs: completes the set's member → wakes the set's waiter.
+        s.poll_round(|sched, tid, _| {
+            assert_eq!(tid, writer);
+            sched.future_write(f).unwrap();
+            Ok(TaskOutcome::Completed)
+        })
+        .unwrap();
+        assert_eq!(s.task_state(waiter), Some(TaskState::Ready)); // woken via the set
+
+        // Waiter re-runs: task.poll now surfaces the ready member.
+        s.poll_round(|sched, tid, _| {
+            assert_eq!(tid, waiter);
+            assert_eq!(sched.task_poll(set).unwrap(), Some(f));
+            Ok(TaskOutcome::Completed)
+        })
+        .unwrap();
+    }
+
+    #[test]
+    fn task_wait_on_an_already_ready_set_does_not_park() {
+        let mut s = Sched::new(SchedConfig::DEFAULT);
+        let t = s.spawn().unwrap();
+        let set = s.waitable_set_new().unwrap();
+        let f = s.future_new().unwrap();
+        s.waitable_set_join(set, f).unwrap();
+        s.future_write(f).unwrap(); // ready before the wait
+
+        assert_eq!(s.task_wait(t, set).unwrap(), WaitResult::AlreadyReady);
+        assert_eq!(s.task_poll(set).unwrap(), Some(f));
+    }
+
+    #[test]
+    fn waitable_set_ops_reject_stale_handles() {
+        let mut s: Scheduler<2, 2, 2, 1> = Scheduler::new(SchedConfig::DEFAULT);
+        let set = s.waitable_set_new().unwrap();
+        let f = s.future_new().unwrap();
+        s.waitable_set_drop(set).unwrap();
+        assert!(s.waitable_set_join(set, f).is_err()); // dropped
+        assert!(s.task_poll(set).is_err());
+        assert!(s.task_wait(TaskId::NONE, set).is_err());
+        assert!(s.waitable_set_new().is_ok()); // slot reusable after drop
     }
 
     #[test]
@@ -675,7 +795,7 @@ mod tests {
 
     #[test]
     fn wake_pending_does_not_leak_across_slot_reuse() {
-        let mut s: Scheduler<1, 1, 1> = Scheduler::new(SchedConfig::DEFAULT);
+        let mut s: Scheduler<1, 1, 1, 1> = Scheduler::new(SchedConfig::DEFAULT);
         let old = s.spawn().unwrap();
         // Wake itself mid-poll, then complete: the pending flag must die with
         // the slot, not leak into the next occupant.

--- a/kiln-async/src/waitable.rs
+++ b/kiln-async/src/waitable.rs
@@ -544,6 +544,24 @@ impl<const NSET: usize, const NMEM: usize> WaitableSetTable<NSET, NMEM> {
         self.live -= 1;
         Ok(())
     }
+
+    /// For every live set with a parked waiter that now has a ready member,
+    /// take the waiter (clearing it) and hand it to `sink`. The scheduler calls
+    /// this after a future completes to wake set-level waiters. At most one
+    /// waiter per set, so `sink` fires at most `NSET` times.
+    pub fn take_ready_waiters<const NF: usize>(
+        &mut self,
+        futures: &FutureTable<NF>,
+        mut sink: impl FnMut(crate::TaskId),
+    ) {
+        for slot in self.slots.iter_mut() {
+            if let Some(set) = slot.set.as_mut() {
+                if let Some(waiter) = set.take_ready_waiter(futures) {
+                    sink(waiter);
+                }
+            }
+        }
+    }
 }
 
 impl<const NSET: usize, const NMEM: usize> Default for WaitableSetTable<NSET, NMEM> {


### PR DESCRIPTION
## What

The **capstone of the v0.3.2 scheduler-core API**: a task can now block on a waitable-set and be woken when **any** member future completes — end-to-end through `poll_round`, across tasks.

## Changes

- `Scheduler` gains a 4th const generic **`NSET`** + a `WaitableSetTable<NSET, NFUT>` (per-set member capacity reuses `NFUT`).
- **`waitable_set_new`/`join`/`drop`**, **`task_wait`** (arm → `AlreadyReady` or `Parked`), **`task_poll`** (non-blocking first-ready member). Stale set handles fail loud everywhere.
- **`future_write`** now also wakes set-level waiters: after completing the future + waking its direct reader, it sweeps the set table (`take_ready_waiters`), collecting woken tasks into a bounded local `[TaskId; NSET]` **before** `mark_ready` (keeps the `sets` borrow off the wake path). A future in multiple sets wakes each set's waiter.
- `intrinsics.rs`: deleted the now-implemented `task.wait`/`task.poll` + `waitable-set.new` stubs (no dead code); module doc maps them to their scheduler methods. Only streams (Phase 2) + error-context remain stubbed.

## Verification

- **TDD**: 3 tests incl. the cross-task **wait-on-set → write → wake → poll** capstone, **verified to bite via mutate-and-restore** (skipping the set-wake fails exactly that test). **71 total green.**
- no_std `thumbv7em-none-eabi` clean; clippy clean; `forbid(unsafe_code)` intact; `rivet validate` 0 errors.

## This closes the v0.3.2 scope

The scheduler-core API is now complete: task lifecycle, futures, waitable-sets, and the `task-control` + `future.*` + `task.wait`/`task.poll` intrinsics. Per the incremental release plan (#306), the next step is **clean-room verification then cutting v0.3.2** — the host-future `RawWaker` bridge + synth integration move to v0.4.0.

Trace: SM-ASYNC-001

🤖 Generated with [Claude Code](https://claude.com/claude-code)