### PR TITLE
chore(release): bump workspace to v0.3.2 (kiln-async scheduler core)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -253,7 +253,7 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cargo-kiln"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1147,7 +1147,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-async"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "criterion",
  "kiln-error",
@@ -1155,7 +1155,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-build-core"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1185,7 +1185,7 @@ version = "0.1.0"
 
 [[package]]
 name = "kiln-component"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "criterion",
  "kiln-decoder",
@@ -1202,7 +1202,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-debug"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "kiln-error",
  "kiln-format",
@@ -1211,7 +1211,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-decoder"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "criterion",
  "hex",
@@ -1228,11 +1228,11 @@ dependencies = [
 
 [[package]]
 name = "kiln-error"
-version = "0.3.1"
+version = "0.3.2"
 
 [[package]]
 name = "kiln-format"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "kani-verifier",
  "kiln-error",
@@ -1242,7 +1242,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-foundation"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "criterion",
  "hashbrown 0.15.4",
@@ -1260,7 +1260,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-host"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "kiln-error",
  "kiln-foundation",
@@ -1271,7 +1271,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-instructions"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "kiln-error",
  "kiln-foundation",
@@ -1283,7 +1283,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-intercept"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "chrono",
  "kani-verifier",
@@ -1296,7 +1296,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-logging"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "kiln-error",
  "kiln-foundation",
@@ -1306,7 +1306,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-math"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "kiln-error",
  "kiln-platform",
@@ -1315,11 +1315,11 @@ dependencies = [
 
 [[package]]
 name = "kiln-panic"
-version = "0.3.1"
+version = "0.3.2"
 
 [[package]]
 name = "kiln-platform"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "criterion",
  "kiln-error",
@@ -1329,7 +1329,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-runtime"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "kiln-debug",
  "kiln-decoder",
@@ -1347,7 +1347,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-sync"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "kani-verifier",
  "kiln-error",
@@ -1356,7 +1356,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-wasi"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "kiln-error",
  "kiln-format",
@@ -1369,7 +1369,7 @@ dependencies = [
 
 [[package]]
 name = "kilnd"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "kiln-component",
  "kiln-debug",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ edition = "2024"
 rust-version = "1.85.0"
 license = "MIT"
 repository = "https://github.com/pulseengine/kiln"
-version = "0.3.1"
+version = "0.3.2"
 
 
 [workspace.dependencies]
@@ -37,22 +37,22 @@ anyhow = "1.0"
 wit-bindgen = "0.41.0"
 
 # Internal crate versions
-kiln-error = { path = "kiln-error", version = "0.3.1", default-features = false }
-kiln-sync = { path = "kiln-sync", version = "0.3.1", default-features = false }
-kiln-format = { path = "kiln-format", version = "0.3.1", default-features = false }
-kiln-foundation = { path = "kiln-foundation", version = "0.3.1", default-features = false }
-kiln-decoder = { path = "kiln-decoder", version = "0.3.1", default-features = false, features = ["std"] }
-kiln-debug = { path = "kiln-debug", version = "0.3.1", default-features = false }
-kiln-runtime = { path = "kiln-runtime", version = "0.3.1", default-features = false }
-kiln-logging = { path = "kiln-logging", version = "0.3.1", default-features = false }
-kiln-instructions = { path = "kiln-instructions", version = "0.3.1", default-features = false }
-kiln-component = { path = "kiln-component", version = "0.3.1", default-features = false }
-kiln-host = { path = "kiln-host", version = "0.3.1", default-features = false }
-kiln-intercept = { path = "kiln-intercept", version = "0.3.1", default-features = false }
-kiln-math = { path = "kiln-math", version = "0.3.1", default-features = false }
-kiln-platform = { path = "kiln-platform", version = "0.3.1", default-features = false }
-kiln-panic = { path = "kiln-panic", version = "0.3.1", default-features = false }
-kiln-wasi = { path = "kiln-wasi", version = "0.3.1", default-features = false }
+kiln-error = { path = "kiln-error", version = "0.3.2", default-features = false }
+kiln-sync = { path = "kiln-sync", version = "0.3.2", default-features = false }
+kiln-format = { path = "kiln-format", version = "0.3.2", default-features = false }
+kiln-foundation = { path = "kiln-foundation", version = "0.3.2", default-features = false }
+kiln-decoder = { path = "kiln-decoder", version = "0.3.2", default-features = false, features = ["std"] }
+kiln-debug = { path = "kiln-debug", version = "0.3.2", default-features = false }
+kiln-runtime = { path = "kiln-runtime", version = "0.3.2", default-features = false }
+kiln-logging = { path = "kiln-logging", version = "0.3.2", default-features = false }
+kiln-instructions = { path = "kiln-instructions", version = "0.3.2", default-features = false }
+kiln-component = { path = "kiln-component", version = "0.3.2", default-features = false }
+kiln-host = { path = "kiln-host", version = "0.3.2", default-features = false }
+kiln-intercept = { path = "kiln-intercept", version = "0.3.2", default-features = false }
+kiln-math = { path = "kiln-math", version = "0.3.2", default-features = false }
+kiln-platform = { path = "kiln-platform", version = "0.3.2", default-features = false }
+kiln-panic = { path = "kiln-panic", version = "0.3.2", default-features = false }
+kiln-wasi = { path = "kiln-wasi", version = "0.3.2", default-features = false }
 
 # Note: Safety level presets should be defined in individual crate Cargo.toml files
 # as workspace.features is not supported by Cargo


### PR DESCRIPTION
Bumps the workspace `0.3.1 → 0.3.2` to cut the first incremental kiln-async release (plan #306).

**v0.3.2 ships:** the kiln-async cooperative scheduler **core library** — `no_std`/`no_alloc`, fuel-sliced `poll_round`, task lifecycle FSM, bounded task/ready/future/waitable-set tables, `cancel`, backpressure, and the `future.*` + `task.wait`/`task.poll` + task-control P3 intrinsics. 71 tests, clippy-clean, **zero unsafe**, criterion-benched. **Clean-room-verified** (cold-agent confirmed all claims).

**Falsification statement:** v0.3.2 provides a usable scheduler *library*; it does **NOT** yet run a synth-lowered async core module end-to-end (the host-future `RawWaker` bridge is not in yet) — that's **v0.4.0**.

`rivet validate`: 0 errors (the 87 warnings / 33 cross-refs are pre-existing non-blocking noise, to be cleaned separately). On merge, tagging `v0.3.2` triggers the signed GitHub release (cosign SHA256SUMS, CycloneDX SBOM, SLSA provenance, rivet snapshot). No crates.io publish — that pipeline is a planned next-release item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)