### PR TITLE
fix(error): gate heap-backed recovery behind `alloc` — restore kiln-async no-alloc (#338)

### DIFF
--- a/kiln-error/Cargo.toml
+++ b/kiln-error/Cargo.toml
@@ -20,7 +20,10 @@ path = "src/lib.rs"
 default = []
 
 # Core allocation strategies (aligned with kiln-foundation)
-dynamic-allocation = []
+# dynamic-allocation implies `alloc`: the heap-backed `recovery` diagnostics are
+# only available where a global allocator exists. Static-allocation / no_alloc
+# builds (ASIL-C/D, gale-nano embedded) deliberately exclude it — see #338.
+dynamic-allocation = ["alloc"]
 static-allocation = []
 verified-static-allocation = ["static-allocation"]
 

--- a/kiln-error/src/lib.rs
+++ b/kiln-error/src/lib.rs
@@ -83,7 +83,12 @@
 #[cfg(feature = "std")]
 extern crate std;
 
-#[cfg(not(feature = "std"))]
+// `alloc` is only required by the `recovery` module's heap-backed diagnostics
+// (String/Vec/BTreeMap). Gating it on the `alloc` feature keeps the core error
+// type — and every consumer that only needs `Error`/`Result` — strictly
+// no-`alloc`, so no_std/no-heap embedded targets (e.g. gale-nano: Cortex-M3,
+// 8 KB SRAM) link without a global allocator. See issue #338.
+#[cfg(all(not(feature = "std"), feature = "alloc"))]
 extern crate alloc;
 
 /// Error codes for kiln
@@ -97,6 +102,12 @@ pub mod kinds;
 pub mod context;
 pub mod helpers;
 pub mod prelude;
+/// Heap-backed error recovery and diagnostics (requires `alloc`).
+///
+/// Gated on the `alloc` feature: its `ErrorContext`/history types use
+/// `String`/`Vec`/`BTreeMap`, so it is excluded from no-`alloc` builds to keep
+/// the core error type heap-free for embedded targets (issue #338).
+#[cfg(feature = "alloc")]
 pub mod recovery;
 
 // ASIL safety support (enabled for ASIL-B and above)

--- a/safety/requirements/safety-mechanisms.yaml
+++ b/safety/requirements/safety-mechanisms.yaml
@@ -377,6 +377,50 @@ artifacts:
       design-doc: docs/architecture/async-scheduler-plan.md
       implementation: kiln-async/ (Phase 0 scaffold)
 
+  - id: SM-ASYNC-003
+    type: design-decision
+    title: kiln-async dependencies must not transitively require a global allocator
+    description: >
+      kiln-async's no-alloc guarantee (SM-ASYNC-001, REQ_ASYNC_SCHED) is only
+      real if NONE of its dependencies transitively force a global allocator.
+      kiln-error — pulled in for the unified Error/Result type — violated this:
+      its src/recovery.rs unconditionally did `extern crate alloc` and put
+      String/Vec/BTreeMap into ErrorContext, so linking kiln-async to a
+      bare-metal staticlib failed with "no global memory allocator found"
+      (issue #338, surfaced by jess's gale-nano profile: Pixhawk 6X-RT STM32F100,
+      Cortex-M3, 8 KB SRAM — a mandatory heap is a hard blocker there). Fix:
+      kiln-error's heap-backed `recovery` module is now gated behind its `alloc`
+      Cargo feature (implied by `dynamic-allocation`/`std`); the core Error type
+      uses only &'static-str messages and is alloc-free. kiln-async depends on
+      kiln-error with default-features=false, so the no-alloc property holds
+      end-to-end. ASIL-C/D (static-allocation) and no_alloc embedded builds
+      correctly shed `recovery`; QM/std builds keep it. The discipline is
+      general: every kiln-async dependency edge must be no-alloc-clean, verified
+      by building the kiln-async staticlib for thumbv7m-none-eabi and asserting
+      the allocator error is absent (only the embedding-supplied #[panic_handler]
+      remains).
+    status: implemented
+    tags: [async, scheduler, no-alloc, embedded, dependency-discipline, kiln-error]
+    links:
+      - type: satisfies
+        target: REQ_ASYNC_SCHED
+    fields:
+      rationale: >
+        A no-alloc claim that any transitive dependency can silently break is
+        not a guarantee. Gating heap-backed error diagnostics behind the `alloc`
+        feature keeps the trusted error type usable on 8 KB-SRAM targets while
+        preserving rich recovery diagnostics for std/QM hosts — the same
+        minimal-TCB discipline SM-ASYNC-001 applies to kiln-async itself.
+      alternatives: >
+        (a) A heap-free fixed-capacity ErrorContext for all builds — rejected:
+        unnecessary churn for std/QM consumers that want rich diagnostics, and
+        the recovery module has no embedded consumers. (b) Forking the error
+        type per-target — rejected: splits the unified Error contract. (c)
+        Leaving it and requiring embedders to supply a global allocator —
+        rejected: contradicts REQ_ASYNC_SCHED's NO-alloc mandate.
+      implementation: kiln-error/src/lib.rs (recovery + extern crate alloc gated on feature "alloc"); kiln-error/Cargo.toml (dynamic-allocation = ["alloc"])
+      upstream-ref: "https://github.com/pulseengine/kiln/issues/338"
+
   # =========================================================================
   # Architecture Boundary Decisions
   # =========================================================================


### PR DESCRIPTION
## Problem

`kiln-async` is documented and built as a `no_std`, **no-`alloc`** cooperative scheduler, but linking it to a bare-metal target **transitively required a global allocator**: `kiln-error/src/recovery.rs` unconditionally did `extern crate alloc` and put `String`/`Vec`/`BTreeMap` into `ErrorContext`, and `kiln-async` pulls `kiln-error` in for the unified `Error`/`Result` type.

Reproduced — `kiln-async` staticlib for `thumbv7m-none-eabi` (Cortex-M3):
```
error: no global memory allocator found but one is required; link to std or add `#[global_allocator]` ...
```

This blocked **jess's gale-nano target** (Pixhawk 6X-RT STM32F100 I/O MCU — Cortex-M3, 8 KB SRAM), where a mandatory heap is a hard blocker. Per #338 it was the **sole remaining** precondition for the gale-nano scheduler substrate (synth#372 i64 load/store already fixed in v0.11.47).

## Fix

Gate the heap-backed `recovery` module and the crate-root `extern crate alloc` behind `kiln-error`'s existing **`alloc`** Cargo feature, now implied by `dynamic-allocation` (and thus `std`/`qm`):

- The core `Error` type uses only `&'static`-str messages — already alloc-free.
- `recovery` has **no cross-crate consumers** (verified workspace-wide), so gating it breaks nothing.
- `kiln-async` already depends on `kiln-error` with `default-features = false` → no-alloc holds end-to-end.
- ASIL-C/D (`static-allocation`) and no_alloc embedded builds correctly shed `recovery`; QM/std builds keep the rich diagnostics.

## Verification

- ✅ `kiln-async` staticlib for `thumbv7m-none-eabi`: the missing-allocator error is **gone** (only the embedding-supplied `#[panic_handler]` remains — jess's to provide)
- ✅ `kiln-error` builds no_alloc by default for `thumbv7m`; with `--features std` still compiles `recovery`
- ✅ 89 `kiln-async` tests pass; full `cargo build --workspace` clean
- ✅ `rivet validate`: 0 errors (unchanged)

## Traceability

Re-establishes the no-`alloc` clause of **REQ_ASYNC_SCHED**. New design-decision **SM-ASYNC-003** ("kiln-async dependencies must not transitively require a global allocator") captures the dependency-discipline rule and the staticlib build as its oracle.

Closes #338.

🤖 Generated with [Claude Code](https://claude.com/claude-code)