### PR TITLE
docs(async): resolve R1 — unsafe waker unnecessary, forbid(unsafe_code) permanent

### DIFF
--- a/docs/architecture/async-scheduler-plan.md
+++ b/docs/architecture/async-scheduler-plan.md
@@ -112,7 +112,7 @@ its proof.
 The dev phases above are *milestones*, not release units. Ship the scheduler in small,
 user-usable increments (kiln workspace versions) rather than holding one release for the
 full Phase-1 exit. Each release: `rivet validate` green, no_std `thumbv7em` builds, criterion
-baseline updated, no `unsafe` except the isolated R1 waker (which arrives in v0.4.0).
+baseline updated, **zero `unsafe`** (R1 resolved — `#![forbid(unsafe_code)]` is permanent; see §8).
 
 - **v0.3.2 — scheduler core (library).** A usable `no_std`/`no_alloc` cooperative scheduler API:
   task-lifecycle FSM, bounded `TaskTable`/`ReadyQueue`, fuel-sliced `poll_round`, `mark_ready` +
@@ -120,9 +120,13 @@ baseline updated, no `unsafe` except the isolated R1 waker (which arrives in v0.
   `task.wait`/`task.poll`. Phase-1 minus the host-future bridge. (PRs #293–#306.)
   *Exit criterion for the tag: the scheduler-level `task.wait`/`task.poll` wiring is in (one
   increment after #305), so the public API is coherent.*
-- **v0.4.0 — embedded P3 integration (the original Phase-1 exit).** Host-future `RawWaker`
-  bridge (R1 — the one ASIL-D `unsafe`) + end-to-end run of a real synth-lowered async core
-  module on host sim / QEMU.
+- **v0.4.0 — embedded P3 integration (the original Phase-1 exit).** End-to-end run of a real
+  synth-lowered async core module — **no unsafe** (R1 resolved): synth lowers a P3 async module to
+  native code that calls kiln-async's intrinsic surface (like kiln-builtins), and kiln-async schedules it.
+  Harness via the established jess pipeline (`adopt → meld_fuse → wasm_optimize → synth_compile → renode`,
+  rules_wasm_component) — gated on synth's P3-async→ARM lowering + Renode test (synth#275). The Wasmtime
+  `wasm_run` path tests the *component*, not kiln-async, so the kiln-async exit specifically needs the
+  synth→Renode leg.
 - **v0.5.0 — streams + backpressure** (Phase 2).
 - **v0.6.0+ — Verus invariant gating** (Phase 3), then fixed-priority/EDF (4),
   Lean+Aeneas refinement (5), hardening (6).
@@ -134,8 +138,14 @@ Meld/synth output — moves to v0.4.0 where its cross-tool dependency lives.
 
 ## 8. Risks / open questions
 
-- **R1** Waker `RawWakerVTable` is the only `unsafe` + pointer code — isolate behind safe `mark_ready(TaskId)`,
-  `external_body` for Verus, exclude from Aeneas (axiomatize wake).
+- **R1** ~~Waker `RawWakerVTable` is the only `unsafe`~~ **RESOLVED — no unsafe needed.** The implemented
+  architecture (R2: opaque poll-outcome callback + safe `mark_ready(TaskId)`) never polls a Rust `Future`,
+  so it never constructs a `Context`/`Waker`, so there is no `RawWakerVTable` and `#![forbid(unsafe_code)]`
+  is **permanent**. A waker would only be needed to drive *host* Rust `async fn`s on the scheduler — a
+  std-only convenience that, if ever wanted, lives in a separate `kiln-async-std` feature/crate outside the
+  cert-scope crate, NOT here. Consequence: the Kani/Verus/Rocq/Lean firepower targets the **safe scheduler
+  invariants** (FSM soundness, queue no-overflow, backpressure correctness, lost-wakeup-freedom), not an
+  unsafe block — a stronger claim (zero unsafe + proven invariants).
 - **R2** `Future`/`Poll` translatability — prove scheduler properties, treat `poll_fn` as opaque; user-future
   correctness is the synthesized code's concern.
 - **R3** ~~Charon (`rustc→.llbc`) not yet in `rules_lean`~~ **RESOLVED 2026-06-06** (rules_lean#1): the

--- a/kiln-async/src/lib.rs
+++ b/kiln-async/src/lib.rs
@@ -27,8 +27,12 @@
 //!
 //! - Fixed-capacity arrays parameterized by compile-time const generics — no
 //!   heap, no provider machinery (minimal trusted computing base).
-//! - `#![forbid(unsafe_code)]` — the only planned `unsafe` (the waker vtable) is
-//!   isolated and arrives in Phase 1.
+//! - `#![forbid(unsafe_code)]` — **permanent**. The scheduler drives tasks via
+//!   an opaque poll-outcome callback ([`Scheduler::poll_round`]) and wakes via
+//!   safe [`Scheduler::mark_ready`]; it never polls a Rust `Future`, so it never
+//!   needs a `RawWaker` vtable. The `unsafe` waker once planned (design R1) was
+//!   only for *host* Rust-future interop — a std-only convenience outside this
+//!   cert-scope crate, not the embedded synth-lowered path.
 //! - Scheduling is fuel-bounded: a task's poll slice is a fuel budget, so
 //!   execution is deterministic and replayable.
 

--- a/safety/requirements/safety-mechanisms.yaml
+++ b/safety/requirements/safety-mechanisms.yaml
@@ -333,14 +333,23 @@ artifacts:
     title: kiln-async — minimal-TCB no_std/no_alloc cooperative scheduler crate
     description: >
       The async scheduler for the embedded base is a dedicated crate
-      (kiln-async), no_std with no alloc, forbidding unsafe code (except a
-      single isolated waker), using fixed-capacity arrays parameterized by a
-      compile-time SchedConfig rather than heap or provider-backed collections.
-      All P3 async intrinsics return an explicit NOT_IMPLEMENTED error until
-      implemented — never a silent Ok. Scheduling is fuel-bounded (a poll slice
-      is a fuel budget) for deterministic, replayable execution. Performance
-      claims are measured, not asserted: a criterion host-bench baseline covers
-      every scheduler primitive from the first commit (REQ_ASYNC_BENCH).
+      (kiln-async), no_std with no alloc, **forbidding unsafe code with no
+      exception** (#![forbid(unsafe_code)] is permanent), using fixed-capacity
+      arrays parameterized by a compile-time SchedConfig rather than heap or
+      provider-backed collections. The once-planned single unsafe waker (design
+      R1) proved unnecessary: the scheduler drives tasks via an opaque
+      poll-outcome callback and wakes via safe mark_ready(TaskId), never polling
+      a Rust Future, so no RawWaker vtable is needed. Host Rust-future interop
+      (the only thing that would need a waker) is a std-only convenience outside
+      this cert-scope crate. All P3 async intrinsics return an explicit
+      NOT_IMPLEMENTED error until implemented — never a silent Ok. Scheduling is
+      fuel-bounded (a poll slice is a fuel budget) for deterministic, replayable
+      execution. Performance claims are measured, not asserted: a criterion
+      host-bench baseline covers every scheduler primitive (REQ_ASYNC_BENCH).
+      Because there is no unsafe, the Kani/Verus/Rocq/Lean verification effort
+      targets the safe scheduler invariants (FSM soundness, queue no-overflow,
+      backpressure correctness, lost-wakeup-freedom) rather than backing an
+      unsafe block — a stronger story: zero unsafe + proven invariants.
     status: partial
     tags: [async, scheduler, no-std, no-alloc, embedded, mechanism]
     links:


### PR DESCRIPTION
Investigated the two flagged kiln-async items: whether the planned `RawWaker` unsafe is avoidable, and how the synth-lowered end-to-end run is established.

## R1 resolved — **no unsafe needed**

The implemented architecture (design **R2**: opaque poll-outcome callback + safe `mark_ready(TaskId)`) **never polls a Rust `Future`**, so it never constructs a `Context`/`Waker`, so there is no `RawWakerVTable`. **`#![forbid(unsafe_code)]` is permanent** on the cert-scope crate. A waker would only be needed to drive *host* Rust `async fn`s on the scheduler — a std-only convenience that, if ever wanted, belongs in a separate `kiln-async-std` feature outside this crate, not here.

**Addresses the "back it with Kani/Verus/Rocq" ask:** with no unsafe to back, that firepower targets the **safe scheduler invariants** (FSM soundness, queue no-overflow, backpressure correctness, lost-wakeup-freedom) — a stronger claim than "verified unsafe": **zero unsafe + proven invariants**.

## End-to-end run (v0.4.0)

Harness via the **established jess pipeline** (`adopt → meld_fuse → wasm_optimize → synth_compile → renode`, on `rules_wasm_component`). The kiln-async exit specifically needs the **synth P3-async→ARM lowering + Renode** leg (gated on synth#275); the Wasmtime `wasm_run` path tests the *component*, not kiln-async.

## Changes
Updates `SM-ASYNC-001`, the plan doc (R1, §7a v0.4.0, the zero-unsafe line), and the crate doc. Verified zero `unsafe` in `kiln-async/src`; `rivet validate` 0 errors.

Trace: SM-ASYNC-001

🤖 Generated with [Claude Code](https://claude.com/claude-code)