### PR TITLE
feat(component): direct component hosting in kilnd — --invoke a typed export (#344)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1485,6 +1485,7 @@ dependencies = [
 name = "kiln-runtime"
 version = "0.3.4"
 dependencies = [
+ "criterion",
  "kiln-debug",
  "kiln-decoder",
  "kiln-error",

--- a/kiln-component/src/components/component_instantiation.rs
+++ b/kiln-component/src/components/component_instantiation.rs
@@ -800,6 +800,8 @@ impl ComponentInstance {
             runtime_engine: None,
             #[cfg(feature = "kiln-execution")]
             main_instance_handle: None,
+            #[cfg(feature = "std")]
+            direct_export_targets: std::collections::HashMap::new(),
         })
     }
 
@@ -2127,7 +2129,7 @@ impl ComponentInstance {
         // Resolve exports and add to instance
         #[cfg(feature = "std")]
         {
-            Self::resolve_exports(&mut instance, &exports_to_resolve)?;
+            Self::resolve_exports(&mut instance, &exports_to_resolve, parsed)?;
         }
 
         // Store resolved imports in instance
@@ -2336,6 +2338,46 @@ impl ComponentInstance {
                         } else {
                             return Err(Error::runtime_execution_error(
                                 "No core instance exports _start - module exports not properly loaded",
+                            ));
+                        }
+                    } else if !instance.direct_export_targets.is_empty() {
+                        // Direct Component-Model hosting (#344, AD-COMPONENT-HOST-001):
+                        // the component has no `_start` but exports directly
+                        // `canon lift`-ed functions. Pick the core instance whose
+                        // module backs one of those exports as the main handle, so
+                        // the lifted core export can be invoked. No fallback/guess:
+                        // the backing core export name must actually be present.
+                        //
+                        // The live engine is the local `engine` here (it is not
+                        // moved into `instance.runtime_engine` until after this
+                        // main-handle selection).
+                        let backing_core_exports: Vec<String> = instance
+                            .direct_export_targets
+                            .values()
+                            .map(|t| t.core_export_name.clone())
+                            .collect();
+                        let mut found_handle = None;
+                        'outer: for core_export in &backing_core_exports {
+                            for (&_idx, &handle) in &core_instances_map {
+                                if engine.has_function(handle, core_export).unwrap_or(false) {
+                                    found_handle = Some(handle);
+                                    break 'outer;
+                                }
+                            }
+                        }
+
+                        if let Some(handle) = found_handle {
+                            #[cfg(feature = "tracing")]
+                            tracing::info!(
+                                ?handle,
+                                "Direct-hosting component - main instance backs a lifted export"
+                            );
+                            instance.main_instance_handle = Some(handle);
+                            handle
+                        } else {
+                            return Err(Error::runtime_execution_error(
+                                "Direct-hosting component: no core instance exports the \
+                                 lifted function's backing core export",
                             ));
                         }
                     } else {
@@ -2776,11 +2818,10 @@ impl ComponentInstance {
     fn resolve_exports(
         instance: &mut Self,
         parsed_exports: &[kiln_format::component::Export],
+        parsed: &kiln_format::component::Component,
     ) -> Result<()> {
-        use crate::bounded_component_infra::ComponentProvider;
         use crate::instantiation::{ExportValue, FunctionExport, ResolvedExport};
         use kiln_format::component::Sort;
-        use kiln_foundation::safe_memory::NoStdProvider;
 
 
         for (idx, export) in parsed_exports.iter().enumerate() {
@@ -2790,21 +2831,54 @@ impl ComponentInstance {
                 format!("{}:{}", export.name.nested.join(":"), export.name.name)
             };
 
+            // For function exports, resolve the REAL signature (result types and
+            // the backing core export name) from the canon lift the export points
+            // at. This replaces the previous placeholder that built an empty,
+            // sometimes-failing unit signature (#344, AD-COMPONENT-HOST-001).
+            //
+            // `direct_target` is `Some` only when the export is a directly
+            // `canon lift`-ed core function — the direct-hosting path. Exports
+            // that resolve to other constructs (e.g. command-style runs) leave it
+            // `None` and fall through to the existing invocation path.
+            let direct_target: Option<crate::types::DirectExportTarget> = match &export.sort {
+                Sort::Function => Self::resolve_direct_export_target(parsed, export.idx)?,
+                _ => None,
+            };
+
+            // Convert the resolved component-level result types into the canonical
+            // ABI `ComponentType` used by the callable function signature.
+            let resolved_returns: Vec<ComponentType> = match &direct_target {
+                Some(t) => t
+                    .returns
+                    .iter()
+                    .map(Self::format_val_type_to_scalar_component_type)
+                    .collect::<Result<Vec<_>>>()?,
+                None => Vec::new(),
+            };
+
+            if let Some(target) = direct_target {
+                instance
+                    .direct_export_targets
+                    .insert(export_name.clone(), target);
+            }
+
 
             // Create an export value based on the sort
             let export_value = match &export.sort {
                 Sort::Function => {
-                    // Create a function export with placeholder signature.
-                    // Surface failures as a graceful Result error instead of
-                    // panicking — a malformed/zero-sized component type must not
-                    // crash the runtime (see issue #269).
-                    let provider = NoStdProvider::<4096>::default();
-                    let signature = kiln_foundation::ComponentType::unit(provider).map_err(|_| {
-                        kiln_error::Error::component_resource_lifecycle_error(
-                            "failed to construct unit component type for function export \
-                             signature during export resolution",
-                        )
-                    })?;
+                    // Build a non-failing FunctionExport signature.
+                    //
+                    // The previous placeholder built `ComponentType::unit(...)`,
+                    // whose inner `BoundedVec::new` rejects items whose serialized
+                    // size is zero — surfacing as the hard "failed to construct unit
+                    // component type" error this path is meant to remove (#269,
+                    // #344). The signature here carries no information used by the
+                    // direct-hosting invocation (the real result types live in
+                    // `direct_export_targets` and the callable function signature),
+                    // so use the `Default` value, which constructs an empty
+                    // component type without that zero-size rejection.
+                    let signature =
+                        kiln_foundation::ComponentType::<crate::bounded_component_infra::ComponentProvider>::default();
 
                     let func_export = FunctionExport {
                         signature,
@@ -2854,12 +2928,20 @@ impl ComponentInstance {
                                 use kiln_foundation::bounded::BoundedVec;
                                 BoundedVec::new()
                             },
+                            // Real resolved result types so invocation knows how to
+                            // lift the core result (#344).
                             #[cfg(feature = "std")]
-                            returns: Vec::new(),
+                            returns: resolved_returns.clone(),
                             #[cfg(not(feature = "std"))]
                             returns: {
                                 use kiln_foundation::bounded::BoundedVec;
-                                BoundedVec::new()
+                                let mut rv = BoundedVec::new();
+                                for ret in &resolved_returns {
+                                    rv.push(ret.clone()).map_err(|_| {
+                                        Error::validation_error("Too many function returns")
+                                    })?;
+                                }
+                                rv
                             },
                         },
                         implementation: FunctionImplementation::Native {
@@ -2927,6 +3009,162 @@ impl ComponentInstance {
         }
 
         Ok(())
+    }
+
+    /// Resolve the direct-hosting invocation target for an exported component
+    /// function index (#344, AD-COMPONENT-HOST-001).
+    ///
+    /// Returns `Some(target)` when the exported function is a directly
+    /// `canon lift`-ed core function: the lift's core function index is resolved
+    /// (through a `core func` alias of a core-instance export) to the backing
+    /// core export name, and the lift's component function type provides the
+    /// result types. Returns `None` when the export does not resolve to a direct
+    /// lift (e.g. a function import or a function alias), leaving the existing
+    /// invocation path untouched.
+    #[cfg(feature = "std")]
+    fn resolve_direct_export_target(
+        parsed: &kiln_format::component::Component,
+        export_func_idx: u32,
+    ) -> Result<Option<crate::types::DirectExportTarget>> {
+        use kiln_format::component::{
+            AliasTarget, CanonOperation, CoreSort, ComponentTypeDefinition, ExternType, Sort,
+        };
+
+        // Component function index space is populated in order:
+        //   1. function imports, 2. function aliases, 3. canon lift operations.
+        // (Mirrors the convention used when building component_import_func_map.)
+        // Only canon lifts create directly-invocable core-backed functions.
+        let mut component_func_idx = 0u32;
+
+        // 1. Function imports occupy the lowest indices.
+        for import in &parsed.imports {
+            if matches!(import.ty, ExternType::Function { .. }) {
+                if component_func_idx == export_func_idx {
+                    // An imported function, not a locally-lifted one.
+                    return Ok(None);
+                }
+                component_func_idx += 1;
+            }
+        }
+
+        // 2. Function aliases (component instance-export / outer of a function).
+        for alias in &parsed.aliases {
+            let is_func_alias = match &alias.target {
+                AliasTarget::InstanceExport { kind, .. } => matches!(kind, Sort::Function),
+                AliasTarget::Outer { kind, .. } => matches!(kind, Sort::Function),
+                AliasTarget::CoreInstanceExport { .. } => false,
+            };
+            if is_func_alias {
+                if component_func_idx == export_func_idx {
+                    // A function alias, not a locally-lifted one.
+                    return Ok(None);
+                }
+                component_func_idx += 1;
+            }
+        }
+
+        // 3. Canon lift operations.
+        for canon in &parsed.canonicals {
+            if let CanonOperation::Lift {
+                func_idx: core_func_idx,
+                type_idx,
+                ..
+            } = &canon.operation
+            {
+                if component_func_idx == export_func_idx {
+                    // Found the lift backing this export. Resolve its core export
+                    // name via the `core func` alias for `core_func_idx`, and its
+                    // result types via the component function type at `type_idx`.
+                    let core_export_name =
+                        Self::resolve_core_func_export_name(parsed, *core_func_idx)?;
+
+                    let returns = match parsed.types.get(*type_idx as usize) {
+                        Some(ty) => match &ty.definition {
+                            ComponentTypeDefinition::Function { results, .. } => results.clone(),
+                            _ => {
+                                return Err(Error::component_resource_lifecycle_error(
+                                    "canon lift type index does not refer to a function type",
+                                ));
+                            },
+                        },
+                        None => {
+                            return Err(Error::component_resource_lifecycle_error(
+                                "canon lift references an out-of-bounds component type index",
+                            ));
+                        },
+                    };
+
+                    return Ok(Some(crate::types::DirectExportTarget {
+                        core_export_name,
+                        returns,
+                    }));
+                }
+                component_func_idx += 1;
+            }
+        }
+
+        // No direct lift backs this export index.
+        let _ = CoreSort::Function;
+        Ok(None)
+    }
+
+    /// Resolve a core function index to the export name it is reached through.
+    ///
+    /// A `canon lift`'s core function index is produced by a `core func` alias of
+    /// a core-instance export (`AliasTarget::CoreInstanceExport`). The alias's
+    /// `dest_idx` is the core function index it occupies; its `name` is the core
+    /// export name the engine can invoke. FAIL LOUD if no such alias exists.
+    #[cfg(feature = "std")]
+    fn resolve_core_func_export_name(
+        parsed: &kiln_format::component::Component,
+        core_func_idx: u32,
+    ) -> Result<String> {
+        use kiln_format::component::{AliasTarget, CoreSort};
+
+        for alias in &parsed.aliases {
+            if let AliasTarget::CoreInstanceExport { name, kind, .. } = &alias.target {
+                if matches!(kind, CoreSort::Function) && alias.dest_idx == Some(core_func_idx) {
+                    return Ok(name.clone());
+                }
+            }
+        }
+
+        Err(Error::component_resource_lifecycle_error(
+            "canon lift core function index does not resolve to a core-instance \
+             export alias — direct hosting requires a lifted core export",
+        ))
+    }
+
+    /// Convert a component-model scalar [`FormatValType`] to the canonical ABI
+    /// [`ComponentType`]. FAIL LOUD on non-scalar types — the direct-hosting
+    /// path only lifts scalar results (#344); aggregates are not yet supported.
+    #[cfg(feature = "std")]
+    fn format_val_type_to_scalar_component_type(
+        vt: &kiln_format::component::FormatValType,
+    ) -> Result<ComponentType> {
+        use kiln_format::component::FormatValType as F;
+
+        let mapped = match vt {
+            F::Bool => ComponentType::Bool,
+            F::S8 => ComponentType::S8,
+            F::U8 => ComponentType::U8,
+            F::S16 => ComponentType::S16,
+            F::U16 => ComponentType::U16,
+            F::S32 => ComponentType::S32,
+            F::U32 => ComponentType::U32,
+            F::S64 => ComponentType::S64,
+            F::U64 => ComponentType::U64,
+            F::F32 => ComponentType::F32,
+            F::F64 => ComponentType::F64,
+            F::Char => ComponentType::Char,
+            _ => {
+                return Err(Error::component_resource_lifecycle_error(
+                    "direct-hosting result lift supports only scalar component types; \
+                     non-scalar result type is not supported",
+                ));
+            },
+        };
+        Ok(mapped)
     }
 
     /// Analyze and instantiate core modules (Step 7 & 8)
@@ -3700,6 +3938,14 @@ impl ComponentInstance {
             } => {
                 #[cfg(feature = "std")]
                 {
+                    // Direct Component-Model hosting (#344, AD-COMPONENT-HOST-001):
+                    // if the named export was resolved to a directly `canon
+                    // lift`-ed core function, invoke that specific core export and
+                    // lift its scalar result, instead of the `wasi:cli/run`
+                    // command-runner path.
+                    if self.direct_export_targets.contains_key(function_name) {
+                        return self.call_direct_export(function_name, args);
+                    }
                     self.call_native_function(*func_index, *module_index, args)
                 }
                 #[cfg(not(feature = "std"))]
@@ -3783,6 +4029,14 @@ impl ComponentInstance {
             } => {
                 #[cfg(feature = "std")]
                 {
+                    // Direct Component-Model hosting (#344, AD-COMPONENT-HOST-001):
+                    // if the named export was resolved to a directly `canon
+                    // lift`-ed core function, invoke that specific core export and
+                    // lift its scalar result, instead of the `wasi:cli/run`
+                    // command-runner path.
+                    if self.direct_export_targets.contains_key(function_name) {
+                        return self.call_direct_export(function_name, args);
+                    }
                     self.call_native_function(*func_index, *module_index, args)
                 }
                 #[cfg(not(feature = "std"))]
@@ -3952,6 +4206,165 @@ impl ComponentInstance {
 
         // Type checking would go here in a full implementation
         Ok(())
+    }
+
+    /// Invoke a directly-hosted, `canon lift`-ed export and lift its scalar
+    /// result (#344, AD-COMPONENT-HOST-001).
+    ///
+    /// Looks up the resolved [`DirectExportTarget`](crate::types::DirectExportTarget)
+    /// for `function_name`, lowers scalar arguments to core values, executes the
+    /// backing core export on the stored engine/instance, and lifts the scalar
+    /// core result back to a [`ComponentValue`] per the resolved result type.
+    ///
+    /// FAIL LOUD when the engine/instance is unavailable, when an argument or
+    /// result is non-scalar, or when the core result arity does not match.
+    #[cfg(all(feature = "std", feature = "kiln-execution"))]
+    fn call_direct_export(
+        &mut self,
+        function_name: &str,
+        args: &[ComponentValue],
+    ) -> Result<Vec<ComponentValue>> {
+        use kiln_foundation::values::Value;
+        use kiln_runtime::engine::CapabilityEngine;
+
+        let target = self
+            .direct_export_targets
+            .get(function_name)
+            .ok_or_else(|| {
+                Error::component_resource_lifecycle_error(
+                    "no direct-hosting target resolved for the requested export",
+                )
+            })?
+            .clone();
+
+        // Lower scalar component arguments to core WASM values. FAIL LOUD on
+        // non-scalar arguments — only scalars are supported on this path.
+        let wasm_args: Vec<Value> = args
+            .iter()
+            .map(Self::lower_scalar_component_value)
+            .collect::<Result<Vec<_>>>()?;
+
+        let (engine_box, instance_handle) =
+            match (&mut self.runtime_engine, self.main_instance_handle) {
+                (Some(engine_box), Some(handle)) => (engine_box, handle),
+                _ => {
+                    return Err(Error::runtime_execution_error(
+                        "direct-hosting invocation requires an instantiated engine and \
+                         main instance handle",
+                    ));
+                },
+            };
+        let engine = engine_box.as_mut();
+
+        // Invoke the specific core export backing the lift.
+        let core_results = engine.execute(instance_handle, &target.core_export_name, &wasm_args)?;
+
+        // Lift the core results back to component values per the resolved result
+        // types. FAIL LOUD on arity or type mismatch.
+        if core_results.len() != target.returns.len() {
+            return Err(Error::runtime_execution_error(
+                "direct-hosting core result arity does not match the lifted \
+                 component function result count",
+            ));
+        }
+
+        let mut lifted = Vec::with_capacity(core_results.len());
+        for (core_value, result_ty) in core_results.iter().zip(target.returns.iter()) {
+            lifted.push(Self::lift_scalar_core_value(core_value, result_ty)?);
+        }
+
+        Ok(lifted)
+    }
+
+    /// Lower a scalar [`ComponentValue`] to a core [`Value`]. FAIL LOUD on
+    /// non-scalar values (#344).
+    #[cfg(all(feature = "std", feature = "kiln-execution"))]
+    fn lower_scalar_component_value(
+        value: &ComponentValue,
+    ) -> Result<kiln_foundation::values::Value> {
+        use kiln_foundation::values::Value;
+
+        let lowered = match value {
+            ComponentValue::Bool(b) => Value::I32(if *b { 1 } else { 0 }),
+            ComponentValue::S8(v) => Value::I32(*v as i32),
+            ComponentValue::U8(v) => Value::I32(*v as i32),
+            ComponentValue::S16(v) => Value::I32(*v as i32),
+            ComponentValue::U16(v) => Value::I32(*v as i32),
+            ComponentValue::S32(v) => Value::I32(*v),
+            ComponentValue::U32(v) => Value::I32(*v as i32),
+            ComponentValue::S64(v) => Value::I64(*v),
+            ComponentValue::U64(v) => Value::I64(*v as i64),
+            ComponentValue::F32(v) => {
+                Value::F32(kiln_foundation::float_repr::FloatBits32::from_f32(*v))
+            },
+            ComponentValue::F64(v) => {
+                Value::F64(kiln_foundation::float_repr::FloatBits64::from_f64(*v))
+            },
+            ComponentValue::Char(c) => Value::I32(*c as i32),
+            _ => {
+                return Err(Error::component_resource_lifecycle_error(
+                    "direct-hosting argument lowering supports only scalar component \
+                     values; non-scalar argument is not supported",
+                ));
+            },
+        };
+        Ok(lowered)
+    }
+
+    /// Lift a scalar core [`Value`] to a [`ComponentValue`] per the resolved
+    /// result type. FAIL LOUD on non-scalar result types or core/expected type
+    /// mismatch (#344).
+    #[cfg(all(feature = "std", feature = "kiln-execution"))]
+    fn lift_scalar_core_value(
+        core_value: &kiln_foundation::values::Value,
+        result_ty: &kiln_format::component::FormatValType,
+    ) -> Result<ComponentValue> {
+        use kiln_format::component::FormatValType as F;
+        use kiln_foundation::values::Value;
+
+        let mismatch = || {
+            Error::runtime_execution_error(
+                "direct-hosting core result type does not match the lifted \
+                 component result type",
+            )
+        };
+
+        let lifted = match (result_ty, core_value) {
+            (F::Bool, Value::I32(v)) => ComponentValue::Bool(*v != 0),
+            (F::S8, Value::I32(v)) => ComponentValue::S8(*v as i8),
+            (F::U8, Value::I32(v)) => ComponentValue::U8(*v as u8),
+            (F::S16, Value::I32(v)) => ComponentValue::S16(*v as i16),
+            (F::U16, Value::I32(v)) => ComponentValue::U16(*v as u16),
+            (F::S32, Value::I32(v)) => ComponentValue::S32(*v),
+            (F::U32, Value::I32(v)) => ComponentValue::U32(*v as u32),
+            (F::S64, Value::I64(v)) => ComponentValue::S64(*v),
+            (F::U64, Value::I64(v)) => ComponentValue::U64(*v as u64),
+            (F::F32, Value::F32(v)) => ComponentValue::F32(v.to_f32()),
+            (F::F64, Value::F64(v)) => ComponentValue::F64(v.to_f64()),
+            (F::Char, Value::I32(v)) => {
+                let c = u32::try_from(*v)
+                    .ok()
+                    .and_then(char::from_u32)
+                    .ok_or_else(|| {
+                        Error::runtime_execution_error(
+                            "direct-hosting char result is not a valid Unicode scalar value",
+                        )
+                    })?;
+                ComponentValue::Char(c)
+            },
+            (
+                F::Bool | F::S8 | F::U8 | F::S16 | F::U16 | F::S32 | F::U32 | F::S64 | F::U64
+                | F::F32 | F::F64 | F::Char,
+                _,
+            ) => return Err(mismatch()),
+            _ => {
+                return Err(Error::component_resource_lifecycle_error(
+                    "direct-hosting result lift supports only scalar component types; \
+                     non-scalar result type is not supported",
+                ));
+            },
+        };
+        Ok(lifted)
     }
 
     #[cfg(feature = "std")]

--- a/kiln-component/src/components/component_linker.rs
+++ b/kiln-component/src/components/component_linker.rs
@@ -647,6 +647,8 @@ impl ComponentLinker {
             runtime_engine: None,
             #[cfg(feature = "kiln-execution")]
             main_instance_handle: None,
+            #[cfg(feature = "std")]
+            direct_export_targets: std::collections::HashMap::new(),
             id: instance_id,
             component: comp,
             state: crate::types::ComponentInstanceState::Initialized,

--- a/kiln-component/src/instantiation.rs
+++ b/kiln-component/src/instantiation.rs
@@ -535,6 +535,8 @@ impl Component {
             runtime_engine: None,
             #[cfg(feature = "kiln-execution")]
             main_instance_handle: None,
+            #[cfg(feature = "std")]
+            direct_export_targets: std::collections::HashMap::new(),
             id: instance_id,
             component: component_ref,
             state: crate::types::ComponentInstanceState::Initialized,

--- a/kiln-component/src/types.rs
+++ b/kiln-component/src/types.rs
@@ -158,6 +158,29 @@ pub struct ComponentInstance {
     /// Main module instance handle for execution
     #[cfg(feature = "kiln-execution")]
     pub main_instance_handle: Option<kiln_runtime::engine::InstanceHandle>,
+    /// Direct-hosting invocation targets, keyed by exported function name.
+    ///
+    /// Populated during export resolution for the direct Component-Model hosting
+    /// path (#344, AD-COMPONENT-HOST-001): maps an exported function name to the
+    /// backing core export name and the component-level result types needed to
+    /// lift the core result. Empty for components driven only via the
+    /// `wasi:cli/run` command path.
+    #[cfg(feature = "std")]
+    pub direct_export_targets: std::collections::HashMap<String, DirectExportTarget>,
+}
+
+/// Resolved direct-hosting invocation target for an exported function (#344).
+///
+/// Describes how to invoke an exported, `canon lift`-ed function: which core
+/// export backs it and what component-level result types its core result must
+/// be lifted to.
+#[cfg(feature = "std")]
+#[derive(Debug, Clone, PartialEq)]
+pub struct DirectExportTarget {
+    /// Export name of the backing core function (callable on the engine).
+    pub core_export_name: String,
+    /// Component-level result types to lift the core result into.
+    pub returns: Vec<kiln_format::component::FormatValType>,
 }
 
 impl fmt::Debug for ComponentInstance {

--- a/kiln-decoder/src/component/parse.rs
+++ b/kiln-decoder/src/component/parse.rs
@@ -1333,17 +1333,52 @@ mod std_parsing {
                     params.push((name, val_type));
                 }
 
-                // Read result vector
-                let (result_count, bytes_read) = binary::read_leb128_u32(bytes, offset)?;
-                offset += bytes_read;
+                // Read the result list.
+                //
+                // Per the Component Model binary format, a functype's results are
+                // NOT a plain vector. They are encoded as:
+                //   0x00 t:valtype                 => (result t)        ; one unnamed result
+                //   0x01 lt*:vec(<labelvaltype>)   => (result lt)*      ; named results
+                // (see WebAssembly/component-model binary.md, `functype`).
+                if offset >= bytes.len() {
+                    return Err(Error::parse_error(
+                        "Unexpected end of input while parsing function result list",
+                    ));
+                }
+                let result_kind = bytes[offset];
+                offset += 1;
 
-                let mut results = Vec::with_capacity(result_count as usize);
-                for _ in 0..result_count {
-                    // Read result type
-                    let (val_type, bytes_read) = parse_val_type(&bytes[offset..])?;
-                    offset += bytes_read;
+                let mut results = Vec::new();
+                match result_kind {
+                    0x00 => {
+                        // Single unnamed result.
+                        let (val_type, bytes_read) = parse_val_type(&bytes[offset..])?;
+                        offset += bytes_read;
+                        results.push(val_type);
+                    },
+                    0x01 => {
+                        // Vector of named results.
+                        let (result_count, bytes_read) = binary::read_leb128_u32(bytes, offset)?;
+                        offset += bytes_read;
 
-                    results.push(val_type);
+                        results.reserve(result_count as usize);
+                        for _ in 0..result_count {
+                            // Each named result is label':<string> t:<valtype>.
+                            let (_name, bytes_read) =
+                                kiln_format::binary::read_string(bytes, offset)?;
+                            offset += bytes_read;
+
+                            let (val_type, bytes_read) = parse_val_type(&bytes[offset..])?;
+                            offset += bytes_read;
+
+                            results.push(val_type);
+                        }
+                    },
+                    _ => {
+                        return Err(Error::parse_error(
+                            "Invalid function result-list tag (expected 0x00 or 0x01)",
+                        ));
+                    },
                 }
 
                 Ok((

--- a/kilnd/src/component_host.rs
+++ b/kilnd/src/component_host.rs
@@ -1,0 +1,67 @@
+//! Direct Component-Model hosting in kilnd.
+//!
+//! This is the DIRECT-HOSTING / std-QM path of decision `AD-COMPONENT-HOST-001`
+//! (gale#63 / `REQ_COMPONENT_HOST`, issue #344): instantiate an external
+//! (e.g. wac-composed) component and invoke a named export, lifting its scalar
+//! result back to a [`ComponentValue`].
+//!
+//! It deliberately does NOT touch the meld-fuse path or anything async
+//! (`SM-ASYNC-002`).
+
+#[cfg(all(feature = "std", feature = "component-model"))]
+use kiln_component::canonical_abi::ComponentValue;
+use kiln_error::Result;
+
+/// Instantiate `wasm` (a Component Model binary) and invoke the named `export`,
+/// returning its lifted scalar result(s).
+///
+/// # Errors
+///
+/// Returns an error if the component fails to decode, instantiate, or if the
+/// named export cannot be invoked.
+#[cfg(all(feature = "std", feature = "component-model"))]
+pub fn invoke_component_export(wasm: &[u8], export: &str) -> Result<Vec<ComponentValue>> {
+    use kiln_component::components::component_instantiation::ComponentInstance;
+    use kiln_decoder::component::decode_component;
+
+    let mut parsed = decode_component(wasm)?;
+    let mut instance = ComponentInstance::from_parsed_with_handler(0, &mut parsed, None, None)?;
+    instance.call_function(export, &[], None)
+}
+
+#[cfg(all(test, feature = "std", feature = "component-model"))]
+mod tests {
+    use super::*;
+
+    /// The acceptance fixture from #344: a component whose single export
+    /// `run-demo` lifts a core function returning `(i32.const 53)` to a
+    /// component-level `u32`.
+    fn fixture() -> Vec<u8> {
+        wat::parse_str(
+            r#"
+            (component
+              (core module $m (func (export "run-demo") (result i32) (i32.const 53)))
+              (core instance $i (instantiate $m))
+              (func $rd (result u32) (canon lift (core func $i "run-demo")))
+              (export "run-demo" (func $rd)))
+            "#,
+        )
+        .expect("fixture must build + validate as a component")
+    }
+
+    #[test]
+    fn invoke_named_export_lifts_scalar() {
+        let wasm = fixture();
+        let result = invoke_component_export(&wasm, "run-demo")
+            .expect("instantiate + invoke run-demo must succeed");
+        assert_eq!(result, vec![ComponentValue::U32(53)]);
+    }
+
+    /// Helper used to materialize the acceptance fixture to disk for the
+    /// end-to-end `--invoke` CLI check. Run with `--ignored`.
+    #[test]
+    #[ignore]
+    fn write_fixture_to_tmp() {
+        std::fs::write("/tmp/fixture.wasm", fixture()).expect("write fixture");
+    }
+}

--- a/kilnd/src/main.rs
+++ b/kilnd/src/main.rs
@@ -71,6 +71,34 @@ pub mod bounded_kilnd_infra;
 // witness MC/DC coverage harness mode (#340)
 pub mod witness_harness;
 
+// Direct Component-Model hosting: instantiate an external component and invoke
+// a named export, lifting its scalar result (#344, AD-COMPONENT-HOST-001).
+#[cfg(feature = "component-model")]
+pub mod component_host;
+
+/// Render a scalar [`ComponentValue`] for user-facing `--invoke` output (#344).
+#[cfg(all(feature = "std", feature = "component-model"))]
+fn format_component_value(value: &kiln_component::canonical_abi::ComponentValue) -> String {
+    use kiln_component::canonical_abi::ComponentValue as V;
+
+    match value {
+        V::Bool(v) => v.to_string(),
+        V::S8(v) => v.to_string(),
+        V::U8(v) => v.to_string(),
+        V::S16(v) => v.to_string(),
+        V::U16(v) => v.to_string(),
+        V::S32(v) => v.to_string(),
+        V::U32(v) => v.to_string(),
+        V::S64(v) => v.to_string(),
+        V::U64(v) => v.to_string(),
+        V::F32(v) => v.to_string(),
+        V::F64(v) => v.to_string(),
+        V::Char(v) => v.to_string(),
+        V::String(v) => v.clone(),
+        other => format!("{:?}", other),
+    }
+}
+
 // Safety-critical memory limits
 #[cfg(feature = "safety-critical")]
 pub mod memory_limits;
@@ -195,6 +223,11 @@ pub struct KilndConfig {
     /// Component interfaces to enable
     #[cfg(feature = "component-model")]
     pub component_interfaces: Vec<String>,
+    /// Named component export to invoke directly (#344). When set, the component
+    /// is instantiated and this export is invoked instead of the `wasi:cli/run`
+    /// command entry point, and its scalar result is printed.
+    #[cfg(feature = "component-model")]
+    pub invoke_export: Option<String>,
     /// Memory profiling enabled
     pub enable_memory_profiling: bool,
     /// Platform-specific optimizations
@@ -231,6 +264,8 @@ impl Default for KilndConfig {
             enable_component_model: true,
             #[cfg(feature = "component-model")]
             component_interfaces: Vec::new(),
+            #[cfg(feature = "component-model")]
+            invoke_export: None,
             enable_memory_profiling: false,
             enable_platform_optimizations: true,
         }
@@ -531,6 +566,7 @@ impl KilndEngine {
     /// For WAC-composed P3 components with nested library components,
     /// inter-component calls are routed through the nested component engines.
     #[cfg(feature = "component-model")]
+    #[allow(clippy::too_many_lines)]
     fn execute_component(&mut self, data: &[u8]) -> Result<()> {
         #[cfg(feature = "component-model")]
         {
@@ -635,6 +671,39 @@ impl KilndEngine {
             if self.config.enable_wasi {
                 if let Err(e) = instance.pre_allocate_wasi_args() {
                     eprintln!("[WASI-PREALLOC] Failed: {}", e);
+                }
+            }
+
+            // Direct Component-Model hosting (#344, AD-COMPONENT-HOST-001):
+            // if a specific export was requested with `--invoke`, invoke it and
+            // print its scalar result instead of running the `wasi:cli/run`
+            // command entry point.
+            if let Some(export_name) = self.config.invoke_export.clone() {
+                let _ = self.logger.handle_minimal_log(
+                    LogLevel::Info,
+                    "Invoking requested component export",
+                );
+
+                #[cfg(feature = "kiln-execution")]
+                let result = instance.call_function(&export_name, &[], Some(&self.host_registry));
+                #[cfg(not(feature = "kiln-execution"))]
+                let result = instance.call_function(&export_name, &[]);
+
+                match result {
+                    Ok(values) => {
+                        // User-facing result output on stdout.
+                        for value in &values {
+                            println!("{}", format_component_value(value));
+                        }
+                        return Ok(());
+                    },
+                    Err(e) => {
+                        #[cfg(feature = "std")]
+                        {
+                            eprintln!("Component export invocation error: {}", e);
+                        }
+                        return Err(e);
+                    },
                 }
             }
 
@@ -1080,6 +1149,11 @@ pub struct SimpleArgs {
     /// Component interfaces to register
     #[cfg(feature = "component-model")]
     pub component_interfaces: Vec<String>,
+    /// Named component export to invoke directly (direct Component-Model hosting,
+    /// #344). When set, kilnd instantiates the component and invokes this export
+    /// instead of the `wasi:cli/run` command entry point.
+    #[cfg(feature = "component-model")]
+    pub invoke_export: Option<String>,
     /// Enable memory profiling
     pub enable_memory_profiling: bool,
     /// Enable platform optimizations
@@ -1111,6 +1185,8 @@ impl SimpleArgs {
             enable_component_model: true,
             #[cfg(feature = "component-model")]
             component_interfaces: Vec::new(),
+            #[cfg(feature = "component-model")]
+            invoke_export: None,
             enable_memory_profiling: false,
             enable_platform_optimizations: true,
         };
@@ -1139,7 +1215,8 @@ impl SimpleArgs {
                     }
                     #[cfg(feature = "component-model")]
                     {
-                        println!("  --component          Enable component model support");
+                        println!("  --component [<path>]  Enable component model support");
+                        println!("  --invoke <export>     Invoke a named component export and print its result");
                         println!("  --interface <name>   Register component interface");
                     }
                     println!("  --help               Show this help message");
@@ -1210,6 +1287,22 @@ impl SimpleArgs {
                 #[cfg(feature = "component-model")]
                 "--component" => {
                     result.enable_component_model = true;
+                    // Optionally accept the component path as a value:
+                    //   --component <path>
+                    // (the path may also be given positionally).
+                    if i + 1 < args.len() && !args[i + 1].starts_with("--") {
+                        i += 1;
+                        if result.module_path.is_none() {
+                            result.module_path = Some(args[i].clone());
+                        }
+                    }
+                },
+                #[cfg(feature = "component-model")]
+                "--invoke" => {
+                    i += 1;
+                    if i < args.len() {
+                        result.invoke_export = Some(args[i].clone());
+                    }
                 },
                 #[cfg(feature = "component-model")]
                 "--interface" => {
@@ -1377,6 +1470,7 @@ fn main_with_stack() -> Result<()> {
     {
         config.enable_component_model = args.enable_component_model;
         config.component_interfaces = args.component_interfaces.clone();
+        config.invoke_export = args.invoke_export.clone();
 
         if config.enable_component_model {
             println!(


### PR DESCRIPTION
## Direct Component-Model hosting in kilnd (#344)

Implements the **DIRECT-HOSTING / std-QM** half of `AD-COMPONENT-HOST-001` (`REQ_COMPONENT_HOST`, gale#63): instantiate an external (wac-composed) component and invoke a named, `canon lift`-ed export, lifting its scalar result. The meld-fuse path and anything async (`SM-ASYNC-002`) are deliberately untouched. **Do not merge** without review.

### Before → After (RED → GREEN)

**Before (RED):** the new acceptance test died during export resolution:
```
Error { ComponentRuntime, 24002, "failed to construct unit component type for
function export signature during export resolution" }
```
Even past that, the decoder silently dropped `(result u32)` (decoding the result-list `0x00` tag as a zero count), and the only invocation path was a hard-coded `wasi:cli/run` command-runner that ignored the export name and always returned `vec![]`.

**After (GREEN):**
- `kilnd::component_host::invoke_component_export(&fixture, "run-demo")` returns `vec![ComponentValue::U32(53)]`.
- `kilnd --component fixture.wasm --invoke run-demo` prints `53` on stdout.

```
[INFO] Invoking requested component export
53
```

**Mutation check:** changing the fixture's lifted core constant from 53 to 99 makes the test observe `U32(99)` (asserting 53 then fails) — proving the lifted value tracks the real core result rather than a hardcoded constant.

### What changed (root-caused, five pieces)

1. **Decoder result-list encoding** (`kiln-decoder/src/component/parse.rs`): a component functype's results are `0x00 valtype` (single unnamed) or `0x01 vec(labelvaltype)` (named), not a plain valtype vector. Fixed per the Component Model binary format.
2. **Export type resolution** (`kiln-component` `resolve_exports`): resolve the export's canon lift to its real result types (populating the callable signature's `returns`) and its backing core export name (recorded in a new `direct_export_targets` map). The `FunctionExport` signature now uses a `Default` component type that avoids the zero-serialized-size `BoundedVec` guard that the old `unit()` placeholder tripped.
3. **Named-export invocation** (`call_direct_export`): invoke the specific core export backing the lift on the stored engine/instance, instead of the `wasi:cli/run` runner.
4. **Scalar result lift**: lift the core `I32(53)` to `ComponentValue::U32(53)` per the resolved result type. FAIL LOUD on non-scalar args/results and on arity/type mismatch.
5. **Main-handle selection**: a direct-hosting component has no `_start`; select the core instance that backs a lifted export (no fallback) instead of erroring.

Plus the kilnd **`--invoke <export>`** CLI flag, threaded through `SimpleArgs`/`KilndConfig` into `execute_component`, which invokes the named export and prints its scalar result.

### Verification
- `cargo build --workspace`: clean.
- `cargo test -p kilnd --bin kilnd`: pass (incl. the new acceptance test).
- `cargo test -p kiln-component --lib --features std,kiln-execution`: 15/15 pass.
- `cargo test -p kiln-decoder --lib --features std`: 99 pass; 2 pre-existing failures (`branch_hint_section`, `toml_config`) confirmed unrelated (fail with this change stashed).
- `rivet validate`: **0 errors** (90 warnings / 46 broken cross-refs — same as the `main` baseline, all pre-existing).
- End-to-end: `cargo run -p kilnd -- --component fixture.wasm --invoke run-demo` prints `53`.

Closes the direct-hosting half of #344.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
