### PR TITLE
chore(release): v0.4.0 — component E5DC2 fix + wasi filesystem/sandbox fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -254,7 +254,7 @@ checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 
 [[package]]
 name = "cargo-kiln"
-version = "0.3.6"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1260,7 +1260,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-async"
-version = "0.3.6"
+version = "0.4.0"
 dependencies = [
  "criterion",
  "kiln-error",
@@ -1268,7 +1268,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-build-core"
-version = "0.3.6"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1298,7 +1298,7 @@ version = "0.1.0"
 
 [[package]]
 name = "kiln-component"
-version = "0.3.6"
+version = "0.4.0"
 dependencies = [
  "criterion",
  "kiln-decoder",
@@ -1316,7 +1316,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-debug"
-version = "0.3.6"
+version = "0.4.0"
 dependencies = [
  "kiln-error",
  "kiln-format",
@@ -1325,7 +1325,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-decoder"
-version = "0.3.6"
+version = "0.4.0"
 dependencies = [
  "criterion",
  "hex",
@@ -1342,11 +1342,11 @@ dependencies = [
 
 [[package]]
 name = "kiln-error"
-version = "0.3.6"
+version = "0.4.0"
 
 [[package]]
 name = "kiln-format"
-version = "0.3.6"
+version = "0.4.0"
 dependencies = [
  "kani-verifier",
  "kiln-error",
@@ -1356,7 +1356,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-foundation"
-version = "0.3.6"
+version = "0.4.0"
 dependencies = [
  "criterion",
  "hashbrown 0.17.1",
@@ -1374,7 +1374,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-host"
-version = "0.3.6"
+version = "0.4.0"
 dependencies = [
  "kiln-error",
  "kiln-foundation",
@@ -1385,7 +1385,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-instructions"
-version = "0.3.6"
+version = "0.4.0"
 dependencies = [
  "kiln-error",
  "kiln-foundation",
@@ -1397,7 +1397,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-intercept"
-version = "0.3.6"
+version = "0.4.0"
 dependencies = [
  "chrono",
  "kani-verifier",
@@ -1410,7 +1410,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-logging"
-version = "0.3.6"
+version = "0.4.0"
 dependencies = [
  "kiln-error",
  "kiln-foundation",
@@ -1420,7 +1420,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-math"
-version = "0.3.6"
+version = "0.4.0"
 dependencies = [
  "kiln-error",
  "kiln-platform",
@@ -1429,11 +1429,11 @@ dependencies = [
 
 [[package]]
 name = "kiln-panic"
-version = "0.3.6"
+version = "0.4.0"
 
 [[package]]
 name = "kiln-platform"
-version = "0.3.6"
+version = "0.4.0"
 dependencies = [
  "criterion",
  "kiln-error",
@@ -1443,7 +1443,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-runtime"
-version = "0.3.6"
+version = "0.4.0"
 dependencies = [
  "criterion",
  "kiln-debug",
@@ -1463,7 +1463,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-sync"
-version = "0.3.6"
+version = "0.4.0"
 dependencies = [
  "kani-verifier",
  "kiln-error",
@@ -1472,7 +1472,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-wasi"
-version = "0.3.6"
+version = "0.4.0"
 dependencies = [
  "kiln-error",
  "kiln-format",
@@ -1485,7 +1485,7 @@ dependencies = [
 
 [[package]]
 name = "kilnd"
-version = "0.3.6"
+version = "0.4.0"
 dependencies = [
  "kiln-component",
  "kiln-debug",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ edition = "2024"
 rust-version = "1.85.0"
 license = "MIT"
 repository = "https://github.com/pulseengine/kiln"
-version = "0.3.6"
+version = "0.4.0"
 
 
 [workspace.dependencies]
@@ -37,22 +37,22 @@ anyhow = "1.0"
 wit-bindgen = "0.41.0"
 
 # Internal crate versions
-kiln-error = { path = "kiln-error", version = "0.3.6", default-features = false }
-kiln-sync = { path = "kiln-sync", version = "0.3.6", default-features = false }
-kiln-format = { path = "kiln-format", version = "0.3.6", default-features = false }
-kiln-foundation = { path = "kiln-foundation", version = "0.3.6", default-features = false }
-kiln-decoder = { path = "kiln-decoder", version = "0.3.6", default-features = false, features = ["std"] }
-kiln-debug = { path = "kiln-debug", version = "0.3.6", default-features = false }
-kiln-runtime = { path = "kiln-runtime", version = "0.3.6", default-features = false }
-kiln-logging = { path = "kiln-logging", version = "0.3.6", default-features = false }
-kiln-instructions = { path = "kiln-instructions", version = "0.3.6", default-features = false }
-kiln-component = { path = "kiln-component", version = "0.3.6", default-features = false }
-kiln-host = { path = "kiln-host", version = "0.3.6", default-features = false }
-kiln-intercept = { path = "kiln-intercept", version = "0.3.6", default-features = false }
-kiln-math = { path = "kiln-math", version = "0.3.6", default-features = false }
-kiln-platform = { path = "kiln-platform", version = "0.3.6", default-features = false }
-kiln-panic = { path = "kiln-panic", version = "0.3.6", default-features = false }
-kiln-wasi = { path = "kiln-wasi", version = "0.3.6", default-features = false }
+kiln-error = { path = "kiln-error", version = "0.4.0", default-features = false }
+kiln-sync = { path = "kiln-sync", version = "0.4.0", default-features = false }
+kiln-format = { path = "kiln-format", version = "0.4.0", default-features = false }
+kiln-foundation = { path = "kiln-foundation", version = "0.4.0", default-features = false }
+kiln-decoder = { path = "kiln-decoder", version = "0.4.0", default-features = false, features = ["std"] }
+kiln-debug = { path = "kiln-debug", version = "0.4.0", default-features = false }
+kiln-runtime = { path = "kiln-runtime", version = "0.4.0", default-features = false }
+kiln-logging = { path = "kiln-logging", version = "0.4.0", default-features = false }
+kiln-instructions = { path = "kiln-instructions", version = "0.4.0", default-features = false }
+kiln-component = { path = "kiln-component", version = "0.4.0", default-features = false }
+kiln-host = { path = "kiln-host", version = "0.4.0", default-features = false }
+kiln-intercept = { path = "kiln-intercept", version = "0.4.0", default-features = false }
+kiln-math = { path = "kiln-math", version = "0.4.0", default-features = false }
+kiln-platform = { path = "kiln-platform", version = "0.4.0", default-features = false }
+kiln-panic = { path = "kiln-panic", version = "0.4.0", default-features = false }
+kiln-wasi = { path = "kiln-wasi", version = "0.4.0", default-features = false }
 
 # Note: Safety level presets should be defined in individual crate Cargo.toml files
 # as workspace.features is not supported by Cargo

--- a/safety/requirements/architecture-decisions.yaml
+++ b/safety/requirements/architecture-decisions.yaml
@@ -470,7 +470,7 @@ artifacts:
       created-by: ai
       model: claude-opus-4-8
       timestamp: 2026-07-02T07:40:14Z
-    release: v0.4.0
+    release: v0.5.0
     links:
       - type: satisfies
         target: REQ_WITNESS_COV

--- a/safety/requirements/functional-requirements.yaml
+++ b/safety/requirements/functional-requirements.yaml
@@ -128,7 +128,7 @@ artifacts:
       relation must be accepted. The relation is currently wrong in BOTH
       directions (too permissive AND too strict). Issue #149.
     status: proposed
-    release: v0.4.0
+    release: v0.5.0
     tags: [wasm-gc, reference-types, subtyping, spec-conformance, release-v0.3.5]
     links:
       - type: derives-from
@@ -910,12 +910,12 @@ artifacts:
       created-by: ai
       model: claude-opus-4-8
       timestamp: 2026-07-02T07:40:03Z
-    release: v0.4.0
+    release: v0.5.0
 
   - id: SR-30
     type: requirement
     title: wasi:cli/run export resolution honors the instance-import offset in the component-instance index space
-    status: implemented
+    status: verified
     description: "resolve_command_entry shall resolve a wasi:cli/run instance export's backing instance by walking the component-instance index space (0..K-1 imported instances, K.. defined instances), offsetting export.idx by the instance-import count K before indexing parsed.instances — and return None (legacy path) if the run instance is an imported instance (export.idx < K). Today it uses export.idx directly, so a meld-fused component with instance-import stubs (K>0) fails with E5DC2 out-of-bounds. Differential oracle: wasmtime 41.0.0 runs the same fused.wasm. Must keep #364's K=0 fixture green. Issue #382 (split from #375)."
     tags: [component-model, instantiation, wasi-cli-run, index-space, bug]
     fields:
@@ -958,7 +958,7 @@ artifacts:
   - id: SR-33
     type: requirement
     title: kilnd --wasi-fs/--dir actually grants filesystem access (no silent no-op)
-    status: implemented
+    status: verified
     description: "When kilnd is given --wasi-fs/--dir <path>, the WASI filesystem capability (read_access, directory_access, and write_access for writable mappings) must actually be enabled so a Preview2 guest can read/list/open files under the preopen — matching wasmtime's --dir. Today kilnd builds WasiCapabilities::minimal() and enables env/random/io but never filesystem access, so --wasi-fs registers an unusable preopen and every op returns noent (silent no-op, violates FAIL-LOUD). Root cause: kilnd/src/lib.rs capability build + dispatcher.rs:663 directory_access gate. Differential oracle: wasmtime 42 reads the same dir. Issue #392."
     tags: [kilnd, wasi, filesystem, bug]
     fields:
@@ -981,7 +981,7 @@ artifacts:
       created-by: ai
       model: claude-opus-4-8
       timestamp: 2026-07-08T06:48:52Z
-    release: v0.4.0
+    release: v0.5.0
 
   - id: SR-36
     type: requirement

--- a/safety/requirements/roadmap-requirements.yaml
+++ b/safety/requirements/roadmap-requirements.yaml
@@ -459,3 +459,17 @@ artifacts:
         run must be satisfied by the WasiDispatcher set (filesystem/cli/clocks/io/
         random); syscall-heavy fused cores needing interfaces outside that set are
         the #340-item-3 stub gap and fail loud at instantiate, not faked here.
+
+  - id: SR-35
+    type: requirement
+    title: kiln is a verified reference oracle, validated by differential testing against an external verified interpreter
+    status: proposed
+    description: "Invest kiln from 'an interpreter that works' into a reference executable oracle: (1) 'runs identically on kiln and on the shipped/dissolved path' becomes a standard differential gate for the dissolve pipeline (kiln is the wasm-side reference; gale already differentials dissolved-native vs wasmtime); (2) validate kiln's own correctness independently by differential-testing against an EXTERNAL, independently-verified Wasm reference interpreter (e.g. WasmRef-Isabelle, PLDI 2023) — an interpreter you also wrote is not its own oracle. Spec-as-machine-oracle pattern; verification-approach direction, not a defect. Relates to #283 (positioning vs Wasmtime TCB) and #280 (Verus). Issue #401."
+    tags: [verification, oracle, differential-testing, research, direction]
+    fields:
+      upstream-ref: https://github.com/pulseengine/kiln/issues/401
+    provenance:
+      created-by: ai
+      model: claude-opus-4-8
+      timestamp: 2026-07-08T22:48:04Z
+    release: v0.7.0


### PR DESCRIPTION
Version bump 0.3.6 → 0.4.0. Kiln's v0.4.0 scope is **verified**: SR-30 + SR-33.

- **SR-30** — wasi:cli/run export resolution honors the instance-import offset; fixes E5DC2 on meld-fused command components (#382). Unit-tested.
- **SR-33** — kilnd `--wasi-fs`/`--dir` grants filesystem access (no silent no-op) + closes a sandbox-escape hazard (#392). Unit-tested.

**Deferred to v0.5.0** (unworked/large): SR-29 (cross-core imports), SR-34 (witness-instrumented core load), REQ_GC_SUBTYPING, SM-MEM-003.

`gale:REQ-OS-SYSCALL-001` shown in `rivet release status v0.4.0` is a **separate-repo (gale) artifact** sharing the v0.4.0 version label — not kiln's release scope, and not a blocker for kiln's tag.

Must pass the 8 required gates → then I tag v0.4.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)