### PR TITLE
ci: scope Pages concurrency per-ref so the required `build` context always reports

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,10 +26,16 @@ permissions:
   pages: write
   id-token: write
 
-# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
-# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+# Serialize PRODUCTION deploys to Pages, but NOT the per-PR build checks.
+# The `build` job here is a REQUIRED status check (branch protection); a single
+# global "pages" group made every PR's build queue/skip against every other PR's
+# and against main, so the required `build` context frequently ended up
+# cancelled/skipped and blocked otherwise-green PRs. Scope the group per-ref so
+# each PR (refs/pull/N/merge) builds independently while all main deploys still
+# share one group (refs/heads/main). cancel-in-progress stays false so deploys
+# complete.
 concurrency:
-  group: "pages"
+  group: "pages-${{ github.ref }}"
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
## Problem
The required `build` status check (branch protection) comes from **publish.yml** ("Deploy Documentation to Pages"). Its concurrency group was a single global `"pages"` shared across *every* PR and main. So one PR's `build` run queued/skipped against another's → the required `build` context frequently ended up **cancelled/skipped**, blocking otherwise-green PRs with *"base branch policy prohibits the merge"* despite zero failures (hit repeatedly on #416/#418/#420/#422).

## Fix
Scope the concurrency group per-ref:
```diff
-  group: "pages"
+  group: "pages-${{ github.ref }}"
```
Each PR (`refs/pull/N/merge`) now builds independently; all main deploys still share one group (`refs/heads/main`) with `cancel-in-progress: false` so production deploys complete. `github.ref` is a safe git ref (not user-controlled input, and used only as a group name — no `run:` injection surface).

This is one of the two durable CI-hardening fixes (the other is sharding the rivet YAML sources to stop concurrent-artifact-PR conflicts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)