### PR TITLE
chore(release): v0.4.1 — component --wasi-fs read/list fix (closes #405)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -254,7 +254,7 @@ checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 
 [[package]]
 name = "cargo-kiln"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1260,7 +1260,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-async"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "criterion",
  "kiln-error",
@@ -1268,7 +1268,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-build-core"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1298,7 +1298,7 @@ version = "0.1.0"
 
 [[package]]
 name = "kiln-component"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "criterion",
  "kiln-decoder",
@@ -1316,7 +1316,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-debug"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "kiln-error",
  "kiln-format",
@@ -1325,7 +1325,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-decoder"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "criterion",
  "hex",
@@ -1342,11 +1342,11 @@ dependencies = [
 
 [[package]]
 name = "kiln-error"
-version = "0.4.0"
+version = "0.4.1"
 
 [[package]]
 name = "kiln-format"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "kani-verifier",
  "kiln-error",
@@ -1356,7 +1356,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-foundation"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "criterion",
  "hashbrown 0.17.1",
@@ -1374,7 +1374,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-host"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "kiln-error",
  "kiln-foundation",
@@ -1385,7 +1385,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-instructions"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "kiln-error",
  "kiln-foundation",
@@ -1397,7 +1397,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-intercept"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "chrono",
  "kani-verifier",
@@ -1410,7 +1410,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-logging"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "kiln-error",
  "kiln-foundation",
@@ -1420,7 +1420,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-math"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "kiln-error",
  "kiln-platform",
@@ -1429,11 +1429,11 @@ dependencies = [
 
 [[package]]
 name = "kiln-panic"
-version = "0.4.0"
+version = "0.4.1"
 
 [[package]]
 name = "kiln-platform"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "criterion",
  "kiln-error",
@@ -1443,7 +1443,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-runtime"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "criterion",
  "kiln-debug",
@@ -1463,7 +1463,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-sync"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "kani-verifier",
  "kiln-error",
@@ -1472,7 +1472,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-wasi"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "kiln-error",
  "kiln-format",
@@ -1486,7 +1486,7 @@ dependencies = [
 
 [[package]]
 name = "kilnd"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "kiln-component",
  "kiln-debug",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ edition = "2024"
 rust-version = "1.85.0"
 license = "MIT"
 repository = "https://github.com/pulseengine/kiln"
-version = "0.4.0"
+version = "0.4.1"
 
 
 [workspace.dependencies]
@@ -37,22 +37,22 @@ anyhow = "1.0"
 wit-bindgen = "0.41.0"
 
 # Internal crate versions
-kiln-error = { path = "kiln-error", version = "0.4.0", default-features = false }
-kiln-sync = { path = "kiln-sync", version = "0.4.0", default-features = false }
-kiln-format = { path = "kiln-format", version = "0.4.0", default-features = false }
-kiln-foundation = { path = "kiln-foundation", version = "0.4.0", default-features = false }
-kiln-decoder = { path = "kiln-decoder", version = "0.4.0", default-features = false, features = ["std"] }
-kiln-debug = { path = "kiln-debug", version = "0.4.0", default-features = false }
-kiln-runtime = { path = "kiln-runtime", version = "0.4.0", default-features = false }
-kiln-logging = { path = "kiln-logging", version = "0.4.0", default-features = false }
-kiln-instructions = { path = "kiln-instructions", version = "0.4.0", default-features = false }
-kiln-component = { path = "kiln-component", version = "0.4.0", default-features = false }
-kiln-host = { path = "kiln-host", version = "0.4.0", default-features = false }
-kiln-intercept = { path = "kiln-intercept", version = "0.4.0", default-features = false }
-kiln-math = { path = "kiln-math", version = "0.4.0", default-features = false }
-kiln-platform = { path = "kiln-platform", version = "0.4.0", default-features = false }
-kiln-panic = { path = "kiln-panic", version = "0.4.0", default-features = false }
-kiln-wasi = { path = "kiln-wasi", version = "0.4.0", default-features = false }
+kiln-error = { path = "kiln-error", version = "0.4.1", default-features = false }
+kiln-sync = { path = "kiln-sync", version = "0.4.1", default-features = false }
+kiln-format = { path = "kiln-format", version = "0.4.1", default-features = false }
+kiln-foundation = { path = "kiln-foundation", version = "0.4.1", default-features = false }
+kiln-decoder = { path = "kiln-decoder", version = "0.4.1", default-features = false, features = ["std"] }
+kiln-debug = { path = "kiln-debug", version = "0.4.1", default-features = false }
+kiln-runtime = { path = "kiln-runtime", version = "0.4.1", default-features = false }
+kiln-logging = { path = "kiln-logging", version = "0.4.1", default-features = false }
+kiln-instructions = { path = "kiln-instructions", version = "0.4.1", default-features = false }
+kiln-component = { path = "kiln-component", version = "0.4.1", default-features = false }
+kiln-host = { path = "kiln-host", version = "0.4.1", default-features = false }
+kiln-intercept = { path = "kiln-intercept", version = "0.4.1", default-features = false }
+kiln-math = { path = "kiln-math", version = "0.4.1", default-features = false }
+kiln-platform = { path = "kiln-platform", version = "0.4.1", default-features = false }
+kiln-panic = { path = "kiln-panic", version = "0.4.1", default-features = false }
+kiln-wasi = { path = "kiln-wasi", version = "0.4.1", default-features = false }
 
 # Note: Safety level presets should be defined in individual crate Cargo.toml files
 # as workspace.features is not supported by Cargo


### PR DESCRIPTION
Version bump **0.4.0 → 0.4.1**. Ships the complete component filesystem read/list fix for WASI Preview2 components under `kilnd --wasi --component --wasi-fs`:

- **SR-37** (#406): `get-directories` returns a guest-usable preopen list (cabi_realloc-backed).
- **SR-38** (#407): file **read** (`blocking-read`) returns bytes in a guest-owned buffer with offset/EOF tracking.
- **SR-39** (#409): directory **enumeration** (`read-directory` / `read-directory-entry`).

Together a preview2 component now reads *and* lists files under a preopen, matching `wasmtime run --dir`. **Closes #405.**

All three verified end-to-end against the wasmtime differential oracle and by unit oracles; merged individually through the required gate. This PR is the version bump + lock sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)