### PR TITLE
chore(release): bump workspace to v0.3.4 — witness MC/DC coverage backend + kiln-error no-alloc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -278,7 +278,7 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cargo-kiln"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1301,7 +1301,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-async"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "criterion",
  "kiln-error",
@@ -1309,7 +1309,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-build-core"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1339,7 +1339,7 @@ version = "0.1.0"
 
 [[package]]
 name = "kiln-component"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "criterion",
  "kiln-decoder",
@@ -1356,7 +1356,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-debug"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "kiln-error",
  "kiln-format",
@@ -1365,7 +1365,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-decoder"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "criterion",
  "hex",
@@ -1382,11 +1382,11 @@ dependencies = [
 
 [[package]]
 name = "kiln-error"
-version = "0.3.3"
+version = "0.3.4"
 
 [[package]]
 name = "kiln-format"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "kani-verifier",
  "kiln-error",
@@ -1396,7 +1396,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-foundation"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "criterion",
  "hashbrown 0.17.1",
@@ -1414,7 +1414,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-host"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "kiln-error",
  "kiln-foundation",
@@ -1425,7 +1425,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-instructions"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "kiln-error",
  "kiln-foundation",
@@ -1437,7 +1437,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-intercept"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "chrono",
  "kani-verifier",
@@ -1450,7 +1450,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-logging"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "kiln-error",
  "kiln-foundation",
@@ -1460,7 +1460,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-math"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "kiln-error",
  "kiln-platform",
@@ -1469,11 +1469,11 @@ dependencies = [
 
 [[package]]
 name = "kiln-panic"
-version = "0.3.3"
+version = "0.3.4"
 
 [[package]]
 name = "kiln-platform"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "criterion",
  "kiln-error",
@@ -1483,7 +1483,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-runtime"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "kiln-debug",
  "kiln-decoder",
@@ -1502,7 +1502,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-sync"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "kani-verifier",
  "kiln-error",
@@ -1511,7 +1511,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-wasi"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "kiln-error",
  "kiln-format",
@@ -1524,7 +1524,7 @@ dependencies = [
 
 [[package]]
 name = "kilnd"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "kiln-component",
  "kiln-debug",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ edition = "2024"
 rust-version = "1.85.0"
 license = "MIT"
 repository = "https://github.com/pulseengine/kiln"
-version = "0.3.3"
+version = "0.3.4"
 
 
 [workspace.dependencies]
@@ -37,22 +37,22 @@ anyhow = "1.0"
 wit-bindgen = "0.41.0"
 
 # Internal crate versions
-kiln-error = { path = "kiln-error", version = "0.3.3", default-features = false }
-kiln-sync = { path = "kiln-sync", version = "0.3.3", default-features = false }
-kiln-format = { path = "kiln-format", version = "0.3.3", default-features = false }
-kiln-foundation = { path = "kiln-foundation", version = "0.3.3", default-features = false }
-kiln-decoder = { path = "kiln-decoder", version = "0.3.3", default-features = false, features = ["std"] }
-kiln-debug = { path = "kiln-debug", version = "0.3.3", default-features = false }
-kiln-runtime = { path = "kiln-runtime", version = "0.3.3", default-features = false }
-kiln-logging = { path = "kiln-logging", version = "0.3.3", default-features = false }
-kiln-instructions = { path = "kiln-instructions", version = "0.3.3", default-features = false }
-kiln-component = { path = "kiln-component", version = "0.3.3", default-features = false }
-kiln-host = { path = "kiln-host", version = "0.3.3", default-features = false }
-kiln-intercept = { path = "kiln-intercept", version = "0.3.3", default-features = false }
-kiln-math = { path = "kiln-math", version = "0.3.3", default-features = false }
-kiln-platform = { path = "kiln-platform", version = "0.3.3", default-features = false }
-kiln-panic = { path = "kiln-panic", version = "0.3.3", default-features = false }
-kiln-wasi = { path = "kiln-wasi", version = "0.3.3", default-features = false }
+kiln-error = { path = "kiln-error", version = "0.3.4", default-features = false }
+kiln-sync = { path = "kiln-sync", version = "0.3.4", default-features = false }
+kiln-format = { path = "kiln-format", version = "0.3.4", default-features = false }
+kiln-foundation = { path = "kiln-foundation", version = "0.3.4", default-features = false }
+kiln-decoder = { path = "kiln-decoder", version = "0.3.4", default-features = false, features = ["std"] }
+kiln-debug = { path = "kiln-debug", version = "0.3.4", default-features = false }
+kiln-runtime = { path = "kiln-runtime", version = "0.3.4", default-features = false }
+kiln-logging = { path = "kiln-logging", version = "0.3.4", default-features = false }
+kiln-instructions = { path = "kiln-instructions", version = "0.3.4", default-features = false }
+kiln-component = { path = "kiln-component", version = "0.3.4", default-features = false }
+kiln-host = { path = "kiln-host", version = "0.3.4", default-features = false }
+kiln-intercept = { path = "kiln-intercept", version = "0.3.4", default-features = false }
+kiln-math = { path = "kiln-math", version = "0.3.4", default-features = false }
+kiln-platform = { path = "kiln-platform", version = "0.3.4", default-features = false }
+kiln-panic = { path = "kiln-panic", version = "0.3.4", default-features = false }
+kiln-wasi = { path = "kiln-wasi", version = "0.3.4", default-features = false }
 
 # Note: Safety level presets should be defined in individual crate Cargo.toml files
 # as workspace.features is not supported by Cargo


### PR DESCRIPTION
Cuts **v0.3.4** — a focused sub-release of the verified witness coverage backend + the no-alloc fix. Additive, non-breaking 0.3.x. (v0.4.0 stays reserved for component hosting #344 + async P3 integration.)

## Ships
- **witness MC/DC coverage backend (#340)** — `ModuleInstance::export_global_snapshot` (kiln-runtime) + `kilnd` witness-harness mode emitting `witness-harness-v1`. Confirmed end-to-end with witness; dual-runtime cross-check (witness#110) unblocked.
- **kiln-error no-alloc fix (#338)** — `recovery` gated behind `alloc`, restoring kiln-async's no-alloc guarantee on bare-metal (jess gale-nano, Cortex-M3).
- **rivet** — REQ_WITNESS_COV, AD-MCDC-001 (kiln dogfoods the MC/DC regime), SM-ASYNC-003, plus the #344 both-paths decision (REQ_COMPONENT_HOST + AD-COMPONENT-HOST-001).

## Verification
- `rivet validate`: 0 errors
- Workspace builds; witness backend tests pass (kiln-runtime 2, kilnd 4)
- kiln-async no-alloc staticlib for `thumbv7m-none-eabi` carries no allocator dependency

## Falsification statement
*v0.3.4 is wrong if:* a `witness run inst.wasm --harness 'kilnd …'` produces a `witness-harness-v1` snapshot whose counters disagree with the wasmtime-coredump backend on the same instrumented artifact (witness#110 differential), **or** linking `kiln-async` (+ `kiln-error`, default features) into a bare-metal `thumbv7m` artifact reintroduces a `#[global_allocator]` requirement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)