### PR TITLE
chore(rivet): triage #344 + record both-paths component decision (AD-COMPONENT-HOST-001)

### DIFF
--- a/safety/requirements/architecture-decisions.yaml
+++ b/safety/requirements/architecture-decisions.yaml
@@ -301,6 +301,55 @@ artifacts:
       implementation: "Enabler: REQ_WITNESS_COV / issue #340 (post-run global snapshot + kilnd --harness). Consumer: witness MC/DC over kiln's meld-fused cert-scope components, gap-row gated in the feature-loop."
       upstream-ref: "https://github.com/pulseengine/kiln/issues/340"
 
+  - id: AD-COMPONENT-HOST-001
+    type: design-decision
+    title: Two component paths — direct hosting (std/QM) AND meld-fuse-to-core (embedded/cert)
+    description: >
+      Kiln supports BOTH ways of running a Component-Model component, scoped by
+      product-line variant (interpreter-QM vs embedded-cert):
+      (1) DIRECT HOSTING in the std reference host (kilnd): load an external
+      wac-composed component, instantiate, invoke a named export, and lift scalar
+      results through a runtime canonical ABI. This is the QM/reference scope
+      (SM-PERF-001 — kilnd is the correctness-reference runtime) and is what
+      gale's kiln-component-host path needs (gale#63 / REQ_COMPONENT_HOST).
+      (2) MELD-FUSE-TO-CORE: Meld lowers components to core modules at build time
+      and kiln runs the resulting core (the embedded-cert path; the jess pipeline;
+      the witness coverage path REQ_WITNESS_COV). This refines RFC #46: its
+      "Component Model is not a runtime feature / no runtime canonical ABI" stance
+      is scoped to the EMBEDDED-CERT path, NOT a global ban — the std QM host may
+      host components directly. The two coexist: kilnd already attempts
+      execute_component (main.rs:996) and the RFC #46 "meld fuse first" message
+      becomes a hint/fallback rather than a wall. The synchronous component
+      machinery is retained (kiln-component, ~31k LOC); only the async simulation
+      surface was removed (SM-ASYNC-002, unchanged — async component lift is a
+      separate concern, still out of runtime scope).
+    status: approved
+    tags: [component-model, rfc46, architecture-boundary, variant, qm, embedded-cert, host]
+    links:
+      - type: satisfies
+        target: REQ_COMPONENT_HOST
+      - type: satisfies
+        target: REQ_FUNC_002
+    fields:
+      rationale: >
+        User decision (2026-06-20): "I want both component and meld use case." A
+        single path is too narrow — the embedded-cert target needs the verifiable
+        meld-fuse-to-core path (no runtime component model), while the std
+        reference host genuinely benefits from hosting composed components
+        directly (gale#63 runs the same artifact on kiln that runs on wasmtime,
+        for differential validation). Scoping by variant keeps the cert path
+        unchanged (RFC #46 holds for embedded-cert) while unlocking the QM host.
+        The code already supports it ~80%; the only real gap is runtime canon.lift.
+      alternatives-considered: >
+        (1) Meld-fuse-only (RFC #46 verbatim) — rejected: forces every std
+        consumer through a build step to run a component kiln can already
+        instantiate, and blocks gale#63's direct-on-kiln validation. (2)
+        Direct-hosting-only — rejected: the embedded-cert path cannot carry a
+        runtime canonical ABI / dynamic linking; meld-fuse stays mandatory there.
+      relates-to: "RFC #46 (docs/architecture/rfc46-toolchain-architecture.md — scoped, not contradicted); SM-ASYNC-002 (async component surface stays removed); SM-PERF-001 (kilnd = QM reference runtime); AD-COMP-001."
+      implementation: "Direct half: REQ_COMPONENT_HOST / #344 (--invoke flag + canon.lift in kiln-component/src/canonical_executor.rs). Meld half: existing (Meld lowers; kiln runs cores)."
+      upstream-ref: "https://github.com/pulseengine/kiln/issues/344"
+
   - id: AD-DEBUG-001
     type: design-decision
     title: Source-level, WIT-aware debugging via DWARF mapping

--- a/safety/requirements/roadmap-requirements.yaml
+++ b/safety/requirements/roadmap-requirements.yaml
@@ -367,3 +367,45 @@ artifacts:
         (filesystem/cli/clocks/io/random implemented today; unsatisfied imports
         currently fail-loud at instantiate); witness-harness-v2 per-row MC/DC
         (deferred by witness). Dual-runtime cross-check (witness#110) can begin.
+
+  - id: REQ_COMPONENT_HOST
+    type: requirement
+    title: Host external composed Component-Model components in kilnd + invoke an export
+    description: >
+      The std reference host (kilnd, interpreter-QM variant) shall load an
+      external wac-composed Component-Model component, instantiate it, and invoke
+      a named export with scalar args, lifting the scalar result through the
+      canonical ABI. Concretely: a `--component <file>` + `--invoke '<export>'`
+      entry that runs e.g. gale's kiln-component-host demo (gale#63: a gale app
+      composed with the gale-kiln host via wac, `run-demo() -> u32 = 53`) directly
+      on kiln — the safety-critical target host — not only on wasmtime. This is
+      the DIRECT-HOSTING half of the dual capability (the meld-fuse-to-core half
+      already works: components lowered by Meld at build time run as core modules,
+      the embedded-cert path). Both paths are supported per AD-COMPONENT-HOST-001;
+      this requirement covers the direct-hosting (QM) half. Kill-criterion: kilnd
+      cannot instantiate + invoke an export of a wac-composed component.
+    status: proposed
+    tags: [component-model, host, kilnd, canonical-abi, qm, cross-tool, roadmap, release-v0.4.0]
+    links:
+      - type: derives-from
+        target: REQ_FUNC_002
+    fields:
+      upstream-ref: "https://github.com/pulseengine/kiln/issues/344"
+      cross-ref: "gale#63 (gale kiln-component-host path; composed demo fixture)"
+      decision: AD-COMPONENT-HOST-001
+      current-state: >
+        Grounded 2026-06-20: the machinery is present and compiled into the
+        DEFAULT kilnd (component-model is a default feature pulling kiln-component
+        + kiln-decoder; ~31k LOC; only the async surface src/async_ was removed per
+        SM-ASYNC-002). kilnd's run dispatch (main.rs:996) already ATTEMPTS
+        execute_component; the RFC #46 "meld fuse first" message (main.rs:1000-1011)
+        is a fallback-on-failure, not an unconditional block. kiln-component
+        decode/instantiate/call_function are real (returns Vec<ComponentValue>).
+        TWO real gaps for run-demo()->u32=53: (1) no --invoke flag (entry hard-coded
+        to wasi:cli/run@*), (2) canon.lift is NOT_IMPLEMENTED
+        (kiln-component/src/canonical_executor.rs:108-125) — a core scalar result
+        is not lifted to a ComponentValue.
+      scope-note: >
+        DIRECT hosting is QM/reference scope (kilnd, SM-PERF-001 reference runtime).
+        The embedded-cert path stays meld-fuse-only (RFC #46 / SM-ASYNC-002 apply
+        there). See AD-COMPONENT-HOST-001 for the both-paths reconciliation.


### PR DESCRIPTION
Records the **"both component and meld"** architecture decision and triages #344. **Planning only — no runtime code yet.**

## Where we are (grounded, not guessed)
- Component-model code is **in and compiled into the default kilnd** (`component-model` is a default feature → `kiln-component` ~31k LOC + `kiln-decoder`). Only the **async** surface (`src/async_/`) was removed (SM-ASYNC-002).
- kilnd's dispatch (`main.rs:996`) already **attempts** `execute_component`; the RFC #46 "meld fuse first" message (`:1000-1011`) is a **fallback on failure**, not a block.
- Two real gaps for `run-demo() -> u32 = 53`: no **`--invoke`** flag (entry hard-coded to `wasi:cli/run@*`), and **canon.lift** is `NOT_IMPLEMENTED` (`kiln-component/src/canonical_executor.rs:108-125`).

## Decision: both paths, scoped by variant
**`AD-COMPONENT-HOST-001`** (approved): 
- **Direct hosting** — std QM reference host (kilnd) hosts composed components directly (runtime canon.lift). For gale#63.
- **Meld-fuse-to-core** — embedded-cert path (RFC #46), the jess/witness path.

This **refines RFC #46**: its "no runtime component model / no runtime canonical ABI" is scoped to the **embedded-cert** path, not a global ban. SM-ASYNC-002 (async component surface removed) is unchanged.

**`REQ_COMPONENT_HOST`** (proposed, release-v0.4.0) captures the direct-hosting capability + kill-criterion.

`rivet validate`: 0 errors.

## Next (implementation, separate PR)
1. `--invoke '<export>'` flag + named-export invocation (trivial wiring)
2. **canon.lift** for scalar results in `canonical_executor.rs` (the real work)
3. Acceptance: the gale composed demo (`run-demo()=53`) runs on kilnd directly

Refs #344, gale#63.

🤖 Generated with [Claude Code](https://claude.com/claude-code)