### PR TITLE
docs(verification): stop citing frozen spec numbers in prose — point to the CI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,14 +115,15 @@ cargo test --workspace
 kiln's correctness rests on **conformance testing and bounded model checking** &mdash;
 not (yet) a mechanized proof of its WebAssembly execution semantics. We state that plainly.
 
-- **WebAssembly spec suite:** **261 / 280 official `.wast` files pass (93.2%)**; within
-  the files that load, **65,618 / 65,633 executed assertions pass (99.98%)**, across
-  2,370 modules. We lead with the file ratio on purpose: a file that fails to *parse*
-  (the `custom-descriptors` proposal) contributes zero assertions to both sides of the
-  99.98%, so only the file count reflects it &mdash; the assertion rate alone would
-  flatter exactly where it shouldn't. Known gaps: validation strictness on some
-  GC-proposal cases (a few should-be-invalid modules are currently accepted) and the
-  `custom-descriptors` parse failure. (`cargo-kiln testsuite --run-wast`.)
+- **WebAssembly spec suite:** the current pass rate is **re-derived by CI on every
+  run and shown in the badge above** (files passed / total · executed-assertion rate),
+  so the number here can't drift from the evidence. We report the **file ratio** as the
+  headline on purpose: a file that fails to *parse* (e.g. the `custom-descriptors`
+  proposal) contributes zero assertions to both sides of the assertion rate, so only
+  the file count reflects it &mdash; the assertion rate alone would flatter exactly
+  where it shouldn't. Known gaps: validation strictness on some GC-proposal cases (a few
+  should-be-invalid modules are currently accepted) and the `custom-descriptors` parse
+  failure. Reproduce locally with `cargo-kiln testsuite --run-wast`.
 - **Unit tests:** 300+ across the interpreter core.
 - **Kani (CBMC bounded model checking):** proof harnesses on *selected* safety-relevant
   components (foundation collections, arithmetic overflow, LEB128, host dispatch,


### PR DESCRIPTION
Follow-up to #423. The dynamic spec-suite badge is working — it re-derived the live rate from CI (now **263/281 files · 99.20% asserts**), which is exactly its job. But the README *prose* still hard-coded the seed values (`261/280`, `65,618/65,633 (99.98%)`), so the two diverged the moment the testsuite pin advanced.

That's the anti-pattern the badge exists to kill (*a number typed in prose goes stale*). This replaces the frozen figures with a pointer to the CI-re-derived badge, keeping the durable qualitative argument (lead with the file ratio; a parse-failure hides in the assertion rate; known gaps). No number in prose can diverge from the evidence anymore.

`claim-check` stays green (it binds no numbers). Only `README.md` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)