### PR TITLE
feat(runtime): post-run exported-global snapshot API for witness MC/DC coverage (#340)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1497,6 +1497,7 @@ dependencies = [
  "kiln-sync",
  "kiln-wasi",
  "serial_test",
+ "wat",
 ]
 
 [[package]]

--- a/kiln-runtime/Cargo.toml
+++ b/kiln-runtime/Cargo.toml
@@ -238,3 +238,4 @@ kani-verifier = []
 
 [dev-dependencies]
 serial_test = "3.4"
+wat = "1.244"

--- a/kiln-runtime/src/module_instance.rs
+++ b/kiln-runtime/src/module_instance.rs
@@ -316,6 +316,47 @@ impl ModuleInstance {
         Err(Error::resource_not_found("Global export not found"))
     }
 
+    /// Post-run snapshot of exported integer globals whose name starts with
+    /// `prefix`, as `export-name -> i64`.
+    ///
+    /// This is the host-reachable coverage accessor for the witness MC/DC tool
+    /// (issue #340): witness instruments core modules with exported globals
+    /// named `__witness_counter_<id>` and reconstructs MC/DC truth tables from
+    /// their values after a run, so a driver calls this with the
+    /// `"__witness_counter_"` prefix once execution finishes. Globals whose name
+    /// does not match `prefix` are excluded. A matching global that is not an
+    /// integer (i32/i64) is a contract violation and returns an error rather
+    /// than being silently dropped.
+    pub fn export_global_snapshot(
+        &self,
+        prefix: &str,
+    ) -> Result<std::collections::BTreeMap<String, i64>> {
+        use crate::module::ExportKind;
+        use kiln_foundation::values::Value;
+
+        let mut snapshot = std::collections::BTreeMap::new();
+        for (_key, export) in self.module.exports.iter() {
+            if export.kind != ExportKind::Global {
+                continue;
+            }
+            let export_name = export.name.as_str().unwrap_or("");
+            if !export_name.starts_with(prefix) {
+                continue;
+            }
+            let counter = match self.global(export.index)?.get()? {
+                Value::I32(v) => i64::from(v),
+                Value::I64(v) => v,
+                _ => {
+                    return Err(Error::runtime_error(
+                        "exported counter global is not an integer (i32/i64)",
+                    ));
+                }
+            };
+            snapshot.insert(export_name.to_string(), counter);
+        }
+        Ok(snapshot)
+    }
+
     /// Get the function type for a function
     pub fn function_type(&self, idx: u32) -> Result<crate::prelude::CoreFuncType> {
         let function = self

--- a/kiln-runtime/tests/witness_snapshot_test.rs
+++ b/kiln-runtime/tests/witness_snapshot_test.rs
@@ -1,0 +1,62 @@
+//! Post-run exported-global snapshot — the witness MC/DC coverage backend (issue #340).
+//!
+//! witness instruments core modules with exported mutable globals
+//! (`__witness_counter_<id>`) and reads coverage back by snapshotting those
+//! globals after a run. These tests cover the host-reachable snapshot accessor
+//! on a live `ModuleInstance`: prefix filtering, integer value reads, and that
+//! the snapshot reflects mutations performed during the run.
+
+use kiln_runtime::engine::{CapabilityAwareEngine, CapabilityEngine, EnginePreset};
+
+/// The snapshot returns only exported globals whose name matches the prefix,
+/// with their (post-instantiation) integer values, excluding non-matching ones.
+#[test]
+fn snapshot_filters_by_prefix_and_reads_integer_values() {
+    let wasm = wat::parse_str(
+        r#"(module
+            (global (export "__witness_counter_0") i32 (i32.const 7))
+            (global (export "__witness_counter_1") (mut i32) (i32.const 0))
+            (global (export "other") i32 (i32.const 99)))"#,
+    )
+    .expect("wat fixture parses");
+
+    let mut engine = CapabilityAwareEngine::with_preset(EnginePreset::QM).unwrap();
+    let module_handle = engine.load_module(&wasm).unwrap();
+    let instance_handle = engine.instantiate(module_handle).unwrap();
+    let instance = engine.get_instance(instance_handle).unwrap();
+
+    let snapshot = instance.export_global_snapshot("__witness_counter_").unwrap();
+
+    assert_eq!(snapshot.len(), 2, "only the two prefixed globals, not `other`");
+    assert_eq!(snapshot.get("__witness_counter_0"), Some(&7i64));
+    assert_eq!(snapshot.get("__witness_counter_1"), Some(&0i64));
+    assert_eq!(snapshot.get("other"), None);
+}
+
+/// The decisive coverage case: a counter incremented during the run is
+/// reflected in the post-run snapshot (i.e. `execute` mutates the same global
+/// state the snapshot reads).
+#[test]
+fn snapshot_reflects_counters_mutated_during_the_run() {
+    let wasm = wat::parse_str(
+        r#"(module
+            (global $c (export "__witness_counter_0") (mut i32) (i32.const 0))
+            (func (export "hit")
+                (global.set $c (i32.add (global.get $c) (i32.const 1)))))"#,
+    )
+    .expect("wat fixture parses");
+
+    let mut engine = CapabilityAwareEngine::with_preset(EnginePreset::QM).unwrap();
+    let module_handle = engine.load_module(&wasm).unwrap();
+    let instance_handle = engine.instantiate(module_handle).unwrap();
+
+    // Run the instrumented branch three times.
+    for _ in 0..3 {
+        engine.execute(instance_handle, "hit", &[]).unwrap();
+    }
+
+    let instance = engine.get_instance(instance_handle).unwrap();
+    let snapshot = instance.export_global_snapshot("__witness_counter_").unwrap();
+
+    assert_eq!(snapshot.get("__witness_counter_0"), Some(&3i64));
+}

