### PR TITLE
docs(rivet): wasm memory-bounding story — AD-WCMC-001 (scry proves the hard half, no new companion)

### DIFF
--- a/rivet.yaml
+++ b/rivet.yaml
@@ -79,3 +79,11 @@ externals:
     path: /Volumes/Home/git/pulseengine/sigil
     ref: main
     prefix: sigil
+
+  scry:
+    # Sound abstract interpretation for WebAssembly (DO-333 leg). Provides the
+    # worst-case shadow-stack / longest-path bounds that answer the hard half of
+    # "how much memory an arbitrary wasm can consume" (AD-WCMC-001).
+    git: https://github.com/pulseengine/scry.git
+    ref: main
+    prefix: scry

--- a/safety/requirements/architecture-decisions.yaml
+++ b/safety/requirements/architecture-decisions.yaml
@@ -539,6 +539,23 @@ artifacts:
         memory-budget pass), synth (per-function native frame sizes for the
         embedded WCSU), sigil (attests the manifest). Registered scry in rivet
         externals for cross-linking.
+      embedded-trust-chain: >
+        scry runs HOST-side (build time) — it is NOT on the embedded path, so the
+        target cannot recompute the bounds; it must instead TRUST them, which
+        means they travel SIGNED and are VERIFIED ON-TARGET. Chain: scry computes
+        the bounds -> written into the kiln.resource_limits custom section ->
+        sigil signs the module INCLUDING that section (sigil embeds signatures in
+        the wasm and already has "verify image size before signing" precedent) ->
+        the embedded target verifies the signature OFFLINE, ON-TARGET, KEY-BASED,
+        then reject-at-loads off the SIGNATURE-VERIFIED size info (never the raw
+        unsigned claim). Two sigil ADJUSTMENTS are required and are the gap: (1) a
+        no_std sigil VERIFIER library (sigil is std-only today — grep finds no
+        no_std/#![no_std]; the verifier must compile for thumbv7em to run on
+        gale/gust), and (2) KEY-BASED offline verification only — sigil's own
+        recorded residual is "offline keyless verification impossible" (Sigstore/
+        keyless needs network), so air-gapped embedded uses embedded public keys.
+        The size/WCMC manifest must be a SIGNED field of the attestation, not an
+        unsigned custom section. Tracked as a sigil coordination issue.
       upstream-ref: https://github.com/pulseengine/kiln/issues/415
     provenance:
       created-by: ai

--- a/safety/requirements/architecture-decisions.yaml
+++ b/safety/requirements/architecture-decisions.yaml
@@ -476,3 +476,72 @@ artifacts:
         target: REQ_WITNESS_COV
       - type: derives-from
         target: REQ_WITNESS_COV
