### PR TITLE
chore(release): v0.3.6 + fix Cargo.lock time conflict (#394 regression)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -254,7 +254,7 @@ checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 
 [[package]]
 name = "cargo-kiln"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -545,9 +545,12 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.5.8"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
+dependencies = [
+ "powerfmt",
+]
 
 [[package]]
 name = "derive-new"
@@ -1257,7 +1260,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-async"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "criterion",
  "kiln-error",
@@ -1265,7 +1268,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-build-core"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1295,7 +1298,7 @@ version = "0.1.0"
 
 [[package]]
 name = "kiln-component"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "criterion",
  "kiln-decoder",
@@ -1313,7 +1316,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-debug"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "kiln-error",
  "kiln-format",
@@ -1322,7 +1325,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-decoder"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "criterion",
  "hex",
@@ -1339,11 +1342,11 @@ dependencies = [
 
 [[package]]
 name = "kiln-error"
-version = "0.3.5"
+version = "0.3.6"
 
 [[package]]
 name = "kiln-format"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "kani-verifier",
  "kiln-error",
@@ -1353,7 +1356,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-foundation"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "criterion",
  "hashbrown 0.17.1",
@@ -1371,7 +1374,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-host"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "kiln-error",
  "kiln-foundation",
@@ -1382,7 +1385,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-instructions"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "kiln-error",
  "kiln-foundation",
@@ -1394,7 +1397,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-intercept"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "chrono",
  "kani-verifier",
@@ -1407,7 +1410,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-logging"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "kiln-error",
  "kiln-foundation",
@@ -1417,7 +1420,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-math"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "kiln-error",
  "kiln-platform",
@@ -1426,11 +1429,11 @@ dependencies = [
 
 [[package]]
 name = "kiln-panic"
-version = "0.3.5"
+version = "0.3.6"
 
 [[package]]
 name = "kiln-platform"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "criterion",
  "kiln-error",
@@ -1440,7 +1443,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-runtime"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "criterion",
  "kiln-debug",
@@ -1460,7 +1463,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-sync"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "kani-verifier",
  "kiln-error",
@@ -1469,7 +1472,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-wasi"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "kiln-error",
  "kiln-format",
@@ -1482,7 +1485,7 @@ dependencies = [
 
 [[package]]
 name = "kilnd"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "kiln-component",
  "kiln-debug",
@@ -1760,9 +1763,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.2"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
 name = "num-integer"
@@ -2884,29 +2887,30 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.53"
+version = "0.3.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
+checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
 dependencies = [
  "deranged",
+ "itoa",
  "num-conv",
  "powerfmt",
- "serde_core",
+ "serde",
  "time-core",
  "time-macros",
 ]
 
 [[package]]
 name = "time-core"
-version = "0.1.9"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
+checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
 
 [[package]]
 name = "time-macros"
-version = "0.2.31"
+version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f"
+checksum = "3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49"
 dependencies = [
  "num-conv",
  "time-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ edition = "2024"
 rust-version = "1.85.0"
 license = "MIT"
 repository = "https://github.com/pulseengine/kiln"
-version = "0.3.5"
+version = "0.3.6"
 
 
 [workspace.dependencies]
@@ -37,22 +37,22 @@ anyhow = "1.0"
 wit-bindgen = "0.41.0"
 
 # Internal crate versions
-kiln-error = { path = "kiln-error", version = "0.3.5", default-features = false }
-kiln-sync = { path = "kiln-sync", version = "0.3.5", default-features = false }
-kiln-format = { path = "kiln-format", version = "0.3.5", default-features = false }
-kiln-foundation = { path = "kiln-foundation", version = "0.3.5", default-features = false }
-kiln-decoder = { path = "kiln-decoder", version = "0.3.5", default-features = false, features = ["std"] }
-kiln-debug = { path = "kiln-debug", version = "0.3.5", default-features = false }
-kiln-runtime = { path = "kiln-runtime", version = "0.3.5", default-features = false }
-kiln-logging = { path = "kiln-logging", version = "0.3.5", default-features = false }
-kiln-instructions = { path = "kiln-instructions", version = "0.3.5", default-features = false }
-kiln-component = { path = "kiln-component", version = "0.3.5", default-features = false }
-kiln-host = { path = "kiln-host", version = "0.3.5", default-features = false }
-kiln-intercept = { path = "kiln-intercept", version = "0.3.5", default-features = false }
-kiln-math = { path = "kiln-math", version = "0.3.5", default-features = false }
-kiln-platform = { path = "kiln-platform", version = "0.3.5", default-features = false }
-kiln-panic = { path = "kiln-panic", version = "0.3.5", default-features = false }
-kiln-wasi = { path = "kiln-wasi", version = "0.3.5", default-features = false }
+kiln-error = { path = "kiln-error", version = "0.3.6", default-features = false }
+kiln-sync = { path = "kiln-sync", version = "0.3.6", default-features = false }
+kiln-format = { path = "kiln-format", version = "0.3.6", default-features = false }
+kiln-foundation = { path = "kiln-foundation", version = "0.3.6", default-features = false }
+kiln-decoder = { path = "kiln-decoder", version = "0.3.6", default-features = false, features = ["std"] }
+kiln-debug = { path = "kiln-debug", version = "0.3.6", default-features = false }
+kiln-runtime = { path = "kiln-runtime", version = "0.3.6", default-features = false }
+kiln-logging = { path = "kiln-logging", version = "0.3.6", default-features = false }
+kiln-instructions = { path = "kiln-instructions", version = "0.3.6", default-features = false }
+kiln-component = { path = "kiln-component", version = "0.3.6", default-features = false }
+kiln-host = { path = "kiln-host", version = "0.3.6", default-features = false }
+kiln-intercept = { path = "kiln-intercept", version = "0.3.6", default-features = false }
+kiln-math = { path = "kiln-math", version = "0.3.6", default-features = false }
+kiln-platform = { path = "kiln-platform", version = "0.3.6", default-features = false }
+kiln-panic = { path = "kiln-panic", version = "0.3.6", default-features = false }
+kiln-wasi = { path = "kiln-wasi", version = "0.3.6", default-features = false }
 
 # Note: Safety level presets should be defined in individual crate Cargo.toml files
 # as workspace.features is not supported by Cargo

--- a/safety/requirements/functional-requirements.yaml
+++ b/safety/requirements/functional-requirements.yaml
@@ -982,3 +982,15 @@ artifacts:
       model: claude-opus-4-8
       timestamp: 2026-07-08T06:48:52Z
     release: v0.4.0
+
+  - id: SR-36
+    type: requirement
+    title: Workspace Cargo.lock is internally consistent (no re-resolution conflicts)
+    status: implemented
+    description: "The committed Cargo.lock must re-resolve without conflict. Dependabot #394 (tract-nnef 0.21.10→0.21.17) pulled tract-linalg 0.21.17 which requires time <0.3.42, but the lock pinned time 0.3.53 (via kani-verifier→os_info→plist ^0.3.30) — an internally inconsistent lock that builds --locked in some feature sets but fails any re-resolution (e.g. a version bump). Fix: pin time to 0.3.41 (satisfies both <0.3.42 and ^0.3.30). Root: dependabot dep-bump created a latent conflict CI didn't catch. Regression fix."
+    tags: [deps, cargo-lock, regression, ci]
+    provenance:
+      created-by: ai
+      model: claude-opus-4-8
+      timestamp: 2026-07-09T02:17:21Z
+    release: v0.3.6


### PR DESCRIPTION
Version bump 0.3.5 → 0.3.6 for the v0.3.6 release (SR-25/27/28 verified: pr-diagnostics fix, kilnd lib extraction, enforced merge gate).

**Also fixes a main regression:** dependabot #394 left the lock internally inconsistent (tract-linalg 0.21.17 needs `time <0.3.42` vs pinned `time 0.3.53`) — it builds `--locked` but fails re-resolution. Pinned time to 0.3.41. rivet SR-36.

Full workspace build green. This must pass the 8 required gates before merge → then I tag v0.3.6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)