### PR TITLE
chore(release): bump workspace to v0.3.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -278,7 +278,7 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cargo-kiln"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1307,7 +1307,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-async"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "criterion",
  "kiln-error",
@@ -1315,7 +1315,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-build-core"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1345,7 +1345,7 @@ version = "0.1.0"
 
 [[package]]
 name = "kiln-component"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "criterion",
  "kiln-decoder",
@@ -1362,7 +1362,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-debug"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "kiln-error",
  "kiln-format",
@@ -1371,7 +1371,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-decoder"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "criterion",
  "hex",
@@ -1388,11 +1388,11 @@ dependencies = [
 
 [[package]]
 name = "kiln-error"
-version = "0.3.2"
+version = "0.3.3"
 
 [[package]]
 name = "kiln-format"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "kani-verifier",
  "kiln-error",
@@ -1402,7 +1402,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-foundation"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "criterion",
  "hashbrown 0.15.4",
@@ -1420,7 +1420,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-host"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "kiln-error",
  "kiln-foundation",
@@ -1431,7 +1431,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-instructions"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "kiln-error",
  "kiln-foundation",
@@ -1443,7 +1443,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-intercept"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "chrono",
  "kani-verifier",
@@ -1456,7 +1456,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-logging"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "kiln-error",
  "kiln-foundation",
@@ -1466,7 +1466,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-math"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "kiln-error",
  "kiln-platform",
@@ -1475,11 +1475,11 @@ dependencies = [
 
 [[package]]
 name = "kiln-panic"
-version = "0.3.2"
+version = "0.3.3"
 
 [[package]]
 name = "kiln-platform"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "criterion",
  "kiln-error",
@@ -1489,7 +1489,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-runtime"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "kiln-debug",
  "kiln-decoder",
@@ -1507,7 +1507,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-sync"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "kani-verifier",
  "kiln-error",
@@ -1516,7 +1516,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-wasi"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "kiln-error",
  "kiln-format",
@@ -1529,7 +1529,7 @@ dependencies = [
 
 [[package]]
 name = "kilnd"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "kiln-component",
  "kiln-debug",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ edition = "2024"
 rust-version = "1.85.0"
 license = "MIT"
 repository = "https://github.com/pulseengine/kiln"
-version = "0.3.2"
+version = "0.3.3"
 
 
 [workspace.dependencies]
@@ -37,22 +37,22 @@ anyhow = "1.0"
 wit-bindgen = "0.41.0"
 
 # Internal crate versions
-kiln-error = { path = "kiln-error", version = "0.3.2", default-features = false }
-kiln-sync = { path = "kiln-sync", version = "0.3.2", default-features = false }
-kiln-format = { path = "kiln-format", version = "0.3.2", default-features = false }
-kiln-foundation = { path = "kiln-foundation", version = "0.3.2", default-features = false }
-kiln-decoder = { path = "kiln-decoder", version = "0.3.2", default-features = false, features = ["std"] }
-kiln-debug = { path = "kiln-debug", version = "0.3.2", default-features = false }
-kiln-runtime = { path = "kiln-runtime", version = "0.3.2", default-features = false }
-kiln-logging = { path = "kiln-logging", version = "0.3.2", default-features = false }
-kiln-instructions = { path = "kiln-instructions", version = "0.3.2", default-features = false }
-kiln-component = { path = "kiln-component", version = "0.3.2", default-features = false }
-kiln-host = { path = "kiln-host", version = "0.3.2", default-features = false }
-kiln-intercept = { path = "kiln-intercept", version = "0.3.2", default-features = false }
-kiln-math = { path = "kiln-math", version = "0.3.2", default-features = false }
-kiln-platform = { path = "kiln-platform", version = "0.3.2", default-features = false }
-kiln-panic = { path = "kiln-panic", version = "0.3.2", default-features = false }
-kiln-wasi = { path = "kiln-wasi", version = "0.3.2", default-features = false }
+kiln-error = { path = "kiln-error", version = "0.3.3", default-features = false }
+kiln-sync = { path = "kiln-sync", version = "0.3.3", default-features = false }
+kiln-format = { path = "kiln-format", version = "0.3.3", default-features = false }
+kiln-foundation = { path = "kiln-foundation", version = "0.3.3", default-features = false }
+kiln-decoder = { path = "kiln-decoder", version = "0.3.3", default-features = false, features = ["std"] }
+kiln-debug = { path = "kiln-debug", version = "0.3.3", default-features = false }
+kiln-runtime = { path = "kiln-runtime", version = "0.3.3", default-features = false }
+kiln-logging = { path = "kiln-logging", version = "0.3.3", default-features = false }
+kiln-instructions = { path = "kiln-instructions", version = "0.3.3", default-features = false }
+kiln-component = { path = "kiln-component", version = "0.3.3", default-features = false }
+kiln-host = { path = "kiln-host", version = "0.3.3", default-features = false }
+kiln-intercept = { path = "kiln-intercept", version = "0.3.3", default-features = false }
+kiln-math = { path = "kiln-math", version = "0.3.3", default-features = false }
+kiln-platform = { path = "kiln-platform", version = "0.3.3", default-features = false }
+kiln-panic = { path = "kiln-panic", version = "0.3.3", default-features = false }
+kiln-wasi = { path = "kiln-wasi", version = "0.3.3", default-features = false }
 
 # Note: Safety level presets should be defined in individual crate Cargo.toml files
 # as workspace.features is not supported by Cargo


### PR DESCRIPTION
Cuts **v0.3.3** with the accumulated, verified work since v0.3.2.

**Ships:**
- **kiln-async library — feature-complete P3 async surface**: task-control, `future.*`, `task.wait`/`task.poll` over waitable-sets, `stream.*` (credit-based backpressure), `error-context`. Zero unsafe (`#![forbid(unsafe_code)]` permanent), **89 tests**, **3 Kani proofs** verified.
- **fix(wast)** — handle wast 244's `HeapType::Exact` (unbroke the workspace build, #335).
- Dependency bumps (criterion 0.8, wat 1.252, kani-verifier 0.67, serial_test, clap, chrono, upload-artifact).

**Scope note (honest framing):** this ships the kiln-async **embedded-scheduler library**. It does **not** change the std interpreter's *separate* P3 async path (`kiln-runtime`'s own `try_dispatch_p3_builtin`) — per RFC #46, kiln-async is the synth-compiled embedded backing, not wired into the interpreter. The synth-lowered end-to-end run (v0.4.0) remains cross-tool (#317).

Non-breaking additions (0.3.x-compatible). `cargo build --workspace --locked` Finishes; kiln-async 89 tests pass; `rivet validate` 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)