### PR TITLE
fix(wast): handle wast HeapType::Exact in ref.null conversion (unbreak workspace build)

### DIFF
--- a/kiln-build-core/src/wast_values.rs
+++ b/kiln-build-core/src/wast_values.rs
@@ -164,6 +164,9 @@ pub fn convert_wast_ret_core_to_value(ret: &WastRetCore) -> Result<Value> {
                     // Concrete type reference - use FuncRef for function types
                     Ok(Value::FuncRef(None))
                 },
+                // `(ref null (exact $t))` — exact (non-subtyping) reference to a
+                // concrete type; a null of it is represented like Concrete.
+                Some(wast::core::HeapType::Exact(_)) => Ok(Value::FuncRef(None)),
                 None => Ok(Value::FuncRef(None)), // Default for unspecified heap type
             }
         },


### PR DESCRIPTION
## The bug

`cargo build --workspace --locked` on main **fails** with `E0004` — non-exhaustive patterns, `Some(wast::core::HeapType::Exact(_))` not covered, at `kiln-build-core/src/wast_values.rs:139`. The pinned `wast 244.0.0` carries the typed-reference **`Exact`** heap type (`(ref (exact $t))`) that the `WastRetCore::RefNull` match didn't handle.

## Why it went unnoticed

kiln-async (recent loop work) doesn't depend on kiln-build-core, so its build/tests stayed green while the **workspace** build was red — which is also why the open **Dependabot PR CIs were failing** (they build the whole workspace, inheriting this break).

## The fix

`(ref null (exact $t))` is an exact (non-subtyping) reference to a concrete type, so represent its null like the existing `Concrete(_)` arm → `Value::FuncRef(None)`. One added match arm.

## Oracle

`cargo build --workspace --locked` now **Finishes** (was `E0004`); no further non-exhaustive `HeapType` matches remain. This should clear the workspace-build failure on the rebased Dependabot PRs too (leaving only genuinely bump-specific issues like criterion 0.8 / wat 1.252's own new variants).

Trace: AD-QUALITY-001

🤖 Generated with [Claude Code](https://claude.com/claude-code)