+
+  - id: AD-WCMC-001
+    type: design-decision
+    title: Bounding arbitrary-wasm memory (WCMC) — scry proves the hard half; kiln plumbs it; NO new companion
+    status: proposed
+    description: >
+      How much memory an arbitrary wasm module can consume (the crux for fixed
+      embedded RAM on gale/gust) is answered by COMPOSING existing PulseEngine
+      tools, NOT by building a new one. Decomposition (measured against
+      kiln-runtime): (a) DECLARED-LIMITS half — guest linear-memory min/max,
+      table min/max, global count, data/element bytes, per-function locals and
+      the static max operand-stack height — all exactly computable from the
+      module bytes in one decode pass (trivial, kiln already decodes it);
+      (b) STACK / longest-path half — worst-case call depth and shadow-stack
+      usage — the analytically hard, partly-undecidable part (recursion), which
+      is exactly what scry already does: "sound abstract interpretation for
+      WebAssembly (the DO-333 leg)", providing shadow-stack bounds + longest-path
+      attribution + budget_from_bound. So scry ALREADY answers the hard half; the
+      memory analog of WCET is scry(space) alongside spar's RTA(time).
+    tags: [memory, wcmc, bounding, embedded, scry, verification, direction]
+    links:
+      - type: satisfies
+        target: REQ_FUNC_003
+    fields:
+      rationale: >
+        Two fable subagents (2026-07-11) analyzed this. The memory-bounding agent
+        recommended a companion analyzer; the maintainer's pointer that "scry
+        already answers a lot of the memory story" resolves it — scry IS that
+        analyzer for the stack half (the part the agent itself flagged as "where
+        a real tool adds value"; the declared-limits half is trivial). spar
+        already has the CONSUMER (a memory-budget pass, memory_budget.rs: Σ(code+
+        data) ≤ memory_size) but lacks a source of truth for wasm component
+        sizes (hand-entered AADL today) — scry-derived bounds make that property
+        DERIVED + attested, exactly as WCET feeds RTA. Pipeline: meld → scry
+        (sound bounds) + kiln (declared-limits extraction) → the EXISTING
+        kiln.resource_limits custom section (kiln-decoder/src/
+        resource_limits_section.rs; carries max_memory_usage, max_call_depth,
+        qualification_hash, ASIL) → {kilnd reject-at-load | synth sizes .bss/
+        stack} → sigil co-signs module+manifest → spar closes the space leg,
+        RTA the time leg → rivet traces the fits verdict. Reject-at-load moves a
+        fixed-RAM overrun from "mid-mission trap in the field" to "integration
+        failure on the bench" — the whole reason WCET analysis exists, applied to
+        space.
+      implementation-plan: >
+        Kiln-side plumbing (concrete, near-term — the soundness gaps the analysis
+        found, all in the SR-41 family): (1) reject-at-load when a module's
+        declared memory `min` exceeds the --memory cap (today Memory::new
+        eagerly allocates `min` BEFORE the SR-41 grow cap applies — the cap is
+        set post-instantiate); (2) add a runtime element cap to Table mirroring
+        Memory::runtime_max_pages (table.grow is UNCAPPED today — same class of
+        bug SR-41 fixed for memory); (3) WIRE the dead kiln.resource_limits
+        section — capability_engine.rs:561 extracts it into _resource_config with
+        a literal `// TODO: Apply resource limits`, so the whole manifest pipe
+        exists but is disconnected; (4) restructure the 8 MiB HeapProvider that is
+        CLONED per-function/per-instruction (bounded_runtime_infra.rs:37 +
+        module.rs) so decoded-module RSS is O(|wasm|) not ~8 MiB × n_functions —
+        until then any interpreter WCMC is dominated by an artifact. These become
+        SR-43/44/45 + a perf fix once SR-41/42 (#417) land.
+      cross-repo: >
+        scry (producer of stack/longest-path bounds), spar (consumer:
+        memory-budget pass), synth (per-function native frame sizes for the
+        embedded WCSU), sigil (attests the manifest). Registered scry in rivet
+        externals for cross-linking.
+      upstream-ref: https://github.com/pulseengine/kiln/issues/415
+    provenance:
+      created-by: ai
+      model: claude-opus-4-8
+      timestamp: 2026-07-11T09:00:00Z
+    release: v0.6.0

--- a/safety/requirements/architecture-decisions.yaml
+++ b/safety/requirements/architecture-decisions.yaml
@@ -556,6 +556,19 @@ artifacts:
         keyless needs network), so air-gapped embedded uses embedded public keys.
         The size/WCMC manifest must be a SIGNED field of the attestation, not an
         unsigned custom section. Tracked as a sigil coordination issue.
+      loader-integration: >
+        CRITICAL shape: the no_std sigil verifier is a LIBRARY compiled INTO
+        kiln's embedded LOADER — NOT a separate verifier component/tool that sits
+        next to the loader and is invoked by it. verify-signature +
+        check-signed-size-fits-budget + reject-at-load are ONE inseparable
+        admission step inside kiln's module-load path (the on-board interpreter's
+        load_module). Rationale: (a) verification is then NON-BYPASSABLE — you
+        physically cannot admit a module without verifying it, no code path loads
+        unverified bytes; (b) the TCB stays a SINGLE fused loader instead of
+        loader + separate verifier + IPC between them, which matters for the
+        minimal-TCB argument (gust: TCB = ~4-fn shim). So the sigil ask is a
+        no_std verify LIBRARY designed to be embedded into a host loader, and
+        kiln's embedded load path calls it inline before instantiation.
       upstream-ref: https://github.com/pulseengine/kiln/issues/415
     provenance:
       created-by: ai


### PR DESCRIPTION
Captures the analysis of the maintainer's crux — *"how much memory an arbitrary wasm can be"* — from two deep fable subagents, resolved by the pointer that **scry already answers a lot of it**.

## The answer: compose, don't build

The problem splits in two:
- **Declared-limits half** — memory/table min/max, globals, data bytes, per-function locals + static max operand-stack height. All exactly computable from the module bytes in one decode pass. Trivial.
- **Stack / longest-path half** — worst-case call depth + shadow-stack usage. The analytically hard, partly-undecidable part (recursion).

**scry** ("sound abstract interpretation for WebAssembly — the DO-333 leg") **already does the hard half**: shadow-stack bounds, longest-path attribution, `budget_from_bound`. So **no new companion** — the memory analog of WCET is **scry(space) alongside spar's RTA(time)**. spar already has the *consumer* (a memory-budget pass) but hand-enters wasm sizes; scry-derived bounds make that property derived + attested.

**Pipeline**: `meld → scry (bounds) + kiln (declared limits) → the existing kiln.resource_limits section → {kilnd reject-at-load | synth sizes .bss/stack} → sigil attests → spar closes the space leg → rivet traces the fits verdict.`

## Concrete kiln soundness gaps found (SR-41 family)
1. **Reject-at-load** when declared memory `min` > `--memory` cap — today `Memory::new` eagerly allocates `min` *before* the SR-41 grow cap applies.
2. **Table runtime cap** — `table.grow` is uncapped (same class of bug SR-41 just fixed for memory).
3. **Wire the dead `kiln.resource_limits` section** — `capability_engine.rs:561` extracts it then `// TODO: Apply resource limits`. The whole manifest pipe exists, disconnected.
4. **Fix the 8 MiB `HeapProvider` cloned per-function** — decoded-module RSS ≈ 8 MiB × n_functions today, which dominates any interpreter WCMC.

These become SR-43/44/45 (+ a perf fix) once SR-41/42 (#417) land. Registered **scry** in rivet externals. `rivet validate` = PASS. Tracks #415.

🤖 Generated with [Claude Code](https://claude.com/claude-code)