### PR TITLE
feat(async): Kani-prove the safe scheduler invariants (FSM, ready-queue, ABA)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -319,3 +319,13 @@ harnesses = [
     "verify_synchronization_primitives",
     "verify_thread_safety"
 ]
+
+# Async scheduler invariants (safe code — kiln-async forbids unsafe)
+[[workspace.metadata.kani.package]]
+name = "kiln-async"
+verification-enabled = true
+harnesses = [
+    "verify_fsm_step_total_and_terminal_absorbing",
+    "verify_ready_queue_never_overflows",
+    "verify_task_table_generation_aba_safe"
+]

--- a/kiln-async/Cargo.toml
+++ b/kiln-async/Cargo.toml
@@ -24,6 +24,13 @@ criterion = { version = "0.6", features = ["html_reports"] }
 
 [features]
 default = []
+# No-op feature so the repo's `cargo kani -p <pkg> --features kani` CI invocation
+# accepts kiln-async; the harnesses gate on `cfg(kani)` (set by `cargo kani`),
+# in src/kani_proofs.rs.
+kani = []
+
+[lints.rust]
+unexpected_cfgs = { level = "allow", check-cfg = ['cfg(kani)'] }
 
 [[bench]]
 name = "scheduler_baseline"

--- a/kiln-async/src/kani_proofs.rs
+++ b/kiln-async/src/kani_proofs.rs
@@ -1,0 +1,86 @@
+//! Kani (CBMC) formal-verification harnesses for kiln-async scheduler
+//! invariants.
+//!
+//! kiln-async is `#![forbid(unsafe_code)]` (permanent — see SM-ASYNC-001 / the
+//! plan §8 R1). Rather than backing an `unsafe` block, this firepower proves the
+//! **safe scheduler invariants**: the lifecycle FSM is total and terminal states
+//! are absorbing, the bounded ready queue never overflows, and freed task
+//! handles are ABA-detectable. CBMC explores these exhaustively over the bounded
+//! state space.
+//!
+//! Run: `cargo kani -p kiln-async --features kani`
+//! (the installed `cargo-kiln kani-verify -p kiln-async` wraps this).
+
+use crate::{ReadyQueue, TaskEvent, TaskId, TaskState, TaskTable};
+
+fn any_state() -> TaskState {
+    match kani::any::<u8>() % 6 {
+        0 => TaskState::Spawned,
+        1 => TaskState::Ready,
+        2 => TaskState::Running,
+        3 => TaskState::Blocked,
+        4 => TaskState::Completed,
+        _ => TaskState::Cancelled,
+    }
+}
+
+fn any_event() -> TaskEvent {
+    match kani::any::<u8>() % 7 {
+        0 => TaskEvent::Admit,
+        1 => TaskEvent::Dispatch,
+        2 => TaskEvent::Yield,
+        3 => TaskEvent::Wait,
+        4 => TaskEvent::Wake,
+        5 => TaskEvent::Complete,
+        _ => TaskEvent::Cancel,
+    }
+}
+
+/// FSM soundness: for *every* (state, event), `step` either returns a valid
+/// transition or an error — it never panics — and a successful transition is
+/// only possible from a non-terminal state (terminal states are absorbing).
+#[kani::proof]
+fn verify_fsm_step_total_and_terminal_absorbing() {
+    let state = any_state();
+    let event = any_event();
+    match state.step(event) {
+        Ok(_next) => {
+            // A successful transition can only leave a non-terminal state.
+            assert!(!state.is_terminal());
+        }
+        Err(_) => {
+            // Illegal transitions are rejected loud — no panic, no silent Ok.
+        }
+    }
+}
+
+/// Bounded ready queue: across every sequence of push/pop, the queue length
+/// never exceeds capacity (no overflow), and no operation panics.
+#[kani::proof]
+#[kani::unwind(7)]
+fn verify_ready_queue_never_overflows() {
+    let mut q: ReadyQueue<4> = ReadyQueue::new();
+    let id = TaskId { index: 1, generation: 0 };
+    for _ in 0..6 {
+        if kani::any() {
+            // push returns Err when full — never overflows the backing array.
+            let _ = q.push(id);
+        } else {
+            let _ = q.pop();
+        }
+        assert!(q.len() <= q.capacity());
+    }
+}
+
+/// ABA safety: after a slot is freed and reused, a handle to the old occupant
+/// no longer validates (the generation was bumped), while the new handle does.
+#[kani::proof]
+fn verify_task_table_generation_aba_safe() {
+    let mut t: TaskTable<2> = TaskTable::new();
+    let old = t.spawn().unwrap();
+    t.remove(old).unwrap();
+    let new = t.spawn().unwrap();
+    // Stale handle (old generation) must not resolve, even if the slot is reused.
+    assert!(t.state_of(old).is_none());
+    assert!(t.state_of(new).is_some());
+}

--- a/kiln-async/src/lib.rs
+++ b/kiln-async/src/lib.rs
@@ -39,6 +39,16 @@
 #![no_std]
 #![forbid(unsafe_code)]
 
+// Kani (CBMC) needs an explicit import in a `#![no_std]` crate to discover its
+// harness machinery. Gated on `cfg(kani)` — only present under `cargo kani`,
+// never in normal/embedded builds. Safe (no `unsafe`); does not affect the crate.
+#[cfg(kani)]
+extern crate kani;
+
+/// Formal-verification harnesses (CBMC via Kani), present only under `cargo kani`.
+#[cfg(kani)]
+mod kani_proofs;
+
 pub mod config;
 pub mod error_context;
 pub mod intrinsics;


### PR DESCRIPTION
With no unsafe to back (R1 resolved, #316), the **Kani firepower targets the safe scheduler invariants** — a stronger claim than "verified unsafe": **zero unsafe + machine-checked invariants.**

Three Kani (CBMC) harnesses (`kiln-async/src/kani_proofs.rs`, `#[cfg(kani)]`), **all VERIFIED SUCCESSFUL** via `cargo kani -p kiln-async` (3/3, 0 failures):

- **`verify_fsm_step_total_and_terminal_absorbing`** — `TaskState::step` is total over *every* `(state, event)` (never panics), and terminal states are absorbing (no successful transition out).
- **`verify_ready_queue_never_overflows`** — over every push/pop sequence the bounded `ReadyQueue` length never exceeds capacity (no overflow / no panic).
- **`verify_task_table_generation_aba_safe`** — a freed-then-reused slot's stale handle never validates (generation bump); the new handle does.

## Setup
- `#[cfg(kani)] extern crate kani` + a `cfg(kani)`-gated `kani_proofs` module (a `#![no_std]` crate needs the explicit Kani import; the module compiles only under `cargo kani`).
- A no-op `kani` feature so the repo's `cargo kani --features kani` CI invocation accepts the crate.
- Registered in `[workspace.metadata.kani.package]` for the #237 KANI CI suite.

## Verification
- `cargo kani -p kiln-async`: **3 verified, 0 failures.**
- `#![forbid(unsafe_code)]` intact; normal builds unaffected — **89 tests**, no_std `thumbv7em` build, clippy all clean; `rivet validate` 0 errors.

This is the formal backing requested for the (now-nonexistent) unsafe, redirected to the safe core. Verus/Lean refinement against spar's RTA/RM/EDF (v0.7.0) remains the next verification layer.

Trace: SM-ASYNC-001

🤖 Generated with [Claude Code](https://claude.com/claude-code)