### PR TITLE
docs(rivet): AD-LOADER-VERIFY-001 — sync the sigil on-target verify contract (kiln#421)

### DIFF
--- a/safety/requirements/architecture-decisions.yaml
+++ b/safety/requirements/architecture-decisions.yaml
@@ -476,3 +476,55 @@ artifacts:
         target: REQ_WITNESS_COV
       - type: derives-from
         target: REQ_WITNESS_COV
+
+  - id: AD-LOADER-VERIFY-001
+    type: design-decision
+    title: On-target admission — kiln's loader verifies a sigil signature before trusting kiln.resource_limits (fail-closed)
+    status: proposed
+    description: >
+      The kiln embedded loader shall VERIFY a module's sigil signature (via sigil's
+      no_std verify-core, compiled INTO the loader) BEFORE trusting the signed
+      kiln.resource_limits bounds it uses for reject-at-load — because scry's bounds
+      are computed host-side and the fixed-RAM target cannot recompute them, so it
+      must trust a signed, on-target-verified bound, never a forgeable raw claim.
+      FAIL-CLOSED contract (agreed with sigil, kiln#421 / sigil#187): the loader
+      REJECTS the module if (a) the signature is invalid, OR (b) the
+      kiln.resource_limits section is absent, OR (c) a signed bound
+      (max_memory_usage / max_call_depth / …) exceeds the provisioned RAM/stack
+      budget. This is the boot-admission gate; it composes with SR-43 (reject-at-load
+      on declared min) and SR-41/SR-44 (runtime caps). Implements the AD-WCMC-001
+      embedded trust chain.
+    tags: [security, loader, embedded, sigil, attestation, reject-at-load, cross-repo, direction]
+    links:
+      - type: satisfies
+        target: REQ_FUNC_003
+    fields:
+      rationale: >
+        Confirmed cross-repo (kiln#421): (1) the loader hook already exists —
+        extract_resource_limits_from_binary (kiln-foundation/src/execution.rs:144,
+        called at capability_engine.rs:559); wiring it to call sigil-verify-first IS
+        SR-45's kiln-side work, extended. (2) cargo-kiln embed-limits already exists
+        (cargo-kiln/src/commands/embed_limits.rs) and runs as a PRE-SIGN step so the
+        bounds land inside sigil's signed hash. (3) the existing ResourceLimitsSection
+        (v1, no_std/BoundedMap) is reused verbatim — sigil's whole-module signature
+        already covers it, no new manifest. sigil↔kiln boundary is a Rust staticlib
+        for thumbv7em (mirroring kiln-async), no C ABI. Verification is fused into
+        load_module (non-bypassable) — see AD-WCMC-001 loader-integration.
+      pipeline: >
+        meld -> cargo-kiln embed-limits (writes kiln.resource_limits) -> sigil sign
+        (embeds Ed25519 signature) -> [target] kiln loader { sigil no_std verify ->
+        trust bounds -> fit-check -> admit | reject } -> run.
+      cross-repo: >
+        sigil delivers: sigil:REQ-15 (no_std verify-core staticlib for thumbv7em,
+        v0.10.0), sigil:REQ-16 (signed reject-at-load of kiln.resource_limits,
+        v0.11.0), sigil:DD-8 (secure-boot verify profile: key-based Ed25519,
+        HW-preferred/SW-fallback), under sigil:FEAT-12. no_std crypto spike cleared
+        (ed25519-compact + ct-codecs build no_std for thumbv7em with pubkey verify).
+        Key-based only (keyless/Sigstore offline impossible). gale#164 covers HW
+        Ed25519 + trust-anchor provisioning. kiln#421 / sigil#187.
+      upstream-ref: https://github.com/pulseengine/kiln/issues/421
+    provenance:
+      created-by: ai
+      model: claude-opus-4-8
+      timestamp: 2026-07-11T11:00:00Z
+    release: v0.6.0


### PR DESCRIPTION
Syncs the sigil-side plan (sigil#187 → kiln#421) into kiln's rivet as a traced contract.

**The contract (fail-closed):** kiln's embedded loader verifies a module's sigil signature — via **sigil's no_std verify-core, compiled INTO the loader** — *before* trusting the signed `kiln.resource_limits` bounds it uses for reject-at-load. Reject if: signature invalid **OR** section absent **OR** a signed bound exceeds the provisioned RAM/stack budget. scry computes the bounds host-side; the target can't recompute them, so it must trust a *signed, on-target-verified* bound, never a forgeable claim.

**Confirmed cross-repo facts** (all grounded in code):
- Loader hook already exists: `extract_resource_limits_from_binary` (execution.rs:144) — wiring it to verify-first is SR-45's work, extended.
- `cargo-kiln embed-limits` already exists — runs pre-sign so bounds land in the signed hash.
- `ResourceLimitsSection` (v1, no_std) reused verbatim; sigil's whole-module signature covers it.
- Boundary = Rust `staticlib` for `thumbv7em` (mirrors kiln-async).

**sigil delivers:** `REQ-15` (no_std verify-core staticlib, v0.10.0), `REQ-16` (signed reject-at-load, v0.11.0), `DD-8` (key-based Ed25519, HW-preferred/SW-fallback). The no_std crypto spike already cleared the dep wall (`ed25519-compact` + `ct-codecs`).

Implements the **AD-WCMC-001** embedded trust chain; extends **SR-45**. `rivet validate` = 0 errors. Cross-links to sigil artifacts land once they're on sigil's main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)