### PR TITLE
chore(rivet): plan crates.io publishing — REQ_CRATES_PUBLISH + AD-PUBLISH-001 (kilnvm-*)

### DIFF
--- a/safety/requirements/architecture-decisions.yaml
+++ b/safety/requirements/architecture-decisions.yaml
@@ -328,3 +328,36 @@ artifacts:
         composition. (3) Function pointer table — rejected, less safe and
         harder to extend with new methods.
       implementation: kiln-foundation/src/traits.rs, kiln-runtime/src/stackless/engine.rs
+
+  - id: AD-PUBLISH-001
+    type: design-decision
+    title: Publish to crates.io under the kilnvm-* namespace, synth-modeled workflow
+    description: >
+      The workspace publishes to crates.io under the kilnvm-* prefix (kilnvm-runtime,
+      kilnvm-foundation, …; daemon kilnvmd; cargo-kiln CLI unchanged). The bare kiln-*
+      namespace is contested by unrelated owners (kiln-runtime by zenvanexus, plus
+      kiln-core/cli/cache/exec and the kiln-sv family), so a dedicated, fully-available
+      prefix is used for published package names only — git repo, tags, directory names,
+      and the CLI stay "kiln". Publishing follows synth's publish-to-crates-io.yml:
+      a v* tag triggers it in parallel with release.yml, auth via the org-wide
+      CRATES_IO_TOKEN, a dependency-order publish walker with index-propagation retry,
+      and a tag-matches-workspace-version preflight.
+    status: planned
+    tags: [release, distribution, crates-io, naming, tooling]
+    links:
+      - type: satisfies
+        target: REQ_CRATES_PUBLISH
+    fields:
+      rationale: >
+        Consistency over a one-off rename: prefixing every published crate (not just the
+        conflicting kiln-runtime) keeps the namespace coherent and squatter-proof. kilnvm
+        ("kiln VM") is compact, brandable, avoids the kiln-wasm-wasi double-noun, and
+        kilnvm itself is free as an umbrella crate. Token auth (not OIDC trusted
+        publishing) mirrors synth/sigil and reuses the existing org secret.
+      alternatives: >
+        (1) kiln-wasm-* — descriptive but yields the awkward kiln-wasm-wasi; runner-up.
+        (2) Rename only kiln-runtime — rejected, leaves the namespace inconsistent and
+        still exposed to the other squatters. (3) Contact owners to transfer kiln-* names
+        — rejected as slow/uncertain. (4) OIDC trusted publishing — deferred (per-crate
+        registration overhead); revisit later.
+      source-ref: "https://github.com/pulseengine/kiln/issues/310"

--- a/safety/requirements/roadmap-requirements.yaml
+++ b/safety/requirements/roadmap-requirements.yaml
@@ -226,3 +226,27 @@ artifacts:
         Phase 1 of the plan carries the criterion baseline (host, std bench
         units over the no_std lib); on-target fuel→cycles measurement and the
         fuzz/Kani/mutation layers land with plan Phase 6 (hardening).
+
+  - id: REQ_CRATES_PUBLISH
+    type: requirement
+    title: Publish the workspace to crates.io (kilnvm-* namespace)
+    description: >
+      The kiln workspace shall be publishable to crates.io so downstream users can
+      depend on the runtime/scheduler libraries by version, not just consume the
+      signed GitHub release artifacts. Published package names use the kilnvm-*
+      prefix (the bare kiln-* namespace is contested by unrelated owners); the
+      publish pipeline is modeled on synth's publish-to-crates-io.yml (v* tag
+      trigger parallel to release.yml, org CRATES_IO_TOKEN, dependency-order walker
+      with index-propagation retry, tag-matches-version preflight).
+    status: planned
+    tags: [release, distribution, crates-io, roadmap]
+    links:
+      - type: derives-from
+        target: REQ_FUNC_003
+    fields:
+      upstream-ref: "https://github.com/pulseengine/kiln/issues/310"
+      note: >
+        Next-release item — NOT v0.3.2 (which ships as a GitHub signed release only).
+        Naming + workflow decision captured in AD-PUBLISH-001. Verified 2026-06-14:
+        20/21 kiln-* names free but kiln-runtime taken (zenvanexus); all kilnvm-*
+        target names available.


### PR DESCRIPTION
Lands the rivet plan for crates.io publishing (issue #310), targeted at the next release (not v0.3.2).

- **REQ_CRATES_PUBLISH** (roadmap, `planned`): publish the workspace to crates.io under `kilnvm-*`.
- **AD-PUBLISH-001** (design-decision): the `kilnvm-*` naming (published names only — repo/tags/dirs/`cargo-kiln` CLI stay "kiln") + the synth-modeled `publish-to-crates-io.yml` (v* trigger, org `CRATES_IO_TOKEN`, dep-order publish walker with index-propagation retry, tag-matches-version preflight). Records the alternatives (kiln-wasm-*, rename-only, OIDC).

Rationale grounded in a verified crates.io check (2026-06-14): bare `kiln-*` is contested (kiln-runtime → zenvanexus, plus kiln-core/cli/cache/exec, kiln-sv-*); all `kilnvm-*` target names are free.

`rivet validate`: 0 errors. `AD-PUBLISH-001` satisfies `REQ_CRATES_PUBLISH` (no dangling-requirement warning).

Trace: AD-PUBLISH-001

🤖 Generated with [Claude Code](https://claude.com/claude-code)