### PR TITLE
fix(component): compile kiln-component standalone + fix the isolated build (SR-54, partial #446)

### DIFF
--- a/kiln-component/Cargo.toml
+++ b/kiln-component/Cargo.toml
@@ -38,9 +38,13 @@ kiln-decoder = { workspace = true, features = ["std"] }
 serial_test = "3.4"
 
 [features]
-# By default, enable std to match kiln-runtime's default behavior
-# This ensures consistent feature resolution across workspace and isolated builds
-default = ["kiln-runtime/std"]
+# Enable kiln-component's OWN std + execution features by default so the crate
+# compiles standalone (`cargo check -p kiln-component`), not only under workspace
+# feature unification. `default = ["kiln-runtime/std"]` used to enable the
+# dependency's std but NOT this crate's own `std`/`kiln-execution`, so the
+# cfg-gated methods (link_imports, call_direct_export, the runtime_engine field)
+# vanished and the isolated build broke while CI stayed green (issue #446).
+default = ["std", "kiln-execution"]
 
 # Standard library support
 std = [

--- a/safety/requirements/functional-requirements/SR-54.yaml
+++ b/safety/requirements/functional-requirements/SR-54.yaml
@@ -1,0 +1,19 @@
+artifacts:
+- id: SR-54
+  type: requirement
+  title: kiln-component compiles standalone (cargo check -p kiln-component), not only under workspace feature unification
+  status: implemented
+  description: 'IMPLEMENTED (PR pending): kiln-component failed to compile in isolation on clean main — `cargo check -p kiln-component` errored (E0433 cannot find std; E0609/E0599 for the runtime_engine field, call_direct_export, call_command_entry, link_imports). Root cause: `default = ["kiln-runtime/std"]` enabled the DEPENDENCY''s std but never kiln-component''s OWN `std`/`kiln-execution` features, so the cfg-gated surface vanished; only workspace feature unification hid it, so CI stayed green (the "green CI over a build that only works via unification" class — a consumer depending on kiln-component alone got a build failure). Fix: `default = ["std", "kiln-execution"]` (kiln-execution is a pure cfg flag, no deps, so no dependency-graph change). Verified: bare `cargo check -p kiln-component` compiles; `cargo check --workspace` still green; consumers unchanged (kilnd 6+4+13, kiln-wasi lib 68 pass). SCOPE: fixes the LIB isolated build only. The crate''s TEST/EXAMPLE targets are separately + more deeply rotten (~47 type mismatches + removed-API refs: execute_start, Component.options, ExternType::Function, task_manager, async_) — a larger fix-or-delete cleanup, the remaining half of #446. Issue #446.'
+  tags:
+  - kiln-component
+  - build
+  - feature-flags
+  - bit-rot
+  - bug
+  fields:
+    upstream-ref: https://github.com/pulseengine/kiln/issues/446
+  provenance:
+    created-by: ai
+    model: claude-opus-4-8
+    timestamp: 2026-07-22T09:30:00Z
+  release: v0.4.3


### PR DESCRIPTION
## The bug (#446)
`cargo check -p kiln-component` **failed to compile on clean main**. `default = ["kiln-runtime/std"]` enabled the *dependency's* std but never kiln-component's **own** `std`/`kiln-execution` features, so cfg-gated items (`link_imports`, `call_direct_export`/`call_command_entry`, the `runtime_engine` field) vanished. Only workspace feature unification hid it — so CI stayed green while a consumer depending on kiln-component **alone** got a build failure.

## Fix
`default = ["std", "kiln-execution"]`. `kiln-execution` is a pure cfg flag (`kiln-execution = []`, no deps), so **no dependency graph changes** — it just enables by default the execution surface a standalone consumer needs, aligning the isolated build with the workspace build.

## Verified
- `cargo check -p kiln-component` (bare, default features) now compiles;
- `cargo check --workspace` still green (unification unaffected);
- consumers unchanged: kilnd 6+4+13 pass, kiln-wasi lib 68 pass.

## Scope — honest boundary
This fixes the **lib** isolated build (the #446 headline). It does **not** fix the crate's **test/example targets**, which are separately and more deeply rotten — `cargo test -p kiln-component --no-run` still fails with ~47 type mismatches plus references to **removed** APIs (`execute_start`, `Component.options`, `ExternType::Function`, `task_manager`, `async_`). That's a larger fix-or-delete cleanup of stale tests; I've left **#446 open** with a `remaining:` note for it rather than pretend this closes it.

Accumulating toward v0.4.3 (rivet **SR-54**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)