--- a/safety/requirements/roadmap-requirements.yaml
+++ b/safety/requirements/roadmap-requirements.yaml
@@ -325,3 +325,33 @@ artifacts:
         additive wiring, so a candidate to pull forward as a focused sub-release
         if witness's MC/DC-on-kiln work is gated on it. Release assignment is a
         planning call (see release-planning).
+      harness-contract: >
+        Pinned with witness (avrabe, 2026-06-20, #340) against witness's
+        crates/witness-core/src/run_record.rs HarnessSnapshot + crates/witness/
+        src/run.rs run_via_harness. TARGET witness-harness-v1 (branch coverage;
+        v2 MC/DC rows are later — do NOT build yet). (a) JSON the harness writes
+        to WITNESS_OUTPUT: {"schema":"witness-harness-v1","counters":{"<id>":N}}
+        where keys are the BARE numeric branch id as a string ("0","1"; witness
+        does key.parse::<u32>()) — i.e. the harness reads each exported global
+        named __witness_counter_<id>, STRIPS the __witness_counter_ prefix, and
+        emits <id>->value; value is the hit count (counters are i64 globals as of
+        witness v0.32+, overflow-safe). No run-id/hash/manifest in the snapshot —
+        witness stamps those itself. (b) Invocation: witness spawns the harness
+        via sh -c, passing only env vars — WITNESS_MODULE (abs path to the
+        instrumented .wasm, READ this), WITNESS_MANIFEST (abs path, optional for
+        v1), WITNESS_OUTPUT (abs path the harness MUST write). Module path is NOT
+        a CLI arg. witness's own --invoke is ignored in harness mode — the harness
+        chooses which export(s) to run (e.g. _start or named fixture exports),
+        then snapshots counters at the end. Non-zero exit or a missing
+        WITNESS_OUTPUT file = harness failure.
+      progress: >
+        Phase 1 DONE (this requirement's first code): host-reachable post-run
+        snapshot accessor ModuleInstance::export_global_snapshot(prefix) ->
+        BTreeMap<name,i64>, prefix-filtered, integer-typed, fail-loud on a
+        non-integer matching global. Kept keyed by FULL export name (general
+        accessor); the witness-v1 prefix-strip + JSON envelope is a Phase-2
+        (kilnd --harness) serialization concern. TDD: 2 tests
+        (kiln-runtime/tests/witness_snapshot_test.rs) — prefix-filter+value reads,
+        and post-run-mutation reflected; mutation-proven. Phase 2 (kilnd --harness
+        env-var driver emitting witness-harness-v1) is fully unblocked by
+        harness-contract above.


### PR DESCRIPTION
**Phase 1 of #340** (REQ_WITNESS_COV / AD-MCDC-001) — the host-reachable coverage accessor that lets witness read MC/DC counters back from a run under kiln.

## What

`ModuleInstance::export_global_snapshot(prefix) -> BTreeMap<String, i64>` — returns every exported global (`ExportKind::Global`) whose name starts with `prefix`, as name→integer, reading **live post-run values** via the existing `global(index)`/`GlobalWrapper::get` path. Non-matching globals excluded; a matching global that isn't an integer (i32/i64) returns an error (fail-loud).

Kept keyed by **full export name** (a general accessor). The witness-specific prefix-strip + JSON envelope (`witness-harness-v1`) is a Phase-2 (`kilnd --harness`) serialization concern — pinned with witness on #340 and recorded in `REQ_WITNESS_COV` `harness-contract`.

## TDD

New `kiln-runtime/tests/witness_snapshot_test.rs` (+ `wat` dev-dep):
- `snapshot_filters_by_prefix_and_reads_integer_values` — **RED watched** (`left 0, right 2` with an empty stub) → GREEN → **mutation-proven** (forcing the filter open ⇒ `left 3`)
- `snapshot_reflects_counters_mutated_during_the_run` — the decisive case: a counter incremented 3× during `execute()` reads back as `3`, proving the snapshot sees the same global state the run mutates

Both pass; `rivet validate`: 0 errors.

## Why this shape (confirmed by witness)

witness's pipeline `meld fuse → core.wasm` means the instrumented artifact is a **core module**, so `global_by_name` applies directly — no live-component traversal. avrabe confirmed (#340) and pinned the `witness-harness-v1` contract; my keying-by-full-name + Phase-2-strips-prefix split matches exactly where witness puts the boundary.

Refs #340. Next: Phase 2 = `kilnd --harness` env-var driver (`WITNESS_MODULE`/`WITNESS_OUTPUT`) emitting `{"schema":"witness-harness-v1","counters":{…}}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)