### PR TITLE
fix(component): offset wasi:cli/run export by the instance-import count (#382, E5DC2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1311,6 +1311,7 @@ dependencies = [
  "kiln-runtime",
  "kiln-sync",
  "log",
+ "wat",
 ]
 
 [[package]]

--- a/kiln-component/Cargo.toml
+++ b/kiln-component/Cargo.toml
@@ -30,6 +30,9 @@ log = { version = "0.4", optional = true }
 
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }
+# Build + decode synthetic components in unit tests (E5DC2 / #382).
+wat = "1.244"
+kiln-decoder = { workspace = true, features = ["std"] }
 
 [features]
 # By default, enable std to match kiln-runtime's default behavior

--- a/kiln-component/src/components/component_instantiation.rs
+++ b/kiln-component/src/components/component_instantiation.rs
@@ -3220,8 +3220,37 @@ impl ComponentInstance {
             }
 
             // 2. Resolve the exported instance's `run` function to a component
-            //    function index.
-            let instance_idx = export.idx as usize;
+            //    function index. `export.idx` is a component-instance
+            //    *index-space* value: 0..K-1 are imported instances, K.. are the
+            //    defined instances (`parsed.instances[i]` = space index `K + i`).
+            //    Offset by the instance-import count K before indexing the
+            //    defined-only vector — mirroring the `instance_interface_map`
+            //    walk in `from_parsed_with_handler`. (#382 / E5DC2: a meld-fused
+            //    component imports K=13 WASI instances, so the raw space index
+            //    overran `parsed.instances`; #364's self-contained fixture had
+            //    K=0, so the raw index happened to be correct.)
+            let num_instance_imports = parsed
+                .imports
+                .iter()
+                .filter(|import| {
+                    use kiln_format::component::ExternType;
+                    matches!(
+                        import.ty,
+                        ExternType::Instance { .. }
+                            | ExternType::Type(_)
+                            | ExternType::Component { .. }
+                            | ExternType::Module { .. }
+                    )
+                })
+                .count();
+            let export_space_idx = export.idx as usize;
+            if export_space_idx < num_instance_imports {
+                // The run instance resolves to an *imported* instance, not the
+                // locally-defined shape this resolver handles — leave the legacy
+                // path to deal with it.
+                return Ok(None);
+            }
+            let instance_idx = export_space_idx - num_instance_imports;
             let inst = parsed.instances.get(instance_idx).ok_or_else(|| {
                 Error::component_resource_lifecycle_error(
                     "wasi:cli/run export references an out-of-bounds component instance index",
@@ -5481,5 +5510,49 @@ pub fn create_component_import(
         name,
         module,
         import_type,
+    }
+}
+
+#[cfg(all(test, feature = "std"))]
+mod e5dc2_tests {
+    use super::*;
+
+    /// #382 (E5DC2): a command component with an **instance import** declared
+    /// before the defined `wasi:cli/run` instance. The import occupies
+    /// component-instance index 0, so the run instance sits at space index 1
+    /// while it is `parsed.instances[0]`. `resolve_command_entry` must offset by
+    /// the instance-import count K before indexing `parsed.instances`; before the
+    /// fix it used the raw space index (1) and returned the out-of-bounds error.
+    ///
+    /// meld corroborated K=13 for the real `hello_c_cli --component --memory
+    /// multi` fusion; K=1 here is the minimal overrun of a K=0-assuming index.
+    // rivet: verifies SR-30
+    #[test]
+    fn resolve_command_entry_offsets_by_instance_import_count() {
+        let wasm = wat::parse_str(
+            r#"
+            (component
+              ;; One instance import — occupies component-instance index 0,
+              ;; pushing the defined run instance to component-instance index 1.
+              (import "test:pkg/thing" (instance $stub))
+              (core module $runner (func (export "run") (result i32) (i32.const 42)))
+              (core instance $ir (instantiate $runner))
+              (func $run (result u32) (canon lift (core func $ir "run")))
+              (instance $run_iface (export "run" (func $run)))
+              (export "wasi:cli/run@0.2.6" (instance $run_iface)))
+            "#,
+        )
+        .expect("instance-import command fixture must build as a component");
+        let parsed =
+            kiln_decoder::component::decode_component(&wasm).expect("fixture must decode");
+
+        let resolved = ComponentInstance::resolve_command_entry(&parsed).expect(
+            "resolve_command_entry must offset by the instance-import count, not fail \
+             with the E5DC2 out-of-bounds error",
+        );
+        assert!(
+            resolved.is_some(),
+            "the wasi:cli/run command entry must resolve to its backing core function",
+        );
     }
 }

--- a/safety/requirements/functional-requirements.yaml
+++ b/safety/requirements/functional-requirements.yaml
@@ -915,7 +915,7 @@ artifacts:
   - id: SR-30
     type: requirement
     title: wasi:cli/run export resolution honors the instance-import offset in the component-instance index space
-    status: proposed
+    status: implemented
     description: "resolve_command_entry shall resolve a wasi:cli/run instance export's backing instance by walking the component-instance index space (0..K-1 imported instances, K.. defined instances), offsetting export.idx by the instance-import count K before indexing parsed.instances — and return None (legacy path) if the run instance is an imported instance (export.idx < K). Today it uses export.idx directly, so a meld-fused component with instance-import stubs (K>0) fails with E5DC2 out-of-bounds. Differential oracle: wasmtime 41.0.0 runs the same fused.wasm. Must keep #364's K=0 fixture green. Issue #382 (split from #375)."
     tags: [component-model, instantiation, wasi-cli-run, index-space, bug]
     fields:


### PR DESCRIPTION
Closes #382. Fixes the E5DC2 out-of-bounds on meld-fused command components.

## Root cause (confirmed both sides)
`resolve_command_entry` indexed `parsed.instances` (defined-only) with the raw `export.idx` — but `export.idx` is a **component-instance index-space** value: `0..K-1` imported instances, `K..` defined (`parsed.instances[i]` = space index `K+i`). meld's inspection confirmed **K=13** WASI instance imports on the real `hello_c_cli --component --memory multi` fusion, so the run export's space index overran `parsed.instances` → `[ComponentRuntime][E5DC2]`. wasmtime runs the same bytes (differential oracle) ⇒ the defect was kilnd's.

## Fix
Count instance imports K (mirroring the `instance_interface_map` walk in `from_parsed_with_handler`) and offset `export.idx` by K before indexing; if the run instance resolves to an *imported* instance (`idx < K`), return `None` to the legacy path. #364's self-contained fixture had K=0 → unaffected.

## Test (RED→GREEN, no meld needed)
A unit test drives `resolve_command_entry` **directly** on a decoded synthetic component with one instance import before the defined run instance (K=1 — the minimal overrun). This bypasses the linking phase that satisfiable WASI imports would otherwise require (why an end-to-end `invoke_component_export` synthetic couldn't reach the resolver earlier). RED reproduced code 24002 exactly; GREEN after the fix.

- kiln-component: **16/16**
- kilnd component_host (#364/#344 K=0): **2/2** — no regression

rivet: SR-30 (v0.4.0), `// rivet: verifies SR-30`. Un-ignores meld's Tier-C `tier_c_fused_executes_on_kiln` (meld#297).

🤖 Generated with [Claude Code](https://claude.com/claude-code)