### PR TITLE
chore(rivet): triage open issues into rivet (SR-27/28/29, SM-MEM-003)

### DIFF
--- a/safety/requirements/architecture-decisions.yaml
+++ b/safety/requirements/architecture-decisions.yaml
@@ -457,3 +457,22 @@ artifacts:
         — rejected as slow/uncertain. (4) OIDC trusted publishing — deferred (per-crate
         registration overhead); revisit later.
       source-ref: "https://github.com/pulseengine/kiln/issues/310"
+
+  - id: SM-MEM-003
+    type: design-decision
+    title: Cross-repo witness --harness JSON contract is a traced artifact, not prose
+    status: proposed
+    description: "The witness-harness-v1 JSON contract shared between kiln (producer) and witness (consumer) shall be a traced rivet artifact (schema + version) linked from both sides, not coordinated as prose in issue comments. Issue #347."
+    tags: [witness, contract, traceability, cross-repo]
+    fields:
+      rationale: "A prose contract has no mechanical trace: a schema change on either side silently fails to re-verify the other. A traced schema artifact linked from both repos makes a contract change re-open the dependent verification."
+    provenance:
+      created-by: ai
+      model: claude-opus-4-8
+      timestamp: 2026-07-02T07:40:14Z
+    release: v0.4.0
+    links:
+      - type: satisfies
+        target: REQ_WITNESS_COV
+      - type: derives-from
+        target: REQ_WITNESS_COV

--- a/safety/requirements/functional-requirements.yaml
+++ b/safety/requirements/functional-requirements.yaml
@@ -869,3 +869,45 @@ artifacts:
       model: claude-opus-4-8
       timestamp: 2026-07-02T06:50:20Z
     release: v0.3.6
+
+  - id: SR-27
+    type: requirement
+    title: kilnd integration tests compile + run under std,component-model
+    status: proposed
+    description: "The kilnd integration test targets (integrated_features_tests.rs, kilnd_integration_tests) shall compile and run under --features std,component-model. They bit-rotted against the WasiCapabilities constructor becoming Result-returning and silently stopped building, giving zero coverage. Fix the API usage and add the feature combo to the CI test matrix so it can't rot dark again. Issue #377."
+    tags: [ci, testing, kilnd]
+    fields:
+      upstream-ref: https://github.com/pulseengine/kiln/issues/377
+    provenance:
+      created-by: ai
+      model: claude-opus-4-8
+      timestamp: 2026-07-02T07:40:02Z
+    release: v0.3.6
+
+  - id: SR-28
+    type: requirement
+    title: main branch enforces the CI gate as required status checks
+    status: proposed
+    description: "The main branch shall enforce required status checks (via ruleset or branch protection) so a PR cannot merge while checks are red, queued, or cancelled. Today required_status_checks.contexts is empty and no ruleset requires any context — CI is advisory only. Add the gate contexts (build, Core Tests/Analysis/Coverage, CI Checks & Docs, Safety Analysis with Clippy, SCORE-Inspired Safety Verification, Security Audit matrix). Issue #378."
+    tags: [ci, release, branch-protection]
+    fields:
+      upstream-ref: https://github.com/pulseengine/kiln/issues/378
+    provenance:
+      created-by: ai
+      model: claude-opus-4-8
+      timestamp: 2026-07-02T07:40:02Z
+    release: v0.3.6
+
+  - id: SR-29
+    type: requirement
+    title: Component multi-core instantiation links cross-core user imports (sibling-module function/memory)
+    status: proposed
+    description: "When a Component-Model artifact decomposes into multiple core modules, an import in one core module satisfied by an export of a sibling core module (cross-core function/memory) shall be linked during instantiation. Today only host imports and same-module refs resolve, so meld-fused multi-core components fail to link. Extends #364/#374. Issue #375."
+    tags: [component-model, instantiation, multicore, linking]
+    fields:
+      upstream-ref: https://github.com/pulseengine/kiln/issues/375
+    provenance:
+      created-by: ai
+      model: claude-opus-4-8
+      timestamp: 2026-07-02T07:40:03Z
+    release: v0.4.0


### PR DESCRIPTION
Issue-hunt pass 2026-07-02 — lands untracked open issues in rivet with release assignment.

_(Supersedes #380, which was corrupted by a stash-pop conflict — conflict markers slipped into the YAML and CI didn't catch it since rivet validate isn't a gating check, cf #378.)_

| rivet id | issue | scope | release |
|---|---|---|---|
| SR-27 | #377 | kilnd integration tests compile+run under std,component-model | v0.3.6 |
| SR-28 | #378 | main enforces the CI gate as required status checks | v0.3.6 |
| SR-29 | #375 | component multi-core cross-core sibling-import linking | v0.4.0 |
| SM-MEM-003 | #347 | witness --harness JSON contract as a traced artifact | v0.4.0 |

`rivet validate`: 0 errors (verified no conflict markers this time).

🤖 Generated with [Claude Code](https://claude.com/claude-code)