### PR TITLE
fix(ci): pr-diagnostics — force-checkout PR head so a dirtied Cargo.lock can't abort the job (#373)

### DIFF
--- a/.github/workflows/pr-diagnostics.yml
+++ b/.github/workflows/pr-diagnostics.yml
@@ -61,7 +61,11 @@ jobs:
         
     - name: Return to PR branch
       run: |
-        git checkout ${{ github.event.pull_request.head.sha }}
+        # Force-checkout: the base build above regenerates/touches Cargo.lock
+        # (and other build artifacts), which would otherwise abort the checkout
+        # with "local changes would be overwritten". These are throwaway baseline
+        # artifacts, so discarding them is safe. (kiln#373)
+        git checkout -f ${{ github.event.pull_request.head.sha }}
         
     - name: Analyze PR diagnostics
       id: pr-diagnostics  

--- a/safety/requirements/functional-requirements.yaml
+++ b/safety/requirements/functional-requirements.yaml
@@ -855,3 +855,17 @@ artifacts:
   # REQ_LFUNC_019 (Component Model Implementation) — duplicates
   #   REQ_FUNC_014 at a lower level.
   # =========================================================================
+
+  - id: SR-25
+    type: requirement
+    title: pr-diagnostics baseline checkout must not abort on a dirtied Cargo.lock
+    status: implemented
+    description: "The pr-diagnostics workflow's baseline step checks out the PR base, builds it (which regenerates Cargo.lock and other artifacts), then checks out the PR head. The head checkout shall not abort on the dirtied baseline artifacts — they are throwaway. Regression: failed on #363 (base build touched Cargo.lock); passed on #362/#361/#359 (clean base). Workflow-mechanics bug, not a code signal; the real gates were green. Fix: force-checkout the head sha. Issue #373."
+    tags: [ci, tooling, pr-diagnostics]
+    fields:
+      upstream-ref: https://github.com/pulseengine/kiln/issues/373
+    provenance:
+      created-by: ai
+      model: claude-opus-4-8
+      timestamp: 2026-07-02T06:50:20Z
+    release: v0.3.6


### PR DESCRIPTION
## Problem (measured)
`Analyze Build Diagnostics` (.github/workflows/pr-diagnostics.yml) checks out the PR base, builds it (regenerates `Cargo.lock`), then `git checkout <head.sha>` — which **aborts** when the base build dirtied the lockfile:
```
error: Your local changes to the following files would be overwritten by checkout: Cargo.lock
```
Reproduced on #363; passed on #362/#361/#359 (clean base builds). Workflow-mechanics bug, not a code signal — the required gates were all green.

## Fix
`git checkout -f <head.sha>` — the baseline build artifacts are throwaway, so discarding them is safe. `head.sha` is a commit hash (not a ref name), so no injection surface is added.

## Verification
The oracle is workflow-level: this can only be confirmed green on a PR whose base build dirties `Cargo.lock`. Tracked as rivet `SR-25` (release v0.3.6), left `implemented` until observed green in the field.

Closes #373.

🤖 Generated with [Claude Code](https://claude.com/claude-code)