### PR TITLE
chore(rivet,ci): triage #443 (SR-53) + remove vestigial Dagger (closes #448)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,6 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
-  # RUST_LOG: "info,cargo_kiln=debug,dagger_sdk=debug" # Optional: for more detailed Dagger logs
 
 jobs:
   ci_checks_and_docs:
@@ -41,11 +40,6 @@ jobs:
             ~/.cargo/git/db/
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-      - name: Dagger Engine Cache
-        uses: actions/cache@v6
-        with:
-          path: ~/.cache/dagger
-          key: ${{ runner.os }}-dagger-engine
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -59,17 +53,6 @@ jobs:
       - name: Run CI Integrity Checks (lint, fmt, deny, spell, headers, etc.)
         run: cargo-kiln verify --detailed
         continue-on-error: true  # Safety verification has pre-existing findings being addressed
-      - name: Setup Java for PlantUML (if CheckDocsStrict Dagger pipeline needs it from host - unlikely)
-        uses: actions/setup-java@v5
-        if: false # Assuming Dagger pipeline for docs is self-contained
-        with:
-          distribution: 'temurin'
-          java-version: '17'
-      - name: Install Python & PlantUML (if CheckDocsStrict Dagger pipeline needs them - unlikely)
-        if: false # Assuming Dagger pipeline for docs is self-contained
-        run: |
-          sudo apt-get update && sudo apt-get install -y python3-pip plantuml
-          pip3 install -r docs/source/requirements.txt
       - name: Run Strict Documentation Check
         run: cargo-kiln docs --private
       - name: Initialize Requirements File (if missing)
@@ -149,11 +132,6 @@ jobs:
             ~/.cargo/git/db/
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-      - name: Dagger Engine Cache
-        uses: actions/cache@v6
-        with:
-          path: ~/.cache/dagger
-          key: ${{ runner.os }}-dagger-engine
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -295,11 +273,6 @@ jobs:
             ~/.cargo/git/db/
             target/
           key: ${{ runner.os }}-cargo-extended-${{ hashFiles('**/Cargo.lock') }}
-      - name: Dagger Engine Cache
-        uses: actions/cache@v6
-        with:
-          path: ~/.cache/dagger
-          key: ${{ runner.os }}-dagger-engine-extended
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,24 +48,7 @@ jobs:
         with:
           # We need history to get tags
           fetch-depth: 0
-      
-      - name: Setup Dagger CLI
-        run: |
-          curl -L https://dl.dagger.io/dagger/install.sh | sh
-          echo "$HOME/.dagger/bin" >> $GITHUB_PATH
-          
-      - name: Start Docker service (required for Dagger)
-        run: |
-          # Ensure Docker is running
-          sudo systemctl status docker || sudo systemctl start docker
-          docker version
-      - name: Check Dagger version
-        run: |
-          export PATH="$(pwd)/bin:$PATH"
-          pwd
-          find . -name "dagger"
-          dagger version
-          echo $PATH          
+
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -121,33 +104,22 @@ jobs:
           # Ensure cargo-kiln is compiled and installed
           cargo build --package cargo-kiln
           cargo install --path cargo-kiln --force
-          # Add Dagger to PATH
-          export PATH="$HOME/.dagger/bin:$(pwd)/bin:$PATH"
-          echo $PATH
           # Run coverage analysis in best-effort mode for documentation
           echo "Running coverage analysis in best-effort mode..."
           cargo-kiln coverage --html --best-effort
         env:
           RUST_LOG: info
           RUST_BACKTRACE: 1
-          # Dagger configuration
-          _EXPERIMENTAL_DAGGER_CLOUD_TOKEN: ""
-          DAGGER_LOG_LEVEL: info
           # CI environment flag
           CI: true
 
       - name: Build documentation via cargo-kiln
         run: |
           echo "Building documentation for versions: ${{ env.VERSIONS_TO_BUILD }}"
-          export PATH="$HOME/.dagger/bin:$(pwd)/bin:$PATH"
           cargo-kiln docs --open --private --output-dir ./docs_output
         env:
           RUST_LOG: info
           RUST_BACKTRACE: 1
-          # Dagger configuration
-          _EXPERIMENTAL_DAGGER_CLOUD_TOKEN: ""
-          DAGGER_LOG_LEVEL: info
-          DAGGER_LOG_FORMAT: plain
           # CI environment flag
           CI: true
 

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -142,5 +142,4 @@ jobs:
           # Exclude packages with undetected licenses that we've manually verified
           # Using PURL format: pkg:cargo/package@version
           allow-dependencies-licenses: |
