### PR TITLE
ci(deps): allow Zlib license in Dependency Review

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -135,8 +135,10 @@ jobs:
       - uses: actions/dependency-review-action@v5
         with:
           fail-on-severity: high
-          # Allow common open source licenses
-          allow-licenses: MIT, Apache-2.0, BSD-3-Clause, ISC, MPL-2.0, Unlicense
+          # Allow common open source licenses. Zlib added 2026-06-18: hashbrown
+          # 0.16+ pulls foldhash (Zlib) as its default hasher (accepted via #325);
+          # Zlib is permissive/OSI-approved/SPDX-listed/GPL-compatible.
+          allow-licenses: MIT, Apache-2.0, BSD-3-Clause, ISC, MPL-2.0, Unlicense, Zlib
           # Exclude packages with undetected licenses that we've manually verified
           # Using PURL format: pkg:cargo/package@version
           allow-dependencies-licenses: |


### PR DESCRIPTION
#325 (hashbrown 0.15→0.17, merged) brought in **foldhash@0.2.0 (Zlib)** as hashbrown 0.16+'s default hasher. Zlib wasn't on the Dependency-Review `allow-licenses`, so it would **red-flag foldhash on every future PR**.

Adds **Zlib** to the allow-list — permissive, OSI-approved, SPDX-listed, GPL-compatible — operationalizing the decision already made by merging #325, and stopping the recurring gate. No code/dep change; CI config only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)