### PR TITLE
chore(rivet): triage #340 — witness MC/DC coverage backend + dogfood the formal validation regime

### DIFF
--- a/safety/requirements/architecture-decisions.yaml
+++ b/safety/requirements/architecture-decisions.yaml
@@ -254,6 +254,53 @@ artifacts:
         for the embedded cert scope.
       implementation: "Verus: kiln-foundation/src/verus_proofs/; Kani harnesses; fuzz/; kiln-build-core/src/wast_execution.rs"
 
+  - id: AD-MCDC-001
+    type: design-decision
+    title: Kiln dogfoods the full PulseEngine formal validation regime (incl. witness MC/DC)
+    description: >
+      Kiln's own work shall be held to the SAME strong formal validation regime
+      the sibling tools follow (spar's Lean proofs, synth's eval-gated benches,
+      witness's MC/DC) — not a weaker one because kiln is the runtime. The
+      defense-in-depth strategy (AD-QUALITY-001) already lists Verus, Kani,
+      fuzzing, WAST conformance and Miri, but it OMITS structural-coverage
+      adequacy: MC/DC (modified condition/decision coverage) on kiln's own
+      WebAssembly artifacts via witness. This decision adds that missing
+      dimension and makes the pulseengine-feature-loop's witness step
+      (truth-table MC/DC with zero unresolved gap rows) a standing gate for
+      kiln's safety-relevant components, alongside the Kani/Verus proofs and
+      rivet traceability already in place. The enabler is REQ_WITNESS_COV (#340):
+      exposing kiln's post-run exported-global snapshot makes kiln a witness
+      coverage backend — and therefore lets kiln run its OWN meld-fused
+      components through itself + witness, so kiln is both the coverage runtime
+      and its first consumer. Sequencing: land REQ_WITNESS_COV, then bring
+      kiln's cert-scope components under MC/DC and read gap rows (not coverage
+      percentages); Verus CI-gating (REQ_ASYNC_SCHED Phase 6 / #237) and sigil
+      attestation complete the regime parity.
+    status: approved
+    tags: [verification, mcdc, witness, defense-in-depth, formal-methods, dogfooding, feature-loop]
+    links:
+      - type: satisfies
+        target: REQ_WITNESS_COV
+      - type: satisfies
+        target: REQ_VERIFY_010
+    fields:
+      rationale: >
+        A runtime that measures others' coverage but is not itself held to
+        structural-coverage adequacy is an inconsistent regime. MC/DC is the
+        coverage criterion the safety standards (DO-178C Level A, ISO 26262
+        ASIL-D) expect for decision logic; the other PulseEngine tools already
+        run it, and #340 removes the only technical blocker to running it on
+        kiln (no host-reachable post-run global read). Dogfooding also hardens
+        the coverage backend: kiln's own components are the first real workload.
+      alternatives-considered: >
+        (1) Keep coverage external (line/branch via tarpaulin) — rejected: not
+        MC/DC, gives no decision-adequacy evidence for cert scope. (2) Defer
+        until the embedded ASIL-D core stabilises — rejected: the regime should
+        lead the code, not trail it (feature-loop: traceability/oracles first).
+      relates-to: "AD-QUALITY-001 (this adds the MC/DC dimension that decision omits)"
+      implementation: "Enabler: REQ_WITNESS_COV / issue #340 (post-run global snapshot + kilnd --harness). Consumer: witness MC/DC over kiln's meld-fused cert-scope components, gap-row gated in the feature-loop."
+      upstream-ref: "https://github.com/pulseengine/kiln/issues/340"
+
   - id: AD-DEBUG-001
     type: design-decision
     title: Source-level, WIT-aware debugging via DWARF mapping

--- a/safety/requirements/roadmap-requirements.yaml
+++ b/safety/requirements/roadmap-requirements.yaml
@@ -267,3 +267,61 @@ artifacts:
         Naming + workflow decision captured in AD-PUBLISH-001. Verified 2026-06-14:
         20/21 kiln-* names free but kiln-runtime taken (zenvanexus); all kilnvm-*
         target names available.
+
+  - id: REQ_WITNESS_COV
+    type: requirement
+    title: Witness MC/DC coverage backend — post-run global snapshot + harness mode
+    description: >
+      Kiln shall act as a coverage backend for the witness MC/DC tool so that
+      instrumented WebAssembly artifacts can be measured under a certifiable,
+      deterministic runtime (and differentially cross-checked against wasmtime
+      as oracle). witness instruments core modules by adding exported mutable
+      globals (__witness_counter_<id>) and reconstructs MC/DC truth tables from
+      their post-run values; wasmtime's component API exposes no way to read an
+      inner core's globals, so kiln — which already decodes/instantiates core
+      modules + Component-Model + WASI 0.2 and reads globals internally — is the
+      enabling runtime. Three concrete capabilities: (1) a post-run
+      exported-global SNAPSHOT API keyed by export name (or by the
+      __witness_counter_* prefix) returning name->integer, reachable from a host
+      driver; (2) a kilnd HARNESS mode (CLI flag and/or WITNESS_MODULE /
+      WITNESS_MANIFEST / WITNESS_OUTPUT env vars) that instantiates + runs the
+      module, invokes the specified export(s), then writes the counter snapshot
+      in witness's counter-snapshot JSON shape; (3) a documented inventory of
+      which wasi:0.2 interfaces are real vs. need no-op stubbing, since coverage
+      runs only require imports satisfied enough that branches execute (correct
+      WASI behaviour is NOT required). Near-term scope is SYNCHRONOUS
+      Component-Model coverage; p3 async-lift/streams are explicitly out of scope
+      (gated on p3 execution maturity; tracked as witness REQ-057 / witness#107B).
+    status: proposed
+    tags: [verification, mcdc, witness, coverage, cross-tool, roadmap, release-v0.4.0]
+    links:
+      - type: derives-from
+        target: REQ_VERIFY_010
+    fields:
+      upstream-ref: "https://github.com/pulseengine/kiln/issues/340"
+      cross-ref: "pulseengine/witness#110 (strategy + dual-runtime cross-check); witness DEC-003 (counter mechanism); witness REQ-054/FEAT-034 (meld composition)"
+      feasibility: >
+        Grounded against the code (2026-06-20): the hard part already exists.
+        ModuleInstance::global_by_name (kiln-runtime/src/module_instance.rs:306)
+        + GlobalWrapper::get (module.rs:4291) already read exported globals by
+        name on a live core instance; Export metadata (name/kind/index,
+        ExportKind::Global) is a DirectMap lookup (module.rs:2823). witness's
+        own pipeline runs `meld fuse component.wasm -o core.wasm` first, so the
+        instrumented artifact is a CORE module — the global_by_name path applies
+        directly, no live-component global traversal needed for the primary
+        path. NEW work is mostly wiring + serialization: a prefix-keyed snapshot
+        accessor, a kilnd --harness / env-var mode emitting witness's JSON shape,
+        and the wasi:0.2 stub inventory (filesystem/cli/clocks/io/random are
+        implemented; coverage cores want no-op stubs). Component-with-live-core
+        global traversal is a later phase (nested-instance lookup) only if a
+        non-fused component path is needed.
+      regime-note: >
+        Keystone for AD-MCDC-001: once kiln is a witness coverage backend it can
+        run its OWN meld-fused components through itself + witness for MC/DC,
+        closing the witness step of the pulseengine-feature-loop for kiln itself
+        (dogfooding the same regime spar/synth/witness already follow).
+      release-note: >
+        Tagged release-v0.4.0 but INDEPENDENT of the kiln-async P3 track; mostly
+        additive wiring, so a candidate to pull forward as a focused sub-release
+        if witness's MC/DC-on-kiln work is gated on it. Release assignment is a
+        planning call (see release-planning).


### PR DESCRIPTION
Triages #340 into the rivet trace and captures the formal-validation-regime directive. **Planning only — no runtime code yet.**

## What landed

**`REQ_WITNESS_COV`** (requirement, `proposed`, `release-v0.4.0`) — kiln as a witness MC/DC coverage backend, the three concrete asks from #340:
1. post-run exported-global **snapshot API** keyed by name / `__witness_counter_*` prefix → name→int
2. `kilnd` **harness mode** (CLI flag and/or `WITNESS_MODULE`/`WITNESS_MANIFEST`/`WITNESS_OUTPUT`) emitting witness's counter-snapshot JSON
3. **wasi:0.2 stub inventory** (coverage needs imports satisfied only enough that branches execute)

**`AD-MCDC-001`** (design-decision, `approved`) — kiln's own work follows the **same strong formal validation regime** as the sibling tools. `AD-QUALITY-001` already lists Verus/Kani/fuzz/WAST/Miri but **omits MC/DC**; this adds that dimension and makes the feature-loop's witness step a standing gate. #340 is the keystone — once kiln is a coverage backend it dogfoods MC/DC on its **own** meld-fused components.

## Feasibility (grounded against the code, not guessed)

The hard part already exists:
- `ModuleInstance::global_by_name()` (`kiln-runtime/src/module_instance.rs:306`) + `GlobalWrapper::get()` (`module.rs:4291`) already read exported globals **by name** on a live core instance
- Export metadata (name/kind/index, `ExportKind::Global`) is a `DirectMap` lookup (`module.rs:2823`)
- witness's pipeline runs `meld fuse … -o core.wasm` first, so the instrumented artifact is a **core module** — the `global_by_name` path applies directly; no live-component global traversal needed for the primary path

So the new work is mostly **wiring + serialization**: a prefix-keyed snapshot accessor, a `kilnd --harness`/env-var mode, and the wasi stub inventory (`filesystem/cli/clocks/io/random` are implemented).

## Trace topology

`REQ_VERIFY_010 ← REQ_WITNESS_COV ← AD-MCDC-001` — `rivet validate`: **0 errors** (unchanged).

## Next

Phase 1 (snapshot API) is buildable now via TDD. Phase 2 (harness output) needs witness's **counter-snapshot JSON shape** — asked on #340 (avrabe offered to share it).

Refs #340. Strategy: pulseengine/witness#110.

🤖 Generated with [Claude Code](https://claude.com/claude-code)