-            pkg:cargo/chrono@0.4.*, 
-            pkg:cargo/dagger-sdk@0.11.10
+            pkg:cargo/chrono@0.4.*

--- a/safety/requirements/functional-requirements/SR-53.yaml
+++ b/safety/requirements/functional-requirements/SR-53.yaml
@@ -1,0 +1,21 @@
+artifacts:
+- id: SR-53
+  type: requirement
+  title: kilnd rejects an arg-arity mismatch instead of zero-filling params and reporting a wrong result as success
+  status: proposed
+  description: 'kilnd invokes an exported function with ZERO-FILLED arguments when params cannot be supplied, and reports the resulting wrong value as success (exit 0) — argument arity is never checked. Measured (HEAD cab5b3a0): a (func (export "addone") (param i32) (result i32)) invoked as `kilnd mod.wasm --function addone` returns I32(1) (= addone(0), proving the missing param was zero-filled, not trapped) and prints "✓ completed successfully"; wasmtime --invoke addone mod.wasm 5 correctly returns 6. There is no CLI mechanism to pass wasm function params at all (--wasi-arg is WASI argv, not wasm params), so ANY function with >=1 param can only ever be called with zeroed args and its wrong result printed as a definite answer. Same "fabricated success" family as #412. Second manifestation of the same missing check: a spec-invalid component (a canon lift whose declared param arity differs from the backing core func) that wasm-tools validate + wasmtime REJECT is accepted and run by kilnd (rejects a result-type mismatch but not a param-arity mismatch). Root cause: execute_traditional_module (kilnd/src/lib.rs:913) always calls engine.execute(instance, fn, &[]) (empty args); the component path call_direct_export (kiln-component/src/components/component_instantiation.rs:4498) validates only result arity (:4541) and never calls the existing validate_function_args (:4447); the engine zero-fills missing params instead of trapping. Fix: reject at invocation when the target export param arity/types do not match the supplied args (call validate_function_args on BOTH paths) so a param-taking fn invoked with no args errors instead of returning a zero-filled result as success; and validate canon lift param arity against the backing core function during component decode. Optionally add a CLI flag to supply wasm params. Relates to SR-42. Issue #443.'
+  tags:
+  - kilnd
+  - kiln-component
+  - invocation
+  - arity
+  - fabricated-success
+  - correctness
+  - bug
+  fields:
+    upstream-ref: https://github.com/pulseengine/kiln/issues/443
+  provenance:
+    created-by: ai
+    model: claude-fable-5
+    timestamp: 2026-07-21T09:00:00Z
+  release: v0.4.3


### PR DESCRIPTION
Two housekeeping items from the tracker.

## #448 — remove vestigial Dagger (`ci:` commit)
A complete check found Dagger is **installed, PATH'd, cached and env-configured but never invoked**:
- no `dagger call/run/query` anywhere in the repo;
- `dagger-sdk` is **not** a Cargo dependency (absent from `Cargo.lock`);
- `cargo-kiln` / `kiln-build-core` reference dagger **zero** times, so the `cargo-kiln coverage` / `cargo-kiln docs` steps the setup wraps don't use it.

Removed across `publish.yml` (CLI install, Docker-for-Dagger, version check, PATH exports, `DAGGER_*` env), `ci.yml` (three `~/.cache/dagger` cache steps that cache a never-written dir + commented `dagger_sdk` log line + two `if: false` PlantUML steps predicated on the non-existent "CheckDocsStrict Dagger pipeline"), and `security-audit.yml` (stale `pkg:cargo/dagger-sdk@0.11.10` allow-list entry). Net −58 lines; the actual `cargo-kiln` commands are unchanged; all three workflows still parse.

**Also found, left for your call:** `deploy-docs-sftp.yml.example` references `cargo xtask publish-docs-dagger` (xtask is a removed legacy component) — but it's an `.example` template, not an active workflow, so I didn't touch it.

## #443 — SR-53 triage (`chore(rivet):` commit)
Lands the arg-arity fabricated-success bug (kilnd zero-fills missing params and reports the wrong result as `✓ success`) as rivet **SR-53**, `release: v0.4.3`. The code fix is in flight on a separate branch (`fix/sr-53-...`).

`rivet validate`: